### PR TITLE
Support repeat one / repeat all modes for the playback

### DIFF
--- a/data_model/response_model.py
+++ b/data_model/response_model.py
@@ -18,6 +18,12 @@ class AudioInfo(BaseModel):
     duration_ms: int
 
 
+class PlaybackMode(BaseModel):
+    shuffle: bool
+    repeat_single: bool
+    repeat_all: bool
+
+
 class PlayerState(BaseModel):
     state: Optional[str] = None
     current_track: Optional[Track] = None

--- a/native_player/AudioPlayer.cpp
+++ b/native_player/AudioPlayer.cpp
@@ -43,7 +43,8 @@ struct StreamNodes {
     nodeChain.emplace_back(std::move(decoder));
   }
 
-  StreamNodes(StreamNodes &&other) : nodeChain(std::move(other.nodeChain)) {}
+  StreamNodes(StreamNodes &&other)
+      : nodeChain(std::move(other.nodeChain)), url(std::move(other.url)) {}
 
   ~StreamNodes() {
     for (NodeChain::reverse_iterator rit = nodeChain.rbegin();
@@ -96,6 +97,19 @@ void AudioPlayer::playNext(const std::string &url) {
   audioEmitter->connectTo(streamSwitcher);
   cleanUpFinishedStreams();
   streamNodesList.emplace_back(std::move(newStream));
+}
+
+void AudioPlayer::remove(const std::string &url) {
+  auto stream = std::find_if(streamNodesList.begin(), streamNodesList.end(),
+                             [&url](const StreamNodes &streamNodes) {
+                               return streamNodes.url == url;
+                             });
+  if (stream != streamNodesList.end()) {
+    streamSwitcher->disconnect(stream->nodeChain.back());
+    streamNodesList.erase(stream);
+  } else {
+    spdlog::warn("Stream {} not found", url);
+  }
 }
 
 void AudioPlayer::stop() {

--- a/native_player/AudioPlayer.h
+++ b/native_player/AudioPlayer.h
@@ -26,6 +26,10 @@ public:
   // finished.
   void playNext(const std::string &url);
 
+  // Remove stream from the playback queue if exists. Stops the playback
+  // if the stream is currently playing.
+  void remove(const std::string &url);
+
   // Stop playback and close the device
   void stop();
 

--- a/native_player/PyBindings.cpp
+++ b/native_player/PyBindings.cpp
@@ -92,6 +92,7 @@ PYBIND11_MODULE(native_player, m) {
       .def(py::init<const Config &>(), py::arg("config"))
       .def("play", &AudioPlayer::play, py::arg("url"))
       .def("play_next", &AudioPlayer::playNext, py::arg("url"))
+      .def("remove", &AudioPlayer::remove, py::arg("url"))
       .def("stop", &AudioPlayer::stop)
       .def("pause", &AudioPlayer::pause, py::arg("paused"))
       .def("seek", &AudioPlayer::seek, py::arg("position_ms"))

--- a/native_player/tests/AudioPlayer_test.cpp
+++ b/native_player/tests/AudioPlayer_test.cpp
@@ -246,3 +246,38 @@ TEST_F(AudioPlayerTest, test_play_pause_next) {
 
   EXPECT_EQ(i, statesCount);
 }
+
+TEST_F(AudioPlayerTest, test_remove_stream) {
+  auto monitor = audioPlayer.monitor();
+  audioPlayer.play(url1);
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  audioPlayer.remove(url1);
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  EXPECT_EQ(audioPlayer.getState().state, AudioGraphNodeState::FINISHED);
+
+  audioPlayer.play(url1);
+  audioPlayer.playNext(url2);
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  audioPlayer.remove(url2);
+
+  while (audioPlayer.getState().state != AudioGraphNodeState::FINISHED) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  }
+
+  AudioGraphNodeState states[] = {
+      AudioGraphNodeState::STOPPED,   AudioGraphNodeState::SOURCE_CHANGED,
+      AudioGraphNodeState::PREPARING, AudioGraphNodeState::STREAMING,
+      AudioGraphNodeState::FINISHED,  AudioGraphNodeState::SOURCE_CHANGED,
+      AudioGraphNodeState::PREPARING, AudioGraphNodeState::STREAMING,
+      AudioGraphNodeState::FINISHED};
+
+  const auto statesCount = sizeof(states) / sizeof(AudioGraphNodeState);
+
+  int i = 0;
+  for (; i < statesCount && monitor->hasData(); ++i) {
+    auto state = monitor->waitState();
+    EXPECT_EQ(state.state, states[i]) << "i=" << i;
+  }
+
+  EXPECT_EQ(i, statesCount);
+}

--- a/src/events.py
+++ b/src/events.py
@@ -11,3 +11,4 @@ class EventType(Enum):
     FavoriteRemoved = "favorite_removed"
     VolumeChanged = "volume_changed"
     StateReplay = "state_replay"
+    PlaybackModeChanged = "playback_mode_changed"

--- a/src/playqueue.py
+++ b/src/playqueue.py
@@ -2,12 +2,12 @@ import logging
 import time
 
 from functools import partial
-from typing import Optional
 from threading import Timer, Thread
 
 from collections import OrderedDict
+from typing import Optional
 
-from data_model.response_model import AudioInfo, PlayerState
+from data_model.response_model import AudioInfo, PlayerState, PlaybackMode
 from data_model.datamodel import Track
 
 from src.event_loop import AsyncExecutor, enqueue
@@ -88,6 +88,11 @@ class PlayQueue(AsyncExecutor):
         self.current_track_id = 0
         self.track_list: list[TrackInfo] = []
 
+        # Playback mode
+        self.shuffle = False  # TODO
+        self.repeat_single = False  # TODO
+        self.repeat_all = False  # TODO
+
         self.timer_thread = None
         self.state_monitor = self.track_player.monitor()
         self.prepared_tracks = OrderedDict()
@@ -141,6 +146,11 @@ class PlayQueue(AsyncExecutor):
                 message=new_state.message,
                 audio_info=to_audio_info(new_state.stream_info),
                 timestamp=state_update_ts,
+                playback_mode=PlaybackMode(
+                    shuffle=self.shuffle,
+                    repeat_single=self.repeat_single,
+                    repeat_all=self.repeat_all,
+                ),
             ).model_dump(exclude_none=True),
         )
 
@@ -281,6 +291,11 @@ class PlayQueue(AsyncExecutor):
             message=stream_state.message,
             audio_info=to_audio_info(stream_state.stream_info),
             timestamp=time.monotonic_ns(),
+            playback_mode=PlaybackMode(
+                shuffle=self.shuffle,
+                repeat_single=self.repeat_single,
+                repeat_all=self.repeat_all,
+            ),
         )
 
     @enqueue
@@ -299,6 +314,11 @@ class PlayQueue(AsyncExecutor):
                 position=self._estimated_progress(stream_state),
                 message=stream_state.message,
                 audio_info=to_audio_info(stream_state.stream_info),
+                playback_mode=PlaybackMode(
+                    shuffle=self.shuffle,
+                    repeat_single=self.repeat_single,
+                    repeat_all=self.repeat_all,
+                ),
             ).model_dump(exclude_none=True),
             self.list(0, len(self.track_list)),
         )
@@ -345,12 +365,12 @@ class PlayQueue(AsyncExecutor):
         return self.prepared_tracks[index]
 
     def _request_more_tracks(self):
-        if self.current_track_id == len(self.track_list) - 1:
+        if not self.repeat_all and self.current_track_id == len(self.track_list) - 1:
             self.event_emitter.dispatch(EventType.RequestMoreTracks)
 
     def _setup_prefetch_timer(self, state: StreamInfo):
         self._cancel_prefetch_timer()
-        next_track_id = self.current_track_id + 1
+
         stream_info = state.stream_info
         if not stream_info:
             return
@@ -359,17 +379,26 @@ class PlayQueue(AsyncExecutor):
             get_duration_ms(stream_info) - state.position - PREFETCH_TIME_MS
         ) / 1000
 
-        if time_to_prefetch_s < 0:
-            self.play_next(next_track_id)
+        if time_to_prefetch_s <= 0:
+            self._play_next_track_timer()
             return
 
         logger.info(f"Prefetching next track in {time_to_prefetch_s} seconds")
 
         self.timer_thread = Timer(
             time_to_prefetch_s,
-            partial(self.play_next, next_track_id),
+            self._play_next_track_timer,
         )
         self.timer_thread.start()
+
+    def _play_next_track_timer(self):
+        next_track_id = self.current_track_id
+        if not self.repeat_single:
+            next_track_id += 1
+        if self.repeat_all and next_track_id >= len(self.track_list):
+            next_track_id = 0
+
+        self.play_next(next_track_id)
 
     def _cancel_prefetch_timer(self):
         if self.timer_thread is not None:
@@ -385,5 +414,56 @@ class PlayQueue(AsyncExecutor):
                 state=to_state_name(AudioGraphNodeState.STOPPED),
                 position=0,
                 timestamp=time.monotonic_ns(),
+                playback_mode=PlaybackMode(
+                    shuffle=self.shuffle,
+                    repeat_single=self.repeat_single,
+                    repeat_all=self.repeat_all,
+                ),
             ).model_dump(exclude_none=True),
         )
+
+    @enqueue
+    def set_playback_mode(
+        self,
+        shuffle: Optional[bool],
+        repeat_single: Optional[bool],
+        repeat_all: Optional[bool],
+    ):
+        self.shuffle = shuffle if shuffle is not None else self.shuffle
+        self.repeat_single = (
+            repeat_single if repeat_single is not None else self.repeat_single
+        )
+        self.repeat_all = repeat_all if repeat_all is not None else self.repeat_all
+        repeat_single_updated = (
+            self.repeat_single != repeat_single if repeat_single is not None else False
+        )
+        if (
+            self.shuffle is not None
+            or self.repeat_all is not None
+            or self.repeat_single is not None
+        ):
+            self.event_emitter.dispatch(
+                EventType.PlaybackModeChanged,
+                PlaybackMode(
+                    shuffle=self.shuffle,
+                    repeat_single=self.repeat_single,
+                    repeat_all=self.repeat_all,
+                ).model_dump(exclude_none=True),
+            )
+            if repeat_single_updated:
+                if self.prepared_tracks:
+                    last_url = self.prepared_tracks.popitem(last=False)
+                    self.track_player.remove(last_url)
+                    self._play_next_track_timer()
+        return PlaybackMode(
+            shuffle=self.shuffle,
+            repeat_single=self.repeat_single,
+            repeat_all=self.repeat_all,
+        ).model_dump(exclude_none=True)
+
+    def get_playback_mode(self):
+        return PlaybackMode(
+            shuffle=self.shuffle,
+            repeat_single=self.repeat_single,
+            repeat_all=self.repeat_all,
+        ).model_dump(exclude_none=True)

--- a/src/playqueue.py
+++ b/src/playqueue.py
@@ -90,8 +90,8 @@ class PlayQueue(AsyncExecutor):
 
         # Playback mode
         self.shuffle = False  # TODO
-        self.repeat_single = False  # TODO
-        self.repeat_all = False  # TODO
+        self.repeat_single = False
+        self.repeat_all = False
 
         self.timer_thread = None
         self.state_monitor = self.track_player.monitor()

--- a/src/playqueue.py
+++ b/src/playqueue.py
@@ -146,11 +146,6 @@ class PlayQueue(AsyncExecutor):
                 message=new_state.message,
                 audio_info=to_audio_info(new_state.stream_info),
                 timestamp=state_update_ts,
-                playback_mode=PlaybackMode(
-                    shuffle=self.shuffle,
-                    repeat_single=self.repeat_single,
-                    repeat_all=self.repeat_all,
-                ),
             ).model_dump(exclude_none=True),
         )
 
@@ -291,11 +286,6 @@ class PlayQueue(AsyncExecutor):
             message=stream_state.message,
             audio_info=to_audio_info(stream_state.stream_info),
             timestamp=time.monotonic_ns(),
-            playback_mode=PlaybackMode(
-                shuffle=self.shuffle,
-                repeat_single=self.repeat_single,
-                repeat_all=self.repeat_all,
-            ),
         )
 
     @enqueue
@@ -314,13 +304,13 @@ class PlayQueue(AsyncExecutor):
                 position=self._estimated_progress(stream_state),
                 message=stream_state.message,
                 audio_info=to_audio_info(stream_state.stream_info),
-                playback_mode=PlaybackMode(
-                    shuffle=self.shuffle,
-                    repeat_single=self.repeat_single,
-                    repeat_all=self.repeat_all,
-                ),
             ).model_dump(exclude_none=True),
             self.list(0, len(self.track_list)),
+            PlaybackMode(
+                shuffle=self.shuffle,
+                repeat_single=self.repeat_single,
+                repeat_all=self.repeat_all,
+            ).model_dump(exclude_none=True),
         )
 
     @enqueue
@@ -414,11 +404,6 @@ class PlayQueue(AsyncExecutor):
                 state=to_state_name(AudioGraphNodeState.STOPPED),
                 position=0,
                 timestamp=time.monotonic_ns(),
-                playback_mode=PlaybackMode(
-                    shuffle=self.shuffle,
-                    repeat_single=self.repeat_single,
-                    repeat_all=self.repeat_all,
-                ),
             ).model_dump(exclude_none=True),
         )
 
@@ -429,14 +414,14 @@ class PlayQueue(AsyncExecutor):
         repeat_single: Optional[bool],
         repeat_all: Optional[bool],
     ):
+        repeat_single_updated = (
+            self.repeat_single != repeat_single if repeat_single is not None else False
+        )
         self.shuffle = shuffle if shuffle is not None else self.shuffle
         self.repeat_single = (
             repeat_single if repeat_single is not None else self.repeat_single
         )
         self.repeat_all = repeat_all if repeat_all is not None else self.repeat_all
-        repeat_single_updated = (
-            self.repeat_single != repeat_single if repeat_single is not None else False
-        )
         if (
             self.shuffle is not None
             or self.repeat_all is not None
@@ -453,7 +438,7 @@ class PlayQueue(AsyncExecutor):
             if repeat_single_updated:
                 if self.prepared_tracks:
                     last_url = self.prepared_tracks.popitem(last=False)
-                    self.track_player.remove(last_url)
+                    self.track_player.remove(last_url[1])
                     self._play_next_track_timer()
         return PlaybackMode(
             shuffle=self.shuffle,

--- a/src/server.py
+++ b/src/server.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from fastapi import FastAPI, Query, Request
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
-from data_model.response_model import FavoriteIds, GenreList, PlayerState
+from data_model.response_model import FavoriteIds, GenreList, PlaybackMode, PlayerState
 from src import state_keeper
 from src.ext_device import Volume
 from src.player_setup import setup
@@ -188,6 +188,19 @@ async def stream(request: Request):
 @app.get("/queue/state")
 async def state() -> PlayerState:
     return playqueue.get_state()
+
+
+@app.get("/queue/mode")
+async def mode() -> PlaybackMode:
+    return playqueue.get_playback_mode()
+
+
+@app.put("/queue/mode")
+async def set_mode(
+    shuffle: bool = None, repeat_single: bool = None, repeat_all: bool = None
+):
+    playqueue.set_playback_mode(shuffle, repeat_single, repeat_all)
+    return {"message": "Ok"}
 
 
 @app.put("/queue/clear")


### PR DESCRIPTION
This change adds support for repeat one / repeat all modes.

In case of repeating all tracks, the player doesn't request more tracks when reaching the end and instead start from track with index 0.

Playback in "repeat one" mode is gapless too. To use the feature corresponding changes to KalinkaApp needs to be installed as well.