### PR TITLE
Docs: correct deb/wheel version source to setuptools-scm tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This will:
 - Create a Python wheel that includes the native player library
 - Package everything into a Debian package with version matching the wheel
 
-The resulting package will be named `kalinka-player-<version>.<architecture>.deb` where the version matches the one from the Python wheel (e.g., `kalinka-player-1.4.1.dev96+g641eb978a.d20250905.amd64.deb`). The version of the package is taken from the most recent `release-x.y.z` tag with `z` increased by one.
+The resulting package will be named `kalinka-player-<version>.<architecture>.deb` where the version matches the one from the Python wheel (e.g., `kalinka-player-0.1.0.amd64.deb`). The version is derived by `setuptools-scm` from the most recent `kalinka-server-vX.Y.Z` git tag; commits made after that tag produce a development version such as `0.1.1.dev4+g641eb978a`.
 
 
 #### Cleaning Build Artifacts


### PR DESCRIPTION
The README claimed the `.deb`/wheel version came from the most recent `release-x.y.z` tag with `z` bumped. That's stale — `build_deb.sh` and the plugin build scripts derive the version via `setuptools-scm` from the `kalinka-server-vX.Y.Z` (and `kalinka-plugin-*-vX.Y.Z`) git tags.

Updates the example filename and the description to match actual behavior, ahead of the first public `0.1.0` alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)