### PR TITLE
Reusable one-shot config trigger; rebuild library on next restart

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
@@ -360,9 +360,16 @@ class LocalFilesConfig(ModuleConfig):
     )
     rescan_on_startup: bool = Field(
         default=False,
-        title="Rescan on next restart",
+        title="Rebuild library on next restart",
         json_schema_extra={
-            "help": "Purges the database and rebuilds it on next server restart",
+            "help": (
+                "Purge the index and artwork cache and rescan all files on the "
+                "next server restart. Resets itself once done."
+            ),
+            # One-shot trigger: the framework resets this (persist-first)
+            # before the plugin acts, so it fires at most once per arming.
+            "one_shot": True,
+            **_SIMPLE,
         },
     )
     searcher: SearcherConfig = Field(

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/input_module_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/input_module_db.py
@@ -20,29 +20,36 @@ class LocalFilesInputModuleDb:
     def __init__(self, config: LocalFilesConfig):
         self.db_path = Path(config.db_path).expanduser().resolve()
         self.artwork_path = Path(config.artwork_path).expanduser().resolve()
-        if config.rescan_on_startup:
-            logger.warning(
-                "Rescan on startup is enabled. This will purge the database and rescan all files."
-            )
-            self._purge_database()
-            logger.warning("Cleaning up cached artwork.")
-            self._purge_artwork()
-            logger.info(
-                "Database purged and artwork cache cleared. The database will be rebuilt."
-            )
-            config.rescan_on_startup = False
-
         self.db_state = None
 
+    def purge_all(self):
+        """Delete the database (with its WAL/-shm sidecars) and the artwork
+        cache so the index is rebuilt from scratch.
+
+        Used by the "Rebuild library on next restart" one-shot. Call before
+        any worker opens the DB (i.e. early in setup), so nothing recreates
+        the file mid-purge.
+        """
+        self._purge_database()
+        self._purge_artwork()
+
     def _purge_database(self):
-        """Purge the database by removing the file and reinitializing it."""
-        if self.db_path.exists():
-            try:
-                self.db_path.unlink()
-                logger.info(f"Database purged: {self.db_path}")
-            except OSError as e:
-                logger.error(f"Failed to purge database: {e}")
-        else:
+        """Remove the database file and its WAL/-shm sidecars."""
+        removed = False
+        for sidecar in ("", "-wal", "-shm"):
+            path = (
+                self.db_path
+                if not sidecar
+                else self.db_path.with_name(self.db_path.name + sidecar)
+            )
+            if path.exists():
+                try:
+                    path.unlink()
+                    removed = True
+                    logger.info(f"Removed {path}")
+                except OSError as e:
+                    logger.error(f"Failed to remove {path}: {e}")
+        if not removed:
             logger.info("No existing database to purge.")
 
     def _purge_artwork(self):

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/module_setup.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/module_setup.py
@@ -154,15 +154,15 @@ class KalinkaPluginLocalFiles(InputModulePlugin):
 
         input_module_db = LocalFilesInputModuleDb(config)
 
-        # LocalFilesInputModuleDb mutates ``rescan_on_startup = False``
-        # on its local copy after consuming the flag. Mirror that on
-        # ``context.config`` so the server's post-setup reconciliation
-        # sees the in-memory model diverge from the loaded override and
-        # rewrites the overrides file — otherwise the True override
-        # would re-fire on every restart and purge the DB each boot.
-        if context.config.rescan_on_startup and not config.rescan_on_startup:
-            context.config.rescan_on_startup = False
-            logger.info("rescan_on_startup reset to False after purge")
+        # "Rebuild library on next restart" is a one-shot trigger: the server
+        # has already reset it (persist-first) before this boot, leaving the
+        # armed value here for us to act on exactly once. Purge before any
+        # worker opens the DB so the indexer rebuilds it from scratch.
+        if config.rescan_on_startup:
+            logger.warning(
+                "Rebuild requested — purging DB and artwork before scan."
+            )
+            input_module_db.purge_all()
 
         # The LocalFilesInputModule will use its own specialized DB
         self._inputmodule = LocalFilesInputModule(

--- a/packages/kalinka-server/src/kalinka_server/config_overrides.py
+++ b/packages/kalinka-server/src/kalinka_server/config_overrides.py
@@ -15,7 +15,7 @@ import json
 import logging
 import os
 import tempfile
-from typing import Any, Dict, List, Mapping
+from typing import Any, Dict, List, Mapping, get_args
 
 from pydantic import BaseModel, TypeAdapter
 
@@ -84,6 +84,78 @@ def save_overrides(path: str, overrides: Mapping[str, Any]) -> None:
         except OSError:
             pass
         raise
+
+
+def _read_path(model: BaseModel, attrs: List[str]) -> Any:
+    current: Any = model
+    for part in attrs:
+        current = getattr(current, part)
+    return current
+
+
+def _model_from_annotation(annotation: Any) -> type[BaseModel] | None:
+    """Resolve a field annotation to its BaseModel class, unwrapping
+    Optional/Union (e.g. ``SubModel | None`` → ``SubModel``). None if the
+    annotation isn't (or doesn't wrap) a BaseModel."""
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    for arg in get_args(annotation):
+        if isinstance(arg, type) and issubclass(arg, BaseModel):
+            return arg
+    return None
+
+
+def is_one_shot_field(model_cls: type[BaseModel], attrs: List[str]) -> bool:
+    """True if the field at dotted ``attrs`` on ``model_cls`` is declared a
+    one-shot trigger via ``json_schema_extra={"one_shot": True}``.
+
+    A one-shot field is a "do X once on the next restart" toggle: set via the
+    normal config PUT, acted on a single time at startup, then reset by the
+    framework. Walks nested pydantic models (including Optional ones) so
+    ``sub.flag`` works too.
+    """
+    cls: Any = model_cls
+    info = None
+    for part in attrs:
+        fields = getattr(cls, "model_fields", None)
+        if not fields or part not in fields:
+            return False
+        info = fields[part]
+        cls = _model_from_annotation(info.annotation)
+    if info is None:
+        return False
+    extra = info.json_schema_extra
+    return isinstance(extra, dict) and bool(extra.get("one_shot"))
+
+
+def find_one_shot_overrides(
+    model_cls: type[BaseModel],
+    prefix: str,
+    config: BaseModel,
+    overrides: Mapping[str, Any],
+) -> List[str]:
+    """Return the override keys under ``prefix`` that target a one-shot field
+    and are currently *armed* — i.e. their value on ``config`` differs from
+    the field's default.
+
+    Pure (no mutation): the caller resets these persist-first before the
+    plugin acts, so an armed trigger fires at most once and never repeats on
+    the following boot.
+    """
+    default = model_cls()
+    armed: List[str] = []
+    for key in overrides:
+        if not key.startswith(prefix):
+            continue
+        attrs = key[len(prefix):].split(".")
+        if not is_one_shot_field(model_cls, attrs):
+            continue
+        try:
+            if _read_path(config, attrs) != _read_path(default, attrs):
+                armed.append(key)
+        except (AttributeError, IndexError, TypeError):
+            continue
+    return armed
 
 
 def apply_overrides_with_prefix(

--- a/packages/kalinka-server/src/kalinka_server/player_setup.py
+++ b/packages/kalinka-server/src/kalinka_server/player_setup.py
@@ -222,7 +222,8 @@ class PreparedModuleCollection:
         if not armed:
             return
 
-        cleared = {k: v for k, v in overrides.items() if k not in set(armed)}
+        armed_set = set(armed)
+        cleared = {k: v for k, v in overrides.items() if k not in armed_set}
 
         if self.overrides_file is not None:
             try:
@@ -260,12 +261,15 @@ class PreparedModuleCollection:
                         )
                 return
 
+        # When there's no overrides file the reset only lives in memory
+        # (tests); say so rather than implying durability.
+        reset_kind = "reset persisted" if self.overrides_file else "reset in memory only"
         for key in armed:
             overrides.pop(key, None)
             logger.warning(
-                "One-shot override '%s' armed — consuming it this boot; "
-                "reset persisted.",
+                "One-shot override '%s' armed — consuming it this boot; %s.",
                 key,
+                reset_kind,
             )
 
     def _reconcile_consumed_overrides(

--- a/packages/kalinka-server/src/kalinka_server/player_setup.py
+++ b/packages/kalinka-server/src/kalinka_server/player_setup.py
@@ -30,7 +30,12 @@ from kalinka_plugin_sdk.plugin import (
 from pydantic import BaseModel, ConfigDict
 
 from .config_model import KalinkaConfig
-from .config_overrides import apply_overrides_with_prefix
+from .config_overrides import (
+    apply_overrides_with_prefix,
+    find_one_shot_overrides,
+    is_one_shot_field,
+    save_overrides,
+)
 from .playqueue import PlayQueueImpl
 from kalinka_plugin_sdk.api import PlayQueueController
 
@@ -116,6 +121,10 @@ class PreparedModuleCollection:
     # (``create_app``) reads this to decide whether to re-persist the
     # overrides dict so the mutations survive a restart.
     overrides_dirty: bool = False
+    # Path of the overrides file, so one-shot triggers can be reset on disk
+    # *before* the owning plugin acts on them (see _consume_one_shot_overrides).
+    # None disables the disk persist (in-memory reset only — used by tests).
+    overrides_file: str | None = None
 
     def _update_enabled_input_modules(self):
         """Update the set of enabled input module names."""
@@ -183,6 +192,82 @@ class PreparedModuleCollection:
         apply_overrides_with_prefix(config, overrides, f"{prefix}{plugin_name}.")
         return config
 
+    def _consume_one_shot_overrides(
+        self,
+        plugin_name: str,
+        plugin_class: type[PluginBase],
+        plugin_config: ModuleConfig,
+        overrides: MutableMapping[str, Any],
+    ) -> None:
+        """Reset any *armed* one-shot triggers for this plugin, persist-first,
+        before its ``setup()`` runs.
+
+        A one-shot field (``json_schema_extra={"one_shot": True}``) is a "do X
+        once on next restart" toggle. We clear it from the overrides — on disk
+        *first* — while leaving the armed value on ``plugin_config`` so the
+        plugin acts this boot. Because the reset is durable before the action,
+        a crash/power-loss mid-action can't make it re-fire next boot. If the
+        reset can't be persisted, we instead *disarm* the in-memory value and
+        skip it this boot, so an action never runs without a durable reset.
+        """
+        prefix = (
+            "input_modules."
+            if plugin_class.PLUGIN_TYPE == PluginType.INPUT_MODULE
+            else "devices."
+        ) + plugin_name + "."
+
+        armed = find_one_shot_overrides(
+            plugin_class.CONFIG_MODEL, prefix, plugin_config, overrides
+        )
+        if not armed:
+            return
+
+        cleared = {k: v for k, v in overrides.items() if k not in set(armed)}
+
+        if self.overrides_file is not None:
+            try:
+                # Persist the reset FIRST; only then does the plugin act.
+                save_overrides(self.overrides_file, cleared)
+            except OSError as exc:
+                logger.error(
+                    "Could not persist one-shot reset to %s; disarming %s this "
+                    "boot so the action doesn't run without a durable reset: %s",
+                    self.overrides_file,
+                    armed,
+                    exc,
+                )
+                default_config = plugin_class.CONFIG_MODEL()
+                for key in armed:
+                    attrs = key[len(prefix):].split(".")
+                    parent = plugin_config
+                    try:
+                        for part in attrs[:-1]:
+                            parent = getattr(parent, part)
+                        default_parent = default_config
+                        for part in attrs[:-1]:
+                            default_parent = getattr(default_parent, part)
+                        setattr(
+                            parent,
+                            attrs[-1],
+                            getattr(default_parent, attrs[-1]),
+                        )
+                    except (AttributeError, IndexError) as disarm_exc:
+                        logger.error(
+                            "Could not disarm one-shot '%s' after a persist "
+                            "failure; it may still act this boot: %s",
+                            key,
+                            disarm_exc,
+                        )
+                return
+
+        for key in armed:
+            overrides.pop(key, None)
+            logger.warning(
+                "One-shot override '%s' armed — consuming it this boot; "
+                "reset persisted.",
+                key,
+            )
+
     def _reconcile_consumed_overrides(
         self,
         plugin_name: str,
@@ -223,6 +308,13 @@ class PreparedModuleCollection:
             if not key.startswith(prefix):
                 continue
             attrs = key[len(prefix):].split(".")
+            # One-shot triggers have their own lifecycle
+            # (_consume_one_shot_overrides). Never reconcile them here: a
+            # transient persist failure leaves the trigger armed on disk for a
+            # retry, and reconcile must not drop it just because the plugin
+            # disarmed the in-memory value.
+            if is_one_shot_field(plugin_class.CONFIG_MODEL, attrs):
+                continue
             try:
                 current = _to_jsonable(_read(plugin_config, attrs))
                 default = _to_jsonable(_read(default_config, attrs))
@@ -268,6 +360,15 @@ class PreparedModuleCollection:
                 config = self._build_module_config(
                     plugin_name, plugin_class, overrides
                 )
+                # Reset armed one-shot triggers on disk *before* the plugin
+                # acts, leaving the armed value on ``config`` for this boot.
+                # Only when the module will actually run (setup() is skipped
+                # for disabled modules) — otherwise the trigger waits, armed,
+                # until the module is enabled rather than being silently lost.
+                if getattr(config, "enabled", True):
+                    self._consume_one_shot_overrides(
+                        plugin_name, plugin_class, config, overrides
+                    )
                 plugin_context = self._make_plugin_context(
                     plugin_name, plugin_class, config
                 )
@@ -351,12 +452,14 @@ class PreparedModuleCollection:
         self,
         player_context: PlayerContext,
         overrides: MutableMapping[str, Any],
+        overrides_file: str | None = None,
     ):
         """Scan for input modules from both entry points and legacy filesystem locations."""
 
         # First, scan for input modules using entry points
         self.player_context = player_context
         self.overrides_dirty = False
+        self.overrides_file = overrides_file
         input_modules = {}
         devices = {}
         async for (
@@ -379,7 +482,9 @@ modules = PreparedModuleCollection()
 
 
 async def setup(
-    config: KalinkaConfig, overrides: MutableMapping[str, Any]
+    config: KalinkaConfig,
+    overrides: MutableMapping[str, Any],
+    overrides_file: str | None = None,
 ) -> PlayerContext:
     """Setup the player components.
 
@@ -412,7 +517,7 @@ async def setup(
         )
 
     # Scan and setup plugins
-    await modules.scan_and_setup_plugins(player_context, overrides)
+    await modules.scan_and_setup_plugins(player_context, overrides, overrides_file)
 
     logger.info("Input modules found: %s", list(modules.prepared_input_modules.keys()))
     logger.info("Output devices found: %s", list(modules.prepared_devices.keys()))

--- a/packages/kalinka-server/src/kalinka_server/server.py
+++ b/packages/kalinka-server/src/kalinka_server/server.py
@@ -218,7 +218,9 @@ async def create_app(
     app.state.config = config
     app.state.overrides_file = overrides_file
     app.state.overrides = dict(overrides)
-    player_context = await setup(config, app.state.overrides)
+    player_context = await setup(
+        config, app.state.overrides, app.state.overrides_file
+    )
     logger.info("Input modules found: %s", list(modules.prepared_input_modules.keys()))
     app.state.player_context = player_context
 

--- a/packages/kalinka-server/src/kalinka_server/server.py
+++ b/packages/kalinka-server/src/kalinka_server/server.py
@@ -224,10 +224,11 @@ async def create_app(
     logger.info("Input modules found: %s", list(modules.prepared_input_modules.keys()))
     app.state.player_context = player_context
 
-    # If any plugin's setup consumed a one-shot override (e.g.
-    # localfiles' ``rescan_on_startup``), persist the reconciled
-    # overrides dict now. Without this the consumed override would
-    # remain in the file and trigger again on the next restart.
+    # Persist the overrides dict if plugin setup reconciled it — i.e. a
+    # plugin mutated config fields that came from the overrides file, so
+    # ``app.state.overrides`` now diverges from disk. (One-shot triggers
+    # are handled separately, persist-first *before* setup, so they're not
+    # what this covers.)
     if modules.overrides_dirty:
         try:
             save_overrides(app.state.overrides_file, app.state.overrides)

--- a/packages/kalinka-server/tests/test_one_shot_overrides.py
+++ b/packages/kalinka-server/tests/test_one_shot_overrides.py
@@ -1,0 +1,180 @@
+"""Tests for one-shot config triggers.
+
+Covers detection (``is_one_shot_field`` / ``find_one_shot_overrides``) and the
+persist-first consume on ``PreparedModuleCollection`` — the guarantee that an
+armed "do X on next restart" trigger is reset *before* the plugin acts, so it
+fires at most once and can never re-fire on the following boot.
+"""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel, Field
+
+from kalinka_plugin_sdk.module_config import ModuleConfig
+from kalinka_plugin_sdk.plugin import PluginType
+
+from kalinka_server.config_overrides import (
+    find_one_shot_overrides,
+    is_one_shot_field,
+    load_overrides,
+)
+from kalinka_server.player_setup import PreparedModuleCollection
+
+
+class _Nested(BaseModel):
+    flag: bool = Field(default=False, json_schema_extra={"one_shot": True})
+
+
+class _Cfg(ModuleConfig):
+    rebuild: bool = Field(default=False, json_schema_extra={"one_shot": True})
+    plain: bool = Field(default=False)
+    sub: _Nested = Field(default_factory=_Nested)
+
+
+class _Plugin:
+    PLUGIN_TYPE = PluginType.INPUT_MODULE
+    CONFIG_MODEL = _Cfg
+
+
+PREFIX = "input_modules.fake."
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+def test_is_one_shot_field_top_level():
+    assert is_one_shot_field(_Cfg, ["rebuild"]) is True
+    assert is_one_shot_field(_Cfg, ["plain"]) is False
+
+
+def test_is_one_shot_field_nested():
+    assert is_one_shot_field(_Cfg, ["sub", "flag"]) is True
+
+
+def test_is_one_shot_field_unknown_path():
+    assert is_one_shot_field(_Cfg, ["nope"]) is False
+    assert is_one_shot_field(_Cfg, ["sub", "nope"]) is False
+
+
+def test_find_one_shot_overrides_returns_only_armed_one_shots():
+    cfg = _Cfg(rebuild=True, plain=True)
+    overrides = {
+        PREFIX + "rebuild": True,  # one-shot, armed
+        PREFIX + "plain": True,  # not one-shot
+        "devices.x.rebuild": True,  # wrong prefix
+    }
+    assert find_one_shot_overrides(_Cfg, PREFIX, cfg, overrides) == [
+        PREFIX + "rebuild"
+    ]
+
+
+def test_find_one_shot_overrides_not_armed_when_value_is_default():
+    cfg = _Cfg(rebuild=False)
+    overrides = {PREFIX + "rebuild": False}
+    assert find_one_shot_overrides(_Cfg, PREFIX, cfg, overrides) == []
+
+
+# ---------------------------------------------------------------------------
+# Consume (persist-first)
+# ---------------------------------------------------------------------------
+
+
+def _collection(overrides_file=None) -> PreparedModuleCollection:
+    c = PreparedModuleCollection()
+    c.overrides_file = overrides_file
+    return c
+
+
+def test_consume_resets_persist_first_and_keeps_armed_value(tmp_path):
+    ofile = str(tmp_path / "ov.json")
+    overrides = {PREFIX + "rebuild": True, PREFIX + "plain": True}
+    with open(ofile, "w") as f:
+        json.dump(overrides, f)
+
+    cfg = _Cfg(rebuild=True, plain=True)
+    live = dict(overrides)
+    _collection(ofile)._consume_one_shot_overrides("fake", _Plugin, cfg, live)
+
+    # Trigger dropped from the live dict and from disk...
+    assert PREFIX + "rebuild" not in live
+    assert PREFIX + "rebuild" not in load_overrides(ofile)
+    # ...other overrides untouched...
+    assert load_overrides(ofile).get(PREFIX + "plain") is True
+    # ...but the armed value stays on config so the plugin acts this boot.
+    assert cfg.rebuild is True
+
+
+def test_consume_is_noop_when_nothing_armed(tmp_path):
+    ofile = str(tmp_path / "ov.json")
+    overrides = {PREFIX + "plain": True}
+    with open(ofile, "w") as f:
+        json.dump(overrides, f)
+
+    cfg = _Cfg(plain=True)
+    live = dict(overrides)
+    _collection(ofile)._consume_one_shot_overrides("fake", _Plugin, cfg, live)
+
+    assert live == {PREFIX + "plain": True}
+
+
+def test_consume_disarms_in_memory_when_persist_fails(monkeypatch):
+    """If the reset can't be persisted, the trigger must NOT fire: the value
+    is disarmed in memory and left armed on disk for a retry next boot."""
+    import kalinka_server.player_setup as ps
+
+    def boom(*a, **k):
+        raise OSError("read-only fs")
+
+    monkeypatch.setattr(ps, "save_overrides", boom)
+
+    cfg = _Cfg(rebuild=True)
+    live = {PREFIX + "rebuild": True}
+    _collection("/does/not/matter")._consume_one_shot_overrides(
+        "fake", _Plugin, cfg, live
+    )
+
+    # Override left in place (retried next boot) and config disarmed so the
+    # plugin skips the action this boot — never act without a durable reset.
+    assert PREFIX + "rebuild" in live
+    assert cfg.rebuild is False
+
+
+def test_consume_without_file_clears_in_memory(tmp_path):
+    cfg = _Cfg(rebuild=True)
+    live = {PREFIX + "rebuild": True}
+    _collection(None)._consume_one_shot_overrides("fake", _Plugin, cfg, live)
+    assert PREFIX + "rebuild" not in live
+    assert cfg.rebuild is True
+
+
+def test_reconcile_never_touches_one_shot_fields():
+    """One-shot triggers are owned by the consume step. Reconcile (which runs
+    after setup) must leave them alone — otherwise a transient persist failure
+    that disarmed the in-memory value would let reconcile drop the still-armed
+    override, silently losing an un-fired trigger.
+    """
+    # Disarmed in memory (rebuild=False) but the override is still on disk —
+    # the exact post-persist-failure state. Reconcile must NOT drop it.
+    cfg = _Cfg(rebuild=False)
+    overrides = {PREFIX + "rebuild": True}
+    changed = PreparedModuleCollection()._reconcile_consumed_overrides(
+        "fake", _Plugin, cfg, overrides
+    )
+    assert changed == 0
+    assert overrides == {PREFIX + "rebuild": True}
+
+
+def test_is_one_shot_field_walks_optional_nested_model():
+    from typing import Optional
+
+    class _OptNested(BaseModel):
+        flag: bool = Field(default=False, json_schema_extra={"one_shot": True})
+
+    class _OptCfg(ModuleConfig):
+        sub: Optional[_OptNested] = None
+
+    assert is_one_shot_field(_OptCfg, ["sub", "flag"]) is True


### PR DESCRIPTION
## What

Adds a generic **one-shot config-field** primitive and rebuilds localfiles' "rebuild library" on top of it.

A plugin marks any config field `json_schema_extra={"one_shot": True}`. At startup the server consumes armed one-shot overrides **persist-first**: it clears the override on disk *before* the plugin acts, leaving the armed value in memory for that one boot. This guarantees a "do X on next restart" toggle fires **at most once** and can never re-fire — fixing the old "rescan fires every restart" bug.

If the reset can't be persisted, the value is **disarmed in memory** instead, so the action never runs without a durable reset. `_reconcile_consumed_overrides` ignores one-shot fields, so a transient persist failure can't drop an un-fired trigger.

`localfiles.rescan_on_startup` is converted to this — retitled **"Rebuild library on next restart"**, shown on the simple settings page. When armed, `setup()` purges the DB (+ `-wal`/`-shm`) and artwork before any worker opens it; the indexer then rebuilds from scratch.

## Why

It's a cancellable toggle (turn off + Apply before restart), set via the normal config PUT, that resets itself — the right model for "rebuild on next restart". The mechanism is reusable for any future per-plugin trigger (clear-cache, reset-to-defaults, re-download-models, …).

## Reusable API

- Declare: `json_schema_extra={"one_shot": True}` on a config field.
- Act: read it in `setup()` and do the thing. No clearing/persisting in plugin code — the framework handles the persist-first reset.

## Testing

- New `tests/test_one_shot_overrides.py`: detection (incl. nested/Optional), persist-first reset, disarm-on-failure, no-file fallback, and reconcile-never-touches-one-shot.
- Full server suite: 235 passing (playqueue excluded per repo convention).

## Pairs with

The standalone **Restart server** button in the KalinkaAI app (separate PR) lets you fire an armed toggle on demand. The toggle also renders automatically and works via the existing Apply-&-restart flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)