### PR TITLE
Add POST /server/test_tone speaker-test endpoint

### DIFF
--- a/packages/kalinka-server/src/kalinka_server/server.py
+++ b/packages/kalinka-server/src/kalinka_server/server.py
@@ -56,6 +56,7 @@ from .internal_modules import internal_modules
 from .service_discovery import ServiceDiscovery
 from .version import get_rest_api_version, get_version
 from .state_keeper import save_state, restore_state
+from .test_tone import VALID_CHANNELS, play_test_tone
 from .queue_ws_handler import (
     handle_websocket_connection as handle_queue_websocket_connection,
 )
@@ -889,6 +890,44 @@ async def create_app(
                 status_code=500, detail="Failed to request restart"
             ) from e
         return {"message": "restarting", "install_queued": accepted}
+
+    @app.post("/server/test_tone")
+    async def server_test_tone(payload: Optional[Dict[str, Any]] = None):
+        """Play a short test tone through the ALSA output (speaker check).
+
+        Body (all fields optional):
+          ``{"channel": "left"|"right"|"both", "device": "<alsa id>"}``
+
+        ``device`` overrides the configured output so the client can test a
+        selection that hasn't been applied yet (the setup wizard stages the
+        ALSA device until its final restart). Any current playback is
+        stopped first — hw: devices are exclusive, and a speaker test in
+        the middle of music would be meaningless anyway. Returns once the
+        tone finished playing (~2 seconds).
+        """
+        payload = payload or {}
+        channel = str(payload.get("channel", "both")).lower()
+        if channel not in VALID_CHANNELS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"channel must be one of {list(VALID_CHANNELS)}",
+            )
+        device = payload.get("device")
+        if device is not None and not isinstance(device, str):
+            raise HTTPException(status_code=400, detail="device must be a string")
+
+        # Release the audio device before the tone opens it.
+        await player_context.playqueue.stop()
+        try:
+            await play_test_tone(
+                player_context.playqueue.config, channel=channel, device=device
+            )
+        except (RuntimeError, TimeoutError) as e:
+            logger.error("Test tone failed: %s", e)
+            raise HTTPException(
+                status_code=500, detail=f"Test tone failed: {e}"
+            ) from e
+        return {"message": "Ok", "channel": channel}
 
     @app.get("/server/optional_packages")
     def get_optional_packages():

--- a/packages/kalinka-server/src/kalinka_server/test_tone.py
+++ b/packages/kalinka-server/src/kalinka_server/test_tone.py
@@ -1,0 +1,95 @@
+"""Speaker test: play a short sine tone through the native player.
+
+Used by the client's first-run setup wizard to verify the selected ALSA
+output and channel wiring. The tone goes through the exact same pipeline as
+normal playback (AudioPlayer -> stream switcher -> ALSA emitter); only the
+source differs — a ``tone://`` pseudo-stream generated in-process by the
+native SineWaveNode, so no decoder or network is involved.
+
+A dedicated, short-lived AudioPlayer instance is created per tone so the
+play queue's player and its state machine are never touched. The caller
+must stop queue playback first (see the ``/server/test_tone`` route) —
+hw: ALSA devices are exclusive, and the tone needs to open the device.
+"""
+
+import asyncio
+import logging
+import time
+
+from native_player.native_player import (
+    AudioFormat,
+    AudioGraphNodeState,
+    AudioPlayer,
+)
+
+logger = logging.getLogger(__name__)
+
+VALID_CHANNELS = ("left", "right", "both")
+
+TONE_FREQUENCY_HZ = 440
+TONE_DURATION_MS = 2000
+
+# Device open + state propagation slack on top of the tone itself.
+_COMPLETION_GRACE_S = 5.0
+_POLL_INTERVAL_S = 0.1
+
+# One tone at a time — two concurrent opens of the same exclusive ALSA
+# device would make the second one fail spuriously.
+_tone_lock = asyncio.Lock()
+
+
+async def play_test_tone(
+    player_config: dict,
+    *,
+    channel: str,
+    device: str | None = None,
+) -> None:
+    """Play a test tone and return once it finished playing.
+
+    ``player_config`` is the flattened native-player config (the play
+    queue's ``config`` dict). ``device`` overrides the configured ALSA
+    output — the client passes its not-yet-applied selection so the tone
+    tests what the user actually picked.
+
+    Raises ``ValueError`` for a bad channel, ``RuntimeError`` when the
+    player reports an error (e.g. the device cannot be opened), and
+    ``TimeoutError`` if playback never finishes.
+    """
+    if channel not in VALID_CHANNELS:
+        raise ValueError(f"channel must be one of {VALID_CHANNELS}")
+
+    config = dict(player_config)
+    if device:
+        config["output.alsa.device"] = str(device)
+
+    async with _tone_lock:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, _play_blocking, config, channel)
+
+
+def _play_blocking(config: dict, channel: str) -> None:
+    logger.info(
+        "Playing %sms test tone on channel=%s device=%s",
+        TONE_DURATION_MS,
+        channel,
+        config.get("output.alsa.device", "default"),
+    )
+    player = AudioPlayer(config)
+    try:
+        url = f"tone://{channel}?freq={TONE_FREQUENCY_HZ}&duration_ms={TONE_DURATION_MS}"
+        # The format argument is ignored for tone:// (no decoder is attached).
+        player.append(url, AudioFormat.FLAC)
+
+        deadline = time.monotonic() + TONE_DURATION_MS / 1000 + _COMPLETION_GRACE_S
+        while time.monotonic() < deadline:
+            state = player.get_state()
+            if state.state == AudioGraphNodeState.FINISHED:
+                return
+            if state.state == AudioGraphNodeState.ERROR:
+                message = state.error.message if state.error else "unknown audio error"
+                raise RuntimeError(message)
+            time.sleep(_POLL_INTERVAL_S)
+        raise TimeoutError("test tone did not finish in time")
+    finally:
+        # Always release the audio device, whatever state we ended up in.
+        player.stop()

--- a/packages/kalinka-server/src/kalinka_server/test_tone.py
+++ b/packages/kalinka-server/src/kalinka_server/test_tone.py
@@ -34,8 +34,18 @@ _COMPLETION_GRACE_S = 5.0
 _POLL_INTERVAL_S = 0.1
 
 # One tone at a time — two concurrent opens of the same exclusive ALSA
-# device would make the second one fail spuriously.
-_tone_lock = asyncio.Lock()
+# device would make the second one fail spuriously. Created lazily from
+# inside a running coroutine rather than at import time, so the lock can
+# never end up bound to a different event loop than the one serving
+# requests.
+_tone_lock: asyncio.Lock | None = None
+
+
+def _get_tone_lock() -> asyncio.Lock:
+    global _tone_lock
+    if _tone_lock is None:
+        _tone_lock = asyncio.Lock()
+    return _tone_lock
 
 
 async def play_test_tone(
@@ -62,7 +72,7 @@ async def play_test_tone(
     if device:
         config["output.alsa.device"] = str(device)
 
-    async with _tone_lock:
+    async with _get_tone_lock():
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _play_blocking, config, channel)
 

--- a/packages/kalinka-server/src/native_player/AudioPlayer.cpp
+++ b/packages/kalinka-server/src/native_player/AudioPlayer.cpp
@@ -8,7 +8,11 @@
 #include "Log.h"
 #include "Mp3StreamDecoder.h"
 #include "PerfMon.h"
+#include "SineWaveNode.h"
 #include "StateMonitor.h"
+
+#include <algorithm>
+#include <cstdlib>
 
 namespace {
 // These numbers can be reduced depending on audio bitness,
@@ -28,6 +32,57 @@ bool isInvalidState(AudioGraphNodeState state) {
          state == AudioGraphNodeState::STOPPED ||
          state == AudioGraphNodeState::ERROR;
 }
+
+// Pseudo-scheme for the speaker test:
+//   tone://<left|right|both>?freq=<hz>&duration_ms=<ms>
+// Generates audio in-process (SineWaveNode) instead of reading a stream, so
+// no decoder is attached. Out-of-range values are clamped, unknown channel
+// names fall back to both.
+struct ToneSpec {
+  int frequency = 440;
+  int durationMs = 2000;
+  ToneChannel channel = ToneChannel::Both;
+};
+
+ToneSpec parseToneUrl(const std::string &url) {
+  ToneSpec spec;
+  std::string rest = url.substr(7); // strip "tone://"
+  std::string query;
+  const auto qpos = rest.find('?');
+  if (qpos != std::string::npos) {
+    query = rest.substr(qpos + 1);
+    rest = rest.substr(0, qpos);
+  }
+  if (rest == "left") {
+    spec.channel = ToneChannel::Left;
+  } else if (rest == "right") {
+    spec.channel = ToneChannel::Right;
+  }
+
+  size_t start = 0;
+  while (start < query.size()) {
+    auto end = query.find('&', start);
+    if (end == std::string::npos) {
+      end = query.size();
+    }
+    const auto kv = query.substr(start, end - start);
+    const auto eq = kv.find('=');
+    if (eq != std::string::npos) {
+      const auto key = kv.substr(0, eq);
+      const int value = std::atoi(kv.substr(eq + 1).c_str());
+      if (key == "freq") {
+        spec.frequency = value;
+      } else if (key == "duration_ms") {
+        spec.durationMs = value;
+      }
+    }
+    start = end + 1;
+  }
+
+  spec.frequency = std::clamp(spec.frequency, 20, 20000);
+  spec.durationMs = std::clamp(spec.durationMs, 100, 10000);
+  return spec;
+}
 } // namespace
 
 struct StreamNodes {
@@ -39,6 +94,18 @@ struct StreamNodes {
   StreamNodes(StreamId id, const std::string &url, const Config &config,
               const AudioFormat format)
       : url(url), id(id) {
+    if (url.substr(0, 7) == "tone://") {
+      // Speaker-test tone, generated in-process — emits PCM frames directly,
+      // so no decoder is attached and `format` is ignored.
+      const auto spec = parseToneUrl(url);
+      spdlog::debug("Creating SineWaveNode: freq={}Hz duration={}ms channel={}",
+                    spec.frequency, spec.durationMs,
+                    static_cast<int>(spec.channel));
+      nodeChain.emplace_back(std::make_shared<SineWaveNode>(
+          spec.frequency, spec.durationMs, 48000u, 16u, spec.channel));
+      return;
+    }
+
     if (url.substr(0, 7) == "file://") {
       // Use FileInputNode for local files
       std::string filePath = url.substr(7);

--- a/packages/kalinka-server/src/native_player/SineWaveNode.h
+++ b/packages/kalinka-server/src/native_player/SineWaveNode.h
@@ -5,16 +5,23 @@
 
 #include <cmath>
 
+// Which channels of the interleaved stereo output carry the tone. Left/Right
+// keep the other channel silent — used by the speaker-test endpoint to verify
+// channel wiring.
+enum class ToneChannel { Both = 0, Left, Right };
+
 class SineWaveNode : public AudioGraphOutputNode {
   size_t position = 0;
   size_t totalDataSize = 0;
   StreamInfo streamInfo;
   int frequency;
+  ToneChannel channel;
 
 public:
   SineWaveNode(int frequency, int durationMs, unsigned int sampleRate = 48000,
-               unsigned int bitsPerSample = 16)
-      : frequency(frequency) {
+               unsigned int bitsPerSample = 16,
+               ToneChannel channel = ToneChannel::Both)
+      : frequency(frequency), channel(channel) {
     totalDataSize = sampleRate * (bitsPerSample >> 3) * 2 * durationMs / 1000;
     streamInfo =
         StreamInfo{.format = {.sampleRate = sampleRate,
@@ -31,9 +38,15 @@ public:
 
     for (size_t i = 0; i < size / 2; i++) {
       size_t pos = i + position / 2;
+      // Interleaved stereo: even sample index = left, odd = right.
+      const bool isRightSample = (pos % 2) != 0;
+      const bool muted = (channel == ToneChannel::Left && isRightSample) ||
+                         (channel == ToneChannel::Right && !isRightSample);
       const auto value =
-          floor(8192 * sin(2 * M_PI * static_cast<double>(frequency) *
-                           floor(pos / 2) / streamInfo.format.sampleRate));
+          muted ? 0.0
+                : floor(8192 * sin(2 * M_PI * static_cast<double>(frequency) *
+                                   floor(pos / 2) /
+                                   streamInfo.format.sampleRate));
       static_cast<int16_t *>(data)[i] = value;
     }
     position += size;

--- a/packages/kalinka-server/src/native_player/tests/SineWaveNode_test.cpp
+++ b/packages/kalinka-server/src/native_player/tests/SineWaveNode_test.cpp
@@ -82,6 +82,33 @@ TEST_F(SineWaveNodeTest, seekToEnd) {
   EXPECT_EQ(sineWaveNode.getState().state, AudioGraphNodeState::FINISHED);
 }
 
+TEST_F(SineWaveNodeTest, read_left_only) {
+  SineWaveNode sineWaveNode(frequency, duration, 48000, 16,
+                            ToneChannel::Left);
+  std::vector<int16_t> data(20);
+  EXPECT_EQ(sineWaveNode.read(data.data(), 40), 40);
+  for (int i = 0; i < 20; i++) {
+    const auto value =
+        floor(8192 * sin(2 * M_PI * static_cast<double>(frequency) *
+                         floor(i / 2) / 48000.0));
+    // Interleaved stereo: even index = left (tone), odd = right (silent).
+    EXPECT_EQ(data[i], i % 2 == 0 ? value : 0);
+  }
+}
+
+TEST_F(SineWaveNodeTest, read_right_only) {
+  SineWaveNode sineWaveNode(frequency, duration, 48000, 16,
+                            ToneChannel::Right);
+  std::vector<int16_t> data(20);
+  EXPECT_EQ(sineWaveNode.read(data.data(), 40), 40);
+  for (int i = 0; i < 20; i++) {
+    const auto value =
+        floor(8192 * sin(2 * M_PI * static_cast<double>(frequency) *
+                         floor(i / 2) / 48000.0));
+    EXPECT_EQ(data[i], i % 2 == 1 ? value : 0);
+  }
+}
+
 TEST_F(SineWaveNodeTest, seekToEnd_and_back) {
   SineWaveNode sineWaveNode(frequency, duration);
   auto state = waitForStatus(sineWaveNode, AudioGraphNodeState::STREAMING);

--- a/packages/kalinka-server/tests/test_test_tone.py
+++ b/packages/kalinka-server/tests/test_test_tone.py
@@ -1,0 +1,100 @@
+import pytest
+from unittest.mock import Mock
+
+from native_player.native_player import (
+    AudioGraphNodeState,
+    StreamError,
+    StreamErrorSource,
+    StreamState,
+)
+
+import kalinka_server.test_tone as test_tone
+
+
+class FakePlayer:
+    """Stand-in for native_player.AudioPlayer: records calls, replays a
+    scripted sequence of states from get_state()."""
+
+    instances: list["FakePlayer"] = []
+
+    # Class-level script applied to the next instance.
+    next_states: list[StreamState] = []
+
+    def __init__(self, config):
+        self.config = dict(config)
+        self.appended: list[tuple[str, object]] = []
+        self.stopped = False
+        self._states = list(FakePlayer.next_states)
+        FakePlayer.instances.append(self)
+
+    def append(self, url, fmt):
+        self.appended.append((url, fmt))
+
+    def get_state(self):
+        if len(self._states) > 1:
+            return self._states.pop(0)
+        return self._states[0]
+
+    def stop(self):
+        self.stopped = True
+
+
+@pytest.fixture(autouse=True)
+def fake_player(monkeypatch):
+    FakePlayer.instances = []
+    FakePlayer.next_states = [
+        StreamState(state=AudioGraphNodeState.STREAMING, position=0),
+        StreamState(state=AudioGraphNodeState.FINISHED),
+    ]
+    monkeypatch.setattr(test_tone, "AudioPlayer", FakePlayer)
+    # Keep the poll loop fast in tests.
+    monkeypatch.setattr(test_tone, "_POLL_INTERVAL_S", 0)
+    return FakePlayer
+
+
+@pytest.mark.asyncio
+async def test_rejects_unknown_channel():
+    with pytest.raises(ValueError):
+        await test_tone.play_test_tone({}, channel="middle")
+    assert FakePlayer.instances == []
+
+
+@pytest.mark.asyncio
+async def test_plays_tone_url_and_releases_player():
+    await test_tone.play_test_tone(
+        {"output.alsa.device": "default"}, channel="left"
+    )
+    (player,) = FakePlayer.instances
+    (url, _fmt) = player.appended[0]
+    assert url.startswith("tone://left?")
+    assert player.config["output.alsa.device"] == "default"
+    assert player.stopped
+
+
+@pytest.mark.asyncio
+async def test_device_override_applies_without_mutating_input():
+    base_config = {"output.alsa.device": "default"}
+    await test_tone.play_test_tone(
+        base_config, channel="right", device="hw:CARD=DAC,DEV=0"
+    )
+    (player,) = FakePlayer.instances
+    assert player.config["output.alsa.device"] == "hw:CARD=DAC,DEV=0"
+    # The shared playqueue config must not be touched.
+    assert base_config["output.alsa.device"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_player_error_raises_runtime_error():
+    FakePlayer.next_states = [
+        StreamState(
+            state=AudioGraphNodeState.ERROR,
+            error=StreamError(
+                source=StreamErrorSource.AUDIO_OUTPUT,
+                message="Cannot open audio device",
+            ),
+        ),
+    ]
+    with pytest.raises(RuntimeError, match="Cannot open audio device"):
+        await test_tone.play_test_tone({}, channel="both")
+    (player,) = FakePlayer.instances
+    assert player.stopped


### PR DESCRIPTION
## Summary

Speaker-test endpoint for the client's first-run setup wizard (KalinkaAI PR #6): plays a short sine tone on the left, right, or both channels through the same native-player pipeline as normal playback.

**Native player:**
- `SineWaveNode` gains a `ToneChannel` (both/left/right) that silences the other channel of the interleaved stereo output
- `AudioPlayer` accepts a `tone://<channel>?freq=<hz>&duration_ms=<ms>` pseudo-scheme — a SineWaveNode source with no decoder attached, values clamped to sane ranges

**Server:**
- `kalinka_server/test_tone.py` plays the tone on a dedicated short-lived `AudioPlayer` so the play queue's player and state machine are untouched; serialised by an asyncio lock, polls FINISHED/ERROR with a timeout, always releases the device
- `POST /server/test_tone {"channel": "left"|"right"|"both", "device": "<alsa id>"}` (both optional): stops queue playback first (hw: devices are exclusive), supports a device override so clients can test a staged, not-yet-applied ALSA selection, maps player errors to HTTP 500 with the underlying ALSA message

## Test plan
- 2 new C++ tests for the channel masking; full native suite: 109 pass, 5 pre-existing AudioPlayerTest failures identical on clean main (environmental)
- 4 new Python unit tests (mocked player): channel validation, tone URL, device override without mutating the shared config, error propagation; full server pytest: 285 pass
- Audible end-to-end verification of left/right/both tones on a live pipewire setup, plus the invalid-device error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)