### PR TITLE
Support replay gain data in Qobuz tracks

### DIFF
--- a/addons/device/musiccast/musiccast.py
+++ b/addons/device/musiccast/musiccast.py
@@ -62,6 +62,9 @@ class Device:
         self.volume_step_to_db = config["addons"]["device"]["musiccast"].get(
             "volume_step_to_db", 0.5
         )
+        self.auto_volume = config["addons"]["device"]["musiccast"].get(
+            "auto_volume_correcton", True
+        )
         self.session = httpx.Client(timeout=5)
         self.base_url = (
             f"http://{self.device_addr}:{self.device_port}/YamahaExtendedControl/v1"
@@ -184,7 +187,11 @@ class Device:
         self.poweroff_timer.start()
 
         # ReplayGain
-        if self.volume.replay_gain is not None and self.volume.replay_gain != 0.0:
+        if (
+            self.auto_volume is True
+            and self.volume.replay_gain is not None
+            and self.volume.replay_gain != 0.0
+        ):
             self.set_volume(
                 self.volume.current_volume
                 - self._db_to_device_units(self.volume.replay_gain)
@@ -203,7 +210,10 @@ class Device:
         self.power_on()
 
         # ReplayGain
-        if state.get("current_track", {}).get("replaygain_gain", None) is not None:
+        if (
+            self.auto_volume is True
+            and state.get("current_track", {}).get("replaygain_gain", None) is not None
+        ):
             if self.volume.replay_gain == state["current_track"]["replaygain_gain"]:
                 return
 

--- a/addons/input_module/qobuz/qobuz.py
+++ b/addons/input_module/qobuz/qobuz.py
@@ -297,6 +297,12 @@ def metadata_from_track(track, album_meta={}):
                 id=str(album_info["genre"]["id"]), name=album_info["genre"]["name"]
             ),
         ),
+        "replaygain_peak": track.get("audio_info", {}).get(
+            "replaygain_track_peak", None
+        ),
+        "replaygain_gain": track.get("audio_info", {}).get(
+            "replaygain_track_gain", None
+        ),
     }
 
 

--- a/addons/input_module/qobuz/qobuz.py
+++ b/addons/input_module/qobuz/qobuz.py
@@ -259,7 +259,6 @@ def extract_track_format(track):
 def qobuz_link_retriever(qobuz_client, id) -> str:
     track = qobuz_client.get_track_url(id, fmt_id=27)
     format = extract_track_format(track)
-    logger.info(f"Track link: {track['url']}")
     track_url = TrackUrl(url=track["url"], format=format)
     return track_url
 

--- a/data_model/datamodel.py
+++ b/data_model/datamodel.py
@@ -60,6 +60,8 @@ class Track(BaseModel):
     duration: int
     performer: Optional[Artist] = None
     album: Album
+    replaygain_peak: Optional[float] = None
+    replaygain_gain: Optional[float] = None
 
 
 class Owner(BaseModel):

--- a/kalinka_conf_example.yaml
+++ b/kalinka_conf_example.yaml
@@ -71,12 +71,14 @@ addons:
     # musiccast:
     #   device_addr: 10.10.10.1
     #   device_port: 80
+    #   connected_input: optical2
     # # This value is to map volume level to dB.
     # # It is used to calculate the volume level for the device when using ReplayGain.
     # # The value can be obtain by reading indicator on your device.
-    # # This is the smallest difference between to readings.
+    # # This is the smallest difference between to readings. Default is 0.5.
     #   volume_step_to_db: 0.5
-    #   connected_input: optical2
+    # # This enables automatic volume correction when ReplayGain information is present.
+    #   auto_volume_correcton: true
 
   input_module:
     qobuz:

--- a/kalinka_conf_example.yaml
+++ b/kalinka_conf_example.yaml
@@ -71,6 +71,11 @@ addons:
     # musiccast:
     #   device_addr: 10.10.10.1
     #   device_port: 80
+    # # This value is to map volume level to dB.
+    # # It is used to calculate the volume level for the device when using ReplayGain.
+    # # The value can be obtain by reading indicator on your device.
+    # # This is the smallest difference between to readings.
+    #   volume_step_to_db: 0.5
     #   connected_input: optical2
 
   input_module:

--- a/run_server.py
+++ b/run_server.py
@@ -76,6 +76,9 @@ if __name__ == "__main__":
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
+    # Reduce logging level for httpx - it's too verbose
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
     if args.config:
         config.set_config_path(args.config)
 

--- a/src/ext_device.py
+++ b/src/ext_device.py
@@ -14,7 +14,7 @@ class SupportedFunction(Enum):
 class Volume(BaseModel):
     max_volume: int
     current_volume: int
-    replay_gain: float = 0.0
+    volume_gain: int = 0
 
 
 class ExternalOutputDevice(ABC):

--- a/src/ext_device.py
+++ b/src/ext_device.py
@@ -14,6 +14,7 @@ class SupportedFunction(Enum):
 class Volume(BaseModel):
     max_volume: int
     current_volume: int
+    replay_gain: float = 0.0
 
 
 class ExternalOutputDevice(ABC):


### PR DESCRIPTION
Enable support for ReplayGain information on tracks. Now (optionally) volume correction can be enabled for musiccast device that will change device volume accordingly instead of correcting the data.