### PR TITLE
Skip and flag tracks whose stream URL can't be retrieved

### DIFF
--- a/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/__init__.py
+++ b/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/__init__.py
@@ -25,6 +25,7 @@ from .events import (
     TracksAddedEvent,
     TracksRemovedEvent,
     TrackMovedEvent,
+    TrackUnavailableEvent,
     PlaybackModeChangedEvent,
     PlaybackErrorEvent,
 )
@@ -72,6 +73,7 @@ __all__ = [
     "TracksAddedEvent",
     "TracksRemovedEvent",
     "TrackMovedEvent",
+    "TrackUnavailableEvent",
     "PlaybackModeChangedEvent",
     "PlaybackErrorEvent",
     # Data Models

--- a/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/datamodel.py
+++ b/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/datamodel.py
@@ -317,6 +317,7 @@ class Track(BaseModel):
         replaygain_peak (Optional[float]): ReplayGain peak value for audio normalization
         replaygain_gain (Optional[float]): ReplayGain gain value for audio normalization
         playlist_track_id (Optional[str]): ID specific to playlist membership
+        unavailable (bool): True when the track's stream URL could not be retrieved and playback skipped it
     """
 
     id: EntityId

--- a/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/datamodel.py
+++ b/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/datamodel.py
@@ -328,6 +328,9 @@ class Track(BaseModel):
     replaygain_peak: Optional[float] = None
     replaygain_gain: Optional[float] = None
     playlist_track_id: Optional[str] = None
+    # True when the track's stream URL could not be retrieved and playback
+    # skipped it. Surfaced to clients so they can flag the track in the queue.
+    unavailable: bool = False
 
 
 class Owner(BaseModel):

--- a/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/events.py
+++ b/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/events.py
@@ -16,6 +16,7 @@ class PlayQueueEventType(Enum):
     TracksAdded = "tracks_added"
     TracksRemoved = "tracks_removed"
     TrackMoved = "track_moved"
+    TrackUnavailable = "track_unavailable"
     PlaybackError = "playback_error"
     PlaybackModeChanged = "playback_mode_changed"
 
@@ -59,6 +60,14 @@ class PlayQueueState(BaseState[PlayQueueEvent]):
             track = track_list.pop(event.from_index)
             track_list.insert(event.to_index, track)
             updates["track_list"] = track_list
+        elif isinstance(event, TrackUnavailableEvent):
+            if not (0 <= event.index < len(self.track_list)):
+                return self
+            track_list = list(self.track_list)
+            track_list[event.index] = track_list[event.index].model_copy(
+                update={"unavailable": event.unavailable}
+            )
+            updates["track_list"] = track_list
         elif isinstance(event, PlaybackModeChangedEvent):
             updates["playback_mode"] = event.mode
         else:
@@ -96,6 +105,14 @@ class TrackMovedEvent(PlayQueueEvent):
 class PlaybackModeChangedEvent(PlayQueueEvent):
     event_type: PlayQueueEventType = PlayQueueEventType.PlaybackModeChanged
     mode: PlaybackMode
+
+
+class TrackUnavailableEvent(PlayQueueEvent):
+    event_type: PlayQueueEventType = PlayQueueEventType.TrackUnavailable
+    index: int
+    # True marks the track as unavailable (URL retrieval failed); False clears
+    # the flag once the track has been streamed successfully again.
+    unavailable: bool = True
 
 
 class PlaybackErrorEvent(PlayQueueEvent):

--- a/packages/kalinka-server/src/kalinka_server/playqueue.py
+++ b/packages/kalinka-server/src/kalinka_server/playqueue.py
@@ -29,6 +29,7 @@ from kalinka_plugin_sdk.events import (
     TracksAddedEvent,
     TracksRemovedEvent,
     TrackMovedEvent,
+    TrackUnavailableEvent,
 )
 from kalinka_plugin_sdk.inputmodule import TrackInfo
 
@@ -233,6 +234,10 @@ class PlayQueueImpl(PlayQueueController):
         self._retry_attempted: bool = False
         # Set to True when SOURCE_CHANGED is expected from a retry, to avoid resetting _retry_attempted
         self._retry_pending: bool = False
+        # Indices of tracks whose URL could not be retrieved. Mirrors the
+        # `unavailable` flag clients see; used to emit TrackUnavailableEvent only
+        # on real state changes. Kept in sync with track_list across mutations.
+        self._unavailable_indices: set[int] = set()
 
         self._state_update_task = None
 
@@ -366,20 +371,22 @@ class PlayQueueImpl(PlayQueueController):
     async def play_next(self, index: int) -> None:
         return await self._play_next_unqueued(index)
 
-    async def _play_unqueued(self, index=None):
+    async def _play_unqueued(self, index=None, step=1):
         self._retry_attempted = False
         if len(self.track_list) == 0:
-            return
-
-        if index is not None and index not in range(0, len(self.track_list)):
             return
 
         if index is None:
             index = self.current_track_id
 
-        track_info = await self._setup_track_to_play(index)
+        resolved_index, track_info = await self._resolve_playable(index, step)
         if track_info is None:
+            # Nothing playable in this direction: either we ran off the end of
+            # the queue (normal no-op, as before) or every remaining track
+            # failed to yield a URL — in which case _resolve_playable has
+            # already flagged them. Leave any current playback untouched.
             return
+        index = resolved_index
 
         self._cancel_prefetch_timer()
 
@@ -403,7 +410,7 @@ class PlayQueueImpl(PlayQueueController):
         if len(self.track_list) == 0:
             return
 
-        if index not in range(0, len(self.track_list)) or index in self.prepared_tracks:
+        if index in self.prepared_tracks:
             return
 
         logger.info(f"Playing next track index={index}")
@@ -414,8 +421,14 @@ class PlayQueueImpl(PlayQueueController):
             await self._play_unqueued(index)
             return
 
-        track_info = await self._setup_track_to_play(index)
+        resolved_index, track_info = await self._resolve_playable(index, step=1)
         if track_info is None:
+            return
+        index = resolved_index
+
+        # Skipping unavailable tracks may have landed on one that is already
+        # queued — nothing more to do in that case.
+        if index in self.prepared_tracks:
             return
 
         # If the player stopped while we were awaiting the URL, fall back to a
@@ -442,7 +455,7 @@ class PlayQueueImpl(PlayQueueController):
 
     @serialised
     async def prev(self):
-        await self._play_unqueued(self.current_track_id - 1)
+        await self._play_unqueued(self.current_track_id - 1, step=-1)
 
     @serialised
     async def seek(self, position_ms: int) -> None:
@@ -481,6 +494,12 @@ class PlayQueueImpl(PlayQueueController):
         for idx, stream_info in self.prepared_tracks.items():
             new_prepared[idx + len(tracks) if idx >= insert_at else idx] = stream_info
         self.prepared_tracks = new_prepared
+
+        # Shift unavailable-track indices >= insert_at up by len(tracks)
+        self._unavailable_indices = {
+            idx + len(tracks) if idx >= insert_at else idx
+            for idx in self._unavailable_indices
+        }
 
         # Validate prefetched next track (same pattern as move())
         expected_next = self.current_track_id
@@ -545,6 +564,13 @@ class PlayQueueImpl(PlayQueueController):
             shift = sum(1 for t in tracks if t < key)
             new_prepared[key - shift] = value
         self.prepared_tracks = new_prepared
+
+        # Drop removed indices and shift the rest down to match the new list.
+        self._unavailable_indices = {
+            idx - sum(1 for t in tracks if t < idx)
+            for idx in self._unavailable_indices
+            if idx not in tracks
+        }
 
         self.current_track_id = min(self.current_track_id, len(self.track_list) - 1)
         if self.current_track_id < 0:
@@ -629,6 +655,7 @@ class PlayQueueImpl(PlayQueueController):
         # Clear existing state
         self.track_list.clear()
         self.prepared_tracks.clear()
+        self._unavailable_indices.clear()
         self._cancel_prefetch_timer()
 
         # Pre-restore current_track_id so that _notify_track_change (fired by
@@ -720,6 +747,12 @@ class PlayQueueImpl(PlayQueueController):
             new_prepared[_remap_index(idx, from_index, to_index)] = stream_info
         self.prepared_tracks = new_prepared
 
+        # Remap unavailable-track indices to follow their tracks
+        self._unavailable_indices = {
+            _remap_index(idx, from_index, to_index)
+            for idx in self._unavailable_indices
+        }
+
         # Verify the prefetched "next" track is still the correct one.
         # If the wrong track is queued as next, remove it and re-prefetch.
         expected_next = self.current_track_id
@@ -757,6 +790,7 @@ class PlayQueueImpl(PlayQueueController):
         self.track_player.clear_all()
         self.current_stream_id = None
         self.prepared_tracks.clear()
+        self._unavailable_indices.clear()
         list_len = len(self.track_list)
         self.track_list = []
         self.current_track_id = 0
@@ -786,23 +820,60 @@ class PlayQueueImpl(PlayQueueController):
 
         return progress
 
-    async def _setup_track_to_play(self, index):
-        """Returns a TrackUrl for the given track index, fetching if not already prepared."""
+    async def _fetch_track_url(self, index):
+        """Fetch the stream URL for a track, returning None if retrieval fails."""
         track = self.track_list[index]
-        if index not in self.prepared_tracks:
-            try:
-                track_info = await track.link_retriever()
-            except Exception as e:
-                logger.warning("Failed to retrieve track link: %s", repr(e))
-                self.event_emitter.dispatch(
-                    PlaybackErrorEvent(message="Failed to retrieve track link")
-                )
-                return None
+        try:
+            return await track.link_retriever()
+        except Exception as e:
+            logger.warning(
+                "Failed to retrieve track link for index %d: %s", index, repr(e)
+            )
+            return None
 
-            return track_info
+    async def _resolve_playable(self, start_index, step=1):
+        """Find the first playable track from start_index, moving by ``step``.
 
-        # Return just the TrackUrl part of the (TrackUrl, StreamId) tuple
-        return self.prepared_tracks[index][0]
+        Tracks whose URL cannot be retrieved are marked unavailable (so clients
+        can flag them) and skipped. Returns ``(index, track_url)`` for the first
+        track that yields a URL, or ``(None, None)`` if none do in that
+        direction. Already-prepared tracks are returned from cache.
+        """
+        n = len(self.track_list)
+        if n == 0:
+            return None, None
+
+        index = start_index
+        for _ in range(n):
+            if index < 0 or index >= n:
+                if self.repeat_all:
+                    index %= n
+                else:
+                    return None, None
+            if index in self.prepared_tracks:
+                # Already prepared — its URL is known good.
+                return index, self.prepared_tracks[index][0]
+            track_info = await self._fetch_track_url(index)
+            if track_info is not None:
+                self._set_track_unavailable(index, False)
+                return index, track_info
+            self._set_track_unavailable(index, True)
+            index += step
+        return None, None
+
+    def _set_track_unavailable(self, index, unavailable):
+        """Notify clients of a track availability change (only on real change)."""
+        if unavailable:
+            if index in self._unavailable_indices:
+                return
+            self._unavailable_indices.add(index)
+        else:
+            if index not in self._unavailable_indices:
+                return
+            self._unavailable_indices.discard(index)
+        self.event_emitter.dispatch(
+            TrackUnavailableEvent(index=index, unavailable=unavailable)
+        )
 
     async def _retry_current_track_async(self, position_ms: int) -> None:
         """Re-fetch the URL for the current track and resume from position_ms."""

--- a/packages/kalinka-server/src/kalinka_server/playqueue.py
+++ b/packages/kalinka-server/src/kalinka_server/playqueue.py
@@ -365,6 +365,11 @@ class PlayQueueImpl(PlayQueueController):
 
     @serialised
     async def play(self, index: Optional[int] = None) -> None:
+        # Index-addressed entry point: reject out-of-range indices instead of
+        # letting _resolve_playable wrap them (which is only intended for the
+        # ±1 boundary stepping done by next()/prev()).
+        if index is not None and index not in range(0, len(self.track_list)):
+            return
         await self._play_unqueued(index)
 
     @serialised
@@ -410,7 +415,9 @@ class PlayQueueImpl(PlayQueueController):
         if len(self.track_list) == 0:
             return
 
-        if index in self.prepared_tracks:
+        # play_next is index-addressed; an out-of-range index is a no-op.
+        # (Prefetch already wraps via _play_next_track_async before calling.)
+        if index not in range(0, len(self.track_list)) or index in self.prepared_tracks:
             return
 
         logger.info(f"Playing next track index={index}")
@@ -834,14 +841,19 @@ class PlayQueueImpl(PlayQueueController):
     async def _resolve_playable(self, start_index, step=1):
         """Find the first playable track from start_index, moving by ``step``.
 
-        Tracks whose URL cannot be retrieved are marked unavailable (so clients
-        can flag them) and skipped. Returns ``(index, track_url)`` for the first
-        track that yields a URL, or ``(None, None)`` if none do in that
-        direction. Already-prepared tracks are returned from cache.
+        ``step`` must be +1 (forward) or -1 (backward); any other value is
+        normalised to one of those so the scan visits each track at most once
+        and never stalls re-fetching the same index. Tracks whose URL cannot be
+        retrieved are marked unavailable (so clients can flag them) and skipped.
+        Returns ``(index, track_url)`` for the first track that yields a URL, or
+        ``(None, None)`` if none do in that direction. Already-prepared tracks
+        are returned from cache.
         """
         n = len(self.track_list)
         if n == 0:
             return None, None
+
+        step = 1 if step >= 0 else -1
 
         index = start_index
         for _ in range(n):

--- a/packages/kalinka-server/tests/test_playqueue.py
+++ b/packages/kalinka-server/tests/test_playqueue.py
@@ -1369,6 +1369,40 @@ async def test_unavailable_indices_cleared_on_clear(event_emitter, playqueue):
     assert playqueue._unavailable_indices == set()
 
 
+@pytest.mark.asyncio
+async def test_play_out_of_range_index_is_noop(event_emitter, playqueue):
+    """play() with an out-of-range index does nothing (no wrap, no flagging)."""
+    await playqueue.add(make_tracks(3))
+    await asyncio.sleep(0)
+    event_emitter.reset_mock()
+
+    await playqueue.play(99)
+
+    assert not playqueue.prepared_tracks
+    assert playqueue._unavailable_indices == set()
+    assert not any(
+        isinstance(e, TrackUnavailableEvent)
+        for e in dispatched_events(event_emitter)
+    )
+
+
+@pytest.mark.asyncio
+async def test_play_next_out_of_range_index_is_noop(event_emitter, playqueue):
+    """play_next() with an out-of-range index does nothing."""
+    await playqueue.add(make_tracks(3))
+    await asyncio.sleep(0)
+    event_emitter.reset_mock()
+
+    await playqueue.play_next(99)
+    await playqueue.play_next(-5)
+
+    assert playqueue._unavailable_indices == set()
+    assert not any(
+        isinstance(e, TrackUnavailableEvent)
+        for e in dispatched_events(event_emitter)
+    )
+
+
 def test_playqueue_state_apply_track_unavailable():
     """PlayQueueState.apply toggles the per-track unavailable flag and ignores
     out-of-range indices."""

--- a/packages/kalinka-server/tests/test_playqueue.py
+++ b/packages/kalinka-server/tests/test_playqueue.py
@@ -19,6 +19,7 @@ from kalinka_plugin_sdk import (
     TracksAddedEvent,
     TracksRemovedEvent,
     TrackMovedEvent,
+    TrackUnavailableEvent,
     RequestMoreTracksEvent,
     EventEmitter,
 )
@@ -1219,3 +1220,178 @@ async def test_add_insert_preserves_valid_prefetch(event_emitter, playqueue):
     # No re-prefetch triggered
     assert playqueue._prefetch_task is None
     assert len(playqueue.track_list) == 5
+
+
+# ── Unavailable-track (link retrieval failure) tests ────────────────────────────
+
+
+async def failing_url():
+    raise KeyError("url")
+
+
+def make_tracks_with_failures(n: int, failing: set[int]) -> list[TrackInfo]:
+    """Create n TrackInfo objects; those at indices in ``failing`` raise on
+    link retrieval."""
+    return [
+        TrackInfo(
+            id=to_track_id(str(i + 1)),
+            metadata=create_track(str(i + 1)),
+            link_retriever=failing_url if i in failing else url1,
+        )
+        for i in range(n)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_playable_skips_failed_track(event_emitter, playqueue):
+    """A track whose URL can't be fetched is marked and skipped; the next
+    playable track is returned."""
+    playqueue.track_list = make_tracks_with_failures(3, {0})
+    event_emitter.reset_mock()
+
+    index, track_url = await playqueue._resolve_playable(0, step=1)
+
+    assert index == 1
+    assert track_url is not None
+    assert playqueue._unavailable_indices == {0}
+    unavailable_events = [
+        e for e in dispatched_events(event_emitter) if isinstance(e, TrackUnavailableEvent)
+    ]
+    assert unavailable_events == [TrackUnavailableEvent(index=0, unavailable=True)]
+
+
+@pytest.mark.asyncio
+async def test_resolve_playable_all_failed_returns_none(event_emitter, playqueue):
+    """When every candidate fails, resolve returns (None, None) and marks all."""
+    playqueue.track_list = make_tracks_with_failures(3, {0, 1, 2})
+    event_emitter.reset_mock()
+
+    index, track_url = await playqueue._resolve_playable(0, step=1)
+
+    assert index is None
+    assert track_url is None
+    assert playqueue._unavailable_indices == {0, 1, 2}
+
+
+@pytest.mark.asyncio
+async def test_resolve_playable_clears_flag_on_success(event_emitter, playqueue):
+    """A previously-unavailable track that now resolves clears its flag."""
+    playqueue.track_list = make_tracks(3)
+    playqueue._unavailable_indices = {0}
+    event_emitter.reset_mock()
+
+    index, track_url = await playqueue._resolve_playable(0, step=1)
+
+    assert index == 0
+    assert track_url is not None
+    assert playqueue._unavailable_indices == set()
+    unavailable_events = [
+        e for e in dispatched_events(event_emitter) if isinstance(e, TrackUnavailableEvent)
+    ]
+    assert unavailable_events == [TrackUnavailableEvent(index=0, unavailable=False)]
+
+
+@pytest.mark.asyncio
+async def test_set_track_unavailable_dedups(event_emitter, playqueue):
+    """Repeated marks/clears only emit an event when the state actually flips."""
+    playqueue.track_list = make_tracks(3)
+    event_emitter.reset_mock()
+
+    playqueue._set_track_unavailable(1, True)
+    playqueue._set_track_unavailable(1, True)
+    playqueue._set_track_unavailable(1, False)
+    playqueue._set_track_unavailable(1, False)
+
+    events = [
+        e for e in dispatched_events(event_emitter) if isinstance(e, TrackUnavailableEvent)
+    ]
+    assert events == [
+        TrackUnavailableEvent(index=1, unavailable=True),
+        TrackUnavailableEvent(index=1, unavailable=False),
+    ]
+    assert playqueue._unavailable_indices == set()
+
+
+@pytest.mark.asyncio
+async def test_unavailable_indices_remap_on_add(event_emitter, playqueue):
+    await playqueue.add(make_tracks(3))
+    await asyncio.sleep(0)
+    playqueue._unavailable_indices = {1, 2}
+
+    await playqueue.add(make_tracks(2), index=0)
+    await asyncio.sleep(0)
+
+    assert playqueue._unavailable_indices == {3, 4}
+
+
+@pytest.mark.asyncio
+async def test_unavailable_indices_remap_on_remove(event_emitter, playqueue):
+    await playqueue.add(make_tracks(4))
+    await asyncio.sleep(0)
+    playqueue._unavailable_indices = {2, 3}
+
+    await playqueue.remove([0])
+
+    assert playqueue._unavailable_indices == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_unavailable_indices_dropped_on_remove(event_emitter, playqueue):
+    await playqueue.add(make_tracks(4))
+    await asyncio.sleep(0)
+    playqueue._unavailable_indices = {1, 3}
+
+    await playqueue.remove([1])
+
+    # Index 1 removed; index 3 shifts down to 2.
+    assert playqueue._unavailable_indices == {2}
+
+
+@pytest.mark.asyncio
+async def test_unavailable_indices_remap_on_move(event_emitter, playqueue):
+    await playqueue.add(make_tracks(4))
+    await asyncio.sleep(0)
+    playqueue._unavailable_indices = {0}
+
+    await playqueue.move(0, 2)
+
+    assert playqueue._unavailable_indices == {2}
+
+
+@pytest.mark.asyncio
+async def test_unavailable_indices_cleared_on_clear(event_emitter, playqueue):
+    await playqueue.add(make_tracks(3))
+    await asyncio.sleep(0)
+    playqueue._unavailable_indices = {0, 1}
+
+    await playqueue.clear()
+
+    assert playqueue._unavailable_indices == set()
+
+
+def test_playqueue_state_apply_track_unavailable():
+    """PlayQueueState.apply toggles the per-track unavailable flag and ignores
+    out-of-range indices."""
+    from kalinka_plugin_sdk.datamodel import PlaybackMode
+    from kalinka_plugin_sdk.events import PlayQueueState
+
+    state = PlayQueueState(
+        playback_state=PlaybackState(state=PlayerStateEnum.STOPPED, index=0),
+        track_list=[create_track("1"), create_track("2")],
+        playback_mode=PlaybackMode(
+            shuffle=False, repeat_single=False, repeat_all=False
+        ),
+        seq=0,
+    )
+
+    marked = state.apply(TrackUnavailableEvent(index=1, unavailable=True, seq=1))
+    assert marked.track_list[1].unavailable is True
+    assert marked.track_list[0].unavailable is False
+
+    cleared = marked.apply(TrackUnavailableEvent(index=1, unavailable=False, seq=2))
+    assert cleared.track_list[1].unavailable is False
+
+    unchanged = cleared.apply(
+        TrackUnavailableEvent(index=99, unavailable=True, seq=3)
+    )
+    assert unchanged is cleared


### PR DESCRIPTION
## Problem

When a track's `link_retriever()` fails (e.g. `Failed to retrieve track link: KeyError('url')`), the play queue bailed out with nothing queued and never advanced `current_track_id`. The player wedged: the current track finished to silence and swiping next/prev kept re-hitting the same broken track. The only escape was tapping a different working track.

(The damaged-file case worked fine because that surfaces as an `ERROR` *state* with a message, which the app already shows as a popup — a different path.)

## Fix

`_resolve_playable()` now walks the queue in the play direction, marking each unreachable track **unavailable** (new `TrackUnavailableEvent`) and skipping to the first track that yields a URL. This covers:
- prefetch / auto-advance
- the `FINISHED` handler
- manual `play(index)`
- `next()` / `prev()` (prev skips backwards)

Tapping a flagged track retries it and clears the flag on success. Running off the end of the queue stays a clean no-op (no spurious error).

`Track` gains an `unavailable` flag carried to clients (`PlayQueueState.apply()` toggles it) so the app can show a warning indicator. `_unavailable_indices` dedupes events and is remapped across add/remove/move/clear.

## Tests

11 new tests covering skip-on-failure, all-failed, flag clearing, dedup, index remapping, and `apply()`. Full `test_playqueue.py` (incl. streaming tests) + `test_eventbus.py` green.

> Frontend counterpart (warning indicator + event handling): madenvel/KalinkaAI#`fix/skip-unavailable-tracks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)