### PR TITLE
Separate event queue for each plugin with a single worker

### DIFF
--- a/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/api.py
+++ b/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/api.py
@@ -1,11 +1,10 @@
 # kalinka_plugin_sdk/api.py
 from collections.abc import Callable
-from typing import Protocol, Any, Optional
+from typing import Protocol, Optional
 
 from kalinka_plugin_sdk.datamodel import PlaybackMode, PlayerState, Track, TrackList
 
 from .inputmodule import TrackInfo
-from .module_config import ModuleConfig
 from .events import EventType
 
 API_VERSION = "1.0"
@@ -88,12 +87,15 @@ class PlayQueueAPI(Protocol):
 
 
 class EventEmitterAPI(Protocol):
-    def dispatch(self, topic: EventType, payload: Any) -> None: ...
+    def dispatch(self, topic: EventType, *args, **kwargs) -> None: ...
+
+
+class SubscriptionHandle(Protocol):
+    def unsubscribe(self) -> None: ...
 
 
 class EventListenerAPI(Protocol):
-    def subscribe(self, topic: EventType, handler: Callable) -> None: ...
-    def unsubscribe(self, topic: EventType, handler: Callable) -> None: ...
+    def subscribe(self, topic: EventType, handler: Callable) -> SubscriptionHandle: ...
 
 
 class LoggerAPI(Protocol):
@@ -105,7 +107,7 @@ class LoggerAPI(Protocol):
     def fatal(self, msg, *args, **kwargs): ...
 
 
-class PluginContext(Protocol):
+class PluginContext:
     playqueue: PlayQueueAPI
     event_emitter: EventEmitterAPI
     listener: EventListenerAPI
@@ -113,4 +115,3 @@ class PluginContext(Protocol):
     plugin_id: str
     sdk_version: str  # equals API_VERSION
     capabilities: set[str]
-    config: ModuleConfig

--- a/packages/kalinka-server/src/kalinka_server/player_setup.py
+++ b/packages/kalinka-server/src/kalinka_server/player_setup.py
@@ -9,16 +9,13 @@ from queue import Queue
 from typing import Generator, get_type_hints
 
 from kalinka_plugin_sdk.api import (
-    EventEmitterAPI,
-    EventListenerAPI,
-    PlayQueueAPI,
     PluginContext,
 )
 from kalinka_plugin_sdk.ext_device import ExternalOutputDevice
 from kalinka_plugin_sdk.inputmodule import InputModule
 from kalinka_plugin_sdk.module_config import ModuleConfig
 from kalinka_plugin_sdk import API_VERSION
-from kalinka_server.plugin_event_queue import KalinkaPluginEventQueue
+from kalinka_server.plugin_event_queue import PluginEventQueue
 
 from .async_common import EventEmitter, EventListener
 from .config_model import KalinkaConfig
@@ -210,9 +207,9 @@ def read_or_create_module_config(
 
 def scan_and_setup_plugins_from_entry_points(
     config_path: str,
-    playqueue: PlayQueueAPI,
-    event_emitter: EventEmitterAPI,
-    plugin_event_queue: EventListenerAPI,
+    playqueue: PlayQueue,
+    event_emitter: EventEmitter,
+    event_listener: EventListener,
 ) -> Generator[tuple[str, PreparedModule], None, None]:
     """Scan for installed plugins using entry points and setup those matching the specified type."""
 
@@ -225,7 +222,7 @@ def scan_and_setup_plugins_from_entry_points(
             prepared_module = PreparedModule(module, config)
             if config.enabled:
                 plugin_context = make_plugin_context(
-                    name, playqueue, event_emitter, plugin_event_queue
+                    name, playqueue, event_emitter, event_listener
                 )
                 prepared_module.setup(plugin_context)
                 prepared_module.health_state = ModuleHealthState.READY
@@ -245,15 +242,15 @@ def scan_and_setup_plugins_from_entry_points(
 
 def make_plugin_context(
     name: str,
-    playqueue: PlayQueueAPI,
-    event_emitter: EventEmitterAPI,
-    plugin_event_queue: EventListenerAPI,
+    playqueue: PlayQueue,
+    event_emitter: EventEmitter,
+    event_listener: EventListener,
 ) -> PluginContext:
     """Create a PluginContext instance."""
     context = PluginContext()
-    context.playqueue = playqueue
-    context.event_emitter = event_emitter
-    context.listener = plugin_event_queue
+    context.playqueue = PlayQueueAPIImpl(playqueue)
+    context.event_emitter = EventEmitterAPIImpl(event_emitter)
+    context.listener = PluginEventQueue(event_listener)
     context.logger = logging.getLogger(name)
     context.plugin_id = name
     context.sdk_version = API_VERSION
@@ -263,9 +260,9 @@ def make_plugin_context(
 
 def scan_and_setup_plugins(
     config_path: str,
-    playqueue: PlayQueueAPI,
-    event_emitter: EventEmitterAPI,
-    plugin_event_queue: EventListenerAPI,
+    playqueue: PlayQueue,
+    event_emitter: EventEmitter,
+    event_listener: EventListener,
 ):
     """Scan for input modules from both entry points and legacy filesystem locations."""
 
@@ -273,7 +270,7 @@ def scan_and_setup_plugins(
     input_modules = {}
     devices = {}
     for name, module in scan_and_setup_plugins_from_entry_points(
-        config_path, playqueue, event_emitter, plugin_event_queue
+        config_path, playqueue, event_emitter, event_listener
     ):
         plugin_type = module.plugin_type
         if plugin_type == PluginType.INPUT_MODULE:
@@ -305,15 +302,8 @@ def setup(config_path: str, config: KalinkaConfig) -> tuple[PlayQueue, EventList
     event_listener = EventListener(queue)
     playqueue = PlayQueue(config, event_emitter)
 
-    # Create plugin interface
-    plugin_event_queue = KalinkaPluginEventQueue(event_listener, max_workers=2)
-    plugin_event_emitter = EventEmitterAPIImpl(event_emitter)
-    plugin_playqueue = PlayQueueAPIImpl(playqueue)
-
     # Scan and setup plugins
-    scan_and_setup_plugins(
-        config_path, plugin_playqueue, plugin_event_emitter, plugin_event_queue
-    )
+    scan_and_setup_plugins(config_path, playqueue, event_emitter, event_listener)
 
     logger.info("Input modules found: %s", list(modules.prepared_input_modules.keys()))
     logger.info("Output devices found: %s", list(modules.prepared_devices.keys()))

--- a/packages/kalinka-server/src/kalinka_server/player_setup.py
+++ b/packages/kalinka-server/src/kalinka_server/player_setup.py
@@ -8,19 +8,24 @@ from importlib import import_module
 from queue import Queue
 from typing import Generator, get_type_hints
 
-from kalinka_plugin_sdk.api import PluginContext
+from kalinka_plugin_sdk.api import (
+    EventEmitterAPI,
+    EventListenerAPI,
+    PlayQueueAPI,
+    PluginContext,
+)
 from kalinka_plugin_sdk.ext_device import ExternalOutputDevice
 from kalinka_plugin_sdk.inputmodule import InputModule
 from kalinka_plugin_sdk.module_config import ModuleConfig
+from kalinka_plugin_sdk import API_VERSION
+from kalinka_server.plugin_event_queue import KalinkaPluginEventQueue
 
 from .async_common import EventEmitter, EventListener
 from .config_model import KalinkaConfig
 from .playqueue import PlayQueue
 from .plugin_api import (
     EventEmitterAPIImpl,
-    EventListenerAPIImpl,
     PlayQueueAPIImpl,
-    PluginContextImpl,
 )
 
 logger = logging.getLogger(__name__.split(".")[-1])
@@ -204,7 +209,10 @@ def read_or_create_module_config(
 
 
 def scan_and_setup_plugins_from_entry_points(
-    config_path: str, playqueue, event_emitter, event_listener
+    config_path: str,
+    playqueue: PlayQueueAPI,
+    event_emitter: EventEmitterAPI,
+    plugin_event_queue: EventListenerAPI,
 ) -> Generator[tuple[str, PreparedModule], None, None]:
     """Scan for installed plugins using entry points and setup those matching the specified type."""
 
@@ -217,7 +225,7 @@ def scan_and_setup_plugins_from_entry_points(
             prepared_module = PreparedModule(module, config)
             if config.enabled:
                 plugin_context = make_plugin_context(
-                    name, playqueue, event_emitter, event_listener
+                    name, playqueue, event_emitter, plugin_event_queue
                 )
                 prepared_module.setup(plugin_context)
                 prepared_module.health_state = ModuleHealthState.READY
@@ -237,31 +245,35 @@ def scan_and_setup_plugins_from_entry_points(
 
 def make_plugin_context(
     name: str,
-    playqueue: PlayQueue,
-    event_emitter: EventEmitter,
-    event_listener: EventListener,
+    playqueue: PlayQueueAPI,
+    event_emitter: EventEmitterAPI,
+    plugin_event_queue: EventListenerAPI,
 ) -> PluginContext:
-    """Create a PluginContextImpl instance."""
-    context = PluginContextImpl()
-    context.playqueue = PlayQueueAPIImpl(playqueue)
-    context.event_emitter = EventEmitterAPIImpl(event_emitter)
-    context.listener = EventListenerAPIImpl(event_listener)
+    """Create a PluginContext instance."""
+    context = PluginContext()
+    context.playqueue = playqueue
+    context.event_emitter = event_emitter
+    context.listener = plugin_event_queue
     context.logger = logging.getLogger(name)
     context.plugin_id = name
-    context.sdk_version = "1.0.0"  # Example version, replace with actual version
+    context.sdk_version = API_VERSION
     context.capabilities = set()
-    context.config = {}
     return context
 
 
-def scan_and_setup_plugins(config_path: str, playqueue, event_emitter, event_listener):
+def scan_and_setup_plugins(
+    config_path: str,
+    playqueue: PlayQueueAPI,
+    event_emitter: EventEmitterAPI,
+    plugin_event_queue: EventListenerAPI,
+):
     """Scan for input modules from both entry points and legacy filesystem locations."""
 
     # First, scan for input modules using entry points
     input_modules = {}
     devices = {}
     for name, module in scan_and_setup_plugins_from_entry_points(
-        config_path, playqueue, event_emitter, event_listener
+        config_path, playqueue, event_emitter, plugin_event_queue
     ):
         plugin_type = module.plugin_type
         if plugin_type == PluginType.INPUT_MODULE:
@@ -293,8 +305,15 @@ def setup(config_path: str, config: KalinkaConfig) -> tuple[PlayQueue, EventList
     event_listener = EventListener(queue)
     playqueue = PlayQueue(config, event_emitter)
 
+    # Create plugin interface
+    plugin_event_queue = KalinkaPluginEventQueue(event_listener, max_workers=2)
+    plugin_event_emitter = EventEmitterAPIImpl(event_emitter)
+    plugin_playqueue = PlayQueueAPIImpl(playqueue)
+
     # Scan and setup plugins
-    scan_and_setup_plugins(config_path, playqueue, event_emitter, event_listener)
+    scan_and_setup_plugins(
+        config_path, plugin_playqueue, plugin_event_emitter, plugin_event_queue
+    )
 
     logger.info("Input modules found: %s", list(modules.prepared_input_modules.keys()))
     logger.info("Output devices found: %s", list(modules.prepared_devices.keys()))

--- a/packages/kalinka-server/src/kalinka_server/playqueue.py
+++ b/packages/kalinka-server/src/kalinka_server/playqueue.py
@@ -488,11 +488,11 @@ class PlayQueue(AsyncExecutor):
             shuffle=self.shuffle,
             repeat_single=self.repeat_single,
             repeat_all=self.repeat_all,
-        ).model_dump(exclude_none=True)
+        )
 
     def get_playback_mode(self):
         return PlaybackMode(
             shuffle=self.shuffle,
             repeat_single=self.repeat_single,
             repeat_all=self.repeat_all,
-        ).model_dump(exclude_none=True)
+        )

--- a/packages/kalinka-server/src/kalinka_server/plugin_api.py
+++ b/packages/kalinka-server/src/kalinka_server/plugin_api.py
@@ -1,13 +1,13 @@
-from typing import Any, Callable, Mapping, Optional
+from typing import Optional
 from kalinka_plugin_sdk.api import (
-    LoggerAPI,
     PlayQueueAPI,
-    PluginContext,
     EventEmitterAPI,
-    EventListenerAPI,
 )
+from kalinka_plugin_sdk.datamodel import PlaybackMode, PlayerState, Track, TrackList
 from kalinka_plugin_sdk.events import EventType
-from .async_common import EventEmitter, EventListener
+from kalinka_plugin_sdk.inputmodule import TrackInfo
+
+from .async_common import EventEmitter
 from .playqueue import PlayQueue
 
 
@@ -50,7 +50,7 @@ class PlayQueueAPIImpl(PlayQueueAPI):
         """Stop playback."""
         self.__playqueue.stop()
 
-    def add(self, tracks: list[Any]) -> None:
+    def add(self, tracks: list[TrackInfo]) -> None:
         """Add tracks to the queue."""
         self.__playqueue.add(tracks)
 
@@ -58,15 +58,15 @@ class PlayQueueAPIImpl(PlayQueueAPI):
         """Remove tracks by their indices."""
         self.__playqueue.remove(tracks)
 
-    def list(self, offset: int, limit: int) -> Any:
+    def list(self, offset: int, limit: int) -> TrackList:
         """List tracks in the queue with pagination."""
         return self.__playqueue.list(offset, limit)
 
-    def get_track_info(self, index: int) -> Optional[Any]:
+    def get_track_info(self, index: int) -> Optional[Track]:
         """Get info for the track at the given index."""
         return self.__playqueue.get_track_info(index)
 
-    def get_state(self) -> Any:
+    def get_state(self) -> PlayerState:
         """Get the current playback state."""
         return self.__playqueue.get_state()
 
@@ -81,11 +81,11 @@ class PlayQueueAPIImpl(PlayQueueAPI):
         shuffle: Optional[bool],
         repeat_single: Optional[bool],
         repeat_all: Optional[bool],
-    ) -> Any:
+    ) -> None:
         """Set playback modes: shuffle, repeat single, repeat all."""
-        return self.__playqueue.set_playback_mode(shuffle, repeat_single, repeat_all)
+        self.__playqueue.set_playback_mode(shuffle, repeat_single, repeat_all)
 
-    def get_playback_mode(self) -> Any:
+    def get_playback_mode(self) -> PlaybackMode:
         """Get the current playback mode."""
         return self.__playqueue.get_playback_mode()
 
@@ -94,27 +94,5 @@ class EventEmitterAPIImpl(EventEmitterAPI):
     def __init__(self, event_emitter: EventEmitter):
         self.__event_emitter = event_emitter
 
-    def dispatch(self, topic: EventType, payload: Any) -> None:
-        self.__event_emitter.dispatch(topic, payload)
-
-
-class EventListenerAPIImpl(EventListenerAPI):
-    def __init__(self, event_listener: EventListener):
-        self.__event_listener = event_listener
-
-    def subscribe(self, topic: EventType, handler: Callable) -> None:
-        self.__event_listener.subscribe(topic, handler)
-
-    def unsubscribe(self, topic: EventType, handler: Callable) -> None:
-        self.__event_listener.unsubscribe(topic, handler)
-
-
-class PluginContextImpl(PluginContext):
-    playqueue: PlayQueueAPI
-    event_emitter: EventEmitterAPI
-    listener: EventListenerAPI
-    logger: LoggerAPI
-    plugin_id: str
-    sdk_version: str  # equals API_VERSION
-    capabilities: set[str]
-    config: Mapping[str, Any]
+    def dispatch(self, topic: EventType, *args, **kwargs) -> None:
+        self.__event_emitter.dispatch(topic, *args, **kwargs)

--- a/packages/kalinka-server/src/kalinka_server/plugin_event_queue.py
+++ b/packages/kalinka-server/src/kalinka_server/plugin_event_queue.py
@@ -1,5 +1,5 @@
-from concurrent.futures import ThreadPoolExecutor
 import queue
+import threading
 from typing import Callable
 from kalinka_plugin_sdk.api import EventListenerAPI, SubscriptionHandle
 from kalinka_plugin_sdk.events import EventType
@@ -10,22 +10,42 @@ import logging
 logger = logging.getLogger(__name__.split(".")[-1])
 
 
-class KalinkaPluginEventQueue(EventListenerAPI):
-    def __init__(self, event_listener: EventListener, max_workers: int = 1):
+class PluginEventQueue(EventListenerAPI):
+    def __init__(self, event_listener: EventListener):
         self.__event_listener = event_listener
-        self.__thread_pool_executor = ThreadPoolExecutor(max_workers=max_workers)
+        self.__event_queue = queue.Queue()
+        self.__worker_thread = threading.Thread(target=self.__worker, daemon=True)
+        self.__running = True
+        self.__worker_thread.start()
+
+    def __worker(self):
+        """Worker thread that processes events from the queue."""
+        while self.__running:
+            try:
+                # Get an event from the queue with a timeout to allow checking __running
+                event_data = self.__event_queue.get(timeout=1.0)
+                if event_data is None:  # Sentinel value to stop processing
+                    break
+
+                handler, args, kwargs = event_data
+                try:
+                    handler(*args, **kwargs)
+                except Exception as e:
+                    logger.exception("Exception in event handler: %s", e)
+                finally:
+                    self.__event_queue.task_done()
+            except queue.Empty:
+                continue  # Timeout occurred, check __running and continue
 
     def subscribe(self, topic: EventType, handler: Callable) -> SubscriptionHandle:
+        def queue_handler(*args, **kwargs):
+            """Put the event into the queue for processing by the worker thread."""
+            self.__event_queue.put((handler, args, kwargs))
 
-        def wrapper(*args, **kwargs):
-            try:
-                handler(*args, **kwargs)
-            except Exception as e:
-                logger.exception("Exception in event handler: %s", e)
+        return self.__event_listener.subscribe(topic, queue_handler)
 
-        return self.__event_listener.subscribe(
-            topic,
-            lambda *args, **kwargs: self.__thread_pool_executor.submit(
-                wrapper, *args, **kwargs
-            ),
-        )
+    def shutdown(self):
+        """Shutdown the event queue and worker thread."""
+        self.__running = False
+        self.__event_queue.put(None)  # Sentinel value to wake up worker
+        self.__worker_thread.join(timeout=5.0)  # Wait up to 5 seconds for shutdown

--- a/packages/kalinka-server/src/kalinka_server/plugin_event_queue.py
+++ b/packages/kalinka-server/src/kalinka_server/plugin_event_queue.py
@@ -1,0 +1,31 @@
+from concurrent.futures import ThreadPoolExecutor
+import queue
+from typing import Callable
+from kalinka_plugin_sdk.api import EventListenerAPI, SubscriptionHandle
+from kalinka_plugin_sdk.events import EventType
+from .async_common import EventListener
+
+import logging
+
+logger = logging.getLogger(__name__.split(".")[-1])
+
+
+class KalinkaPluginEventQueue(EventListenerAPI):
+    def __init__(self, event_listener: EventListener, max_workers: int = 1):
+        self.__event_listener = event_listener
+        self.__thread_pool_executor = ThreadPoolExecutor(max_workers=max_workers)
+
+    def subscribe(self, topic: EventType, handler: Callable) -> SubscriptionHandle:
+
+        def wrapper(*args, **kwargs):
+            try:
+                handler(*args, **kwargs)
+            except Exception as e:
+                logger.exception("Exception in event handler: %s", e)
+
+        return self.__event_listener.subscribe(
+            topic,
+            lambda *args, **kwargs: self.__thread_pool_executor.submit(
+                wrapper, *args, **kwargs
+            ),
+        )


### PR DESCRIPTION
Each plugin gets a separate event queue to avoid blocking other plugins in case of slow consumption.