### PR TITLE
Add Jamendo input plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ kalinka-server-deb:
 	@echo "Building kalinka-server deb package..."
 	@cd packages/kalinka-server && ./scripts/build_deb.sh
 
-## Build all plugin deb packages (SDK, local files, musiccast, dummydevice)
+## Build all plugin deb packages (SDK, local files, musiccast, dummydevice, jamendo)
 kalinka-plugins-deb:
 	@echo "Building plugin deb packages..."
 	@for dir in packages/kalinka-plugin-*; do \

--- a/packages/kalinka-plugin-jamendo/README.md
+++ b/packages/kalinka-plugin-jamendo/README.md
@@ -1,0 +1,68 @@
+# Jamendo Plugin for Kalinka Music Player
+
+## Overview
+
+An input-module plugin that lets you search, browse and play music from
+[Jamendo](https://www.jamendo.com) — a catalogue of free, Creative-Commons /
+royalty-free music — inside the Kalinka play queue, alongside local files and
+other sources.
+
+> **Disclaimer**: This plugin is an independent, community-developed integration
+> and is not affiliated with or endorsed by Jamendo. It is provided "as is".
+> Streaming via the Jamendo API is intended for personal use; commercial use of
+> Jamendo tracks requires a licence from Jamendo Licensing.
+
+## Configuration
+
+| Setting        | Description                                                                 |
+| -------------- | --------------------------------------------------------------------------- |
+| `client_id`    | **Required.** Free Jamendo API key. Register an app at https://devportal.jamendo.com |
+| `audio_format` | Streaming quality: MP3 VBR (default), MP3 96 kbps, OGG, or FLAC.             |
+
+## Capabilities
+
+Implemented:
+
+- **Search** — tracks, albums, artists, playlists (Jamendo `namesearch`).
+- **Browse** — a discovery root catalog (Popular Tracks, New Releases, Popular
+  Albums, Popular Artists, Featured Playlists) and drill-down into albums,
+  artists and playlists.
+- **Playback** — `get_track_info` returns metadata plus the streaming URL in
+  the configured format.
+- **`get`** — detail lookup for a track / album / artist / playlist.
+
+Intentionally **not** implemented:
+
+- **Favourites** (`list_favorite`, `add_to_favorite`, …) and **playlist
+  management** (`playlist_create`, …) — these require an OAuth2 user session,
+  which is out of scope. They degrade to empty results / no-ops.
+- **`list_genre`** — Jamendo has no genre taxonomy (it uses free-form tags), so
+  this returns an empty list and catalogs disable genre filtering.
+- **`ai_search`** — left at the SDK default (empty) until the semantic backend
+  is wired up.
+
+## Known limitations
+
+- **No exact result totals.** The Jamendo API reports only the size of the
+  current page, never a grand total. Reported totals are therefore estimates
+  tuned to keep "load more" pagination working.
+- **Free-tier rate limits.** The Jamendo API rate-limits requests per
+  client_id; heavy browsing may be throttled.
+- **FLAC is best-effort.** Lossless streams exist only for tracks whose artist
+  enabled download; otherwise Jamendo serves a lossy stream.
+
+## Building
+
+```bash
+./scripts/build_wheel.sh   # build the wheel (version from setuptools-scm)
+./scripts/build_deb.sh     # build the .deb (wheel + Debian control)
+```
+
+Release versions come from a git tag of the form
+`kalinka-plugin-jamendo-v1.2.3`; untagged builds produce a dev version.
+
+## Testing
+
+```bash
+pytest            # smoke + offline mapping tests (no network/client_id needed)
+```

--- a/packages/kalinka-plugin-jamendo/debian/control.in
+++ b/packages/kalinka-plugin-jamendo/debian/control.in
@@ -1,0 +1,9 @@
+Package: kalinka-plugin-jamendo
+Version: @VERSION@
+Section: python
+Priority: optional
+Architecture: all
+Depends: kalinka-plugin-sdk (>= 1.0), kalinka-plugin-sdk (<< 2), python3, ca-certificates
+Maintainer: Dmitry Savin <envelsavinds@gmail.com>
+Description: Kalinka Plugin for Jamendo – Jamendo plugin for Kalinka Music Player
+ Jamendo plugin for Kalinka Music Player

--- a/packages/kalinka-plugin-jamendo/debian/prerm
+++ b/packages/kalinka-plugin-jamendo/debian/prerm
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+case "$1" in
+  remove|deconfigure)
+    VENVDIR="/opt/kalinka/venv"
+    PKG="kalinka-plugin-jamendo"
+    if [ -x "$VENVDIR/bin/pip" ]; then
+      "$VENVDIR/bin/pip" uninstall -y "$PKG" || true
+    fi
+    ;;
+esac
+exit 0

--- a/packages/kalinka-plugin-jamendo/debian/rules
+++ b/packages/kalinka-plugin-jamendo/debian/rules
@@ -1,0 +1,10 @@
+#!/usr/bin/make -f
+
+%:
+	dh $@
+
+override_dh_auto_build:
+	# No build step needed - wheel is pre-built
+
+override_dh_auto_install:
+	# Custom installation handled by scripts

--- a/packages/kalinka-plugin-jamendo/debian/triggers
+++ b/packages/kalinka-plugin-jamendo/debian/triggers
@@ -1,0 +1,1 @@
+activate-noawait kalinka-server-restart

--- a/packages/kalinka-plugin-jamendo/pyproject.toml
+++ b/packages/kalinka-plugin-jamendo/pyproject.toml
@@ -1,0 +1,67 @@
+[build-system]
+requires = ["setuptools>=68", "wheel", "build", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kalinka-plugin-jamendo"
+dynamic = ["version"]
+description = "Jamendo plugin for Kalinka Music Player"
+readme = "README.md"
+license = "GPL-3.0-or-later"
+requires-python = ">=3.10"
+authors = [
+    {name = "Dmitry Savin", email = "envelsavinds@gmail.com"}
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+dependencies = [
+    "kalinka-plugin-sdk>=1,<2",
+    "httpx>=0.24",
+]
+
+[project.optional-dependencies]
+dev = [
+    "kalinka-plugin-dev>=1.0,<2",
+    "pytest",
+    "pytest-asyncio",
+    "setuptools-scm",
+]
+
+[project.entry-points."kalinka.plugins"]
+kalinka_plugin_jamendo = "kalinka_plugin_jamendo:KalinkaPluginJamendo"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools_scm]
+write_to = "src/kalinka_plugin_jamendo/_version.py"
+tag_regex = "^kalinka-plugin-jamendo-v(?P<version>\\d+\\.\\d+\\.\\d+)$"
+git_describe_command = "git describe --dirty --tags --long --match kalinka-plugin-jamendo-v*"
+version_scheme = "guess-next-dev"
+local_scheme = "node-and-date"
+fallback_version = "0.0.0"
+search_parent_directories = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py", "*_test.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+asyncio_mode = "auto"
+addopts = [
+    "-v",
+    "--tb=short",
+    "--strict-markers",
+]
+markers = [
+    "smoke: smoke tests for basic functionality",
+    "integration: integration tests",
+]

--- a/packages/kalinka-plugin-jamendo/scripts/build_deb.sh
+++ b/packages/kalinka-plugin-jamendo/scripts/build_deb.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_SLUG="kalinka-plugin-jamendo"
+
+echo "Building .deb package for ${PLUGIN_SLUG} using setuptools_scm for version detection"
+
+# Clean up previous build
+rm -rf pkgroot/ dist/
+mkdir -p pkgroot/opt/kalinka/wheels
+mkdir -p pkgroot/DEBIAN
+
+# Build wheel first to generate version
+echo "Building wheel first to detect version..."
+./scripts/build_wheel.sh
+
+# Extract version from the built wheel filename
+WHEEL_PATH=$(ls dist/*.whl 2>/dev/null | sort -V | tail -1 || true)
+if [ -z "$WHEEL_PATH" ] || [ ! -f "$WHEEL_PATH" ]; then
+    echo "Error: No wheel could be built." >&2
+    exit 1
+fi
+
+VERSION=$(basename "$WHEEL_PATH" | sed 's/kalinka_plugin_jamendo-\(.*\)-py3-none-any\.whl/\1/')
+
+PLUGIN_WHEEL="kalinka_plugin_jamendo-${VERSION}-py3-none-any.whl"
+
+echo "Detected version: ${VERSION}"
+echo "Expected wheel: ${PLUGIN_WHEEL}"
+
+if [ ! -f "dist/${PLUGIN_WHEEL}" ]; then
+    echo "Error: Wheel file dist/${PLUGIN_WHEEL} not found" >&2
+    echo "Available wheels:"
+    ls -la dist/ || echo "No dist directory found"
+    exit 1
+fi
+
+# Copy wheel to package root
+cp "dist/${PLUGIN_WHEEL}" "pkgroot/opt/kalinka/wheels/"
+
+# Generate control file from template
+sed "s/@VERSION@/${VERSION}/g" debian/control.in > pkgroot/DEBIAN/control
+
+# Copy maintainer scripts and triggers
+cp debian/triggers pkgroot/DEBIAN/triggers
+cp debian/prerm pkgroot/DEBIAN/prerm
+chmod 755 pkgroot/DEBIAN/prerm
+
+# Build the .deb package
+dpkg-deb --root-owner-group --build pkgroot "${PLUGIN_SLUG}_${VERSION}_all.deb"
+
+echo "Package built: ${PLUGIN_SLUG}_${VERSION}_all.deb"
+ls -l "${PLUGIN_SLUG}_${VERSION}_all.deb"

--- a/packages/kalinka-plugin-jamendo/scripts/build_wheel.sh
+++ b/packages/kalinka-plugin-jamendo/scripts/build_wheel.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_SLUG="kalinka-plugin-jamendo"
+
+echo "Building wheel for ${PLUGIN_SLUG} using setuptools_scm for version detection"
+
+# Install required build tools
+python3 -m pip install --upgrade build setuptools-scm
+
+# Build the wheel (setuptools_scm handles version detection and _version.py)
+python3 -m build --wheel

--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/__init__.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/__init__.py
@@ -1,0 +1,3 @@
+from .module_setup import KalinkaPluginJamendo
+
+__all__ = ["KalinkaPluginJamendo"]

--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/config_model.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/config_model.py
@@ -1,0 +1,50 @@
+from typing import ClassVar
+from enum import Enum
+
+from pydantic import ConfigDict, Field
+
+from kalinka_plugin_sdk.module_config import ModuleConfig
+
+
+class JamendoAudioFormat(str, Enum):
+    """User-facing audio quality labels.
+
+    The labels are what the settings UI shows; they map to Jamendo's
+    ``audioformat`` codes (mp31/mp32/ogg/flac) in ``jamendo.FORMAT_CODE``.
+    """
+
+    MP3_VBR = "MP3 (VBR ~V0)"
+    MP3_96 = "MP3 (96 kbps)"
+    OGG = "OGG Vorbis"
+    FLAC = "FLAC"
+
+
+class JamendoConfig(ModuleConfig):
+    """Jamendo input module settings."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    __module_icon__: ClassVar[str] = "music_note_outlined"
+    __module_icon_color__: ClassVar[str] = "#2E7D32"  # Jamendo green
+    __preview_fields__: ClassVar[list[str]] = ["audio_format"]
+
+    name: str = Field(default="jamendo", title="Jamendo", frozen=True, exclude=True)
+    client_id: str = Field(
+        default="",
+        title="Client ID",
+        description=(
+            "Jamendo API client_id. Required — without it every request "
+            "fails. Create a free application to obtain one at: "
+            "https://devportal.jamendo.com"
+        ),
+        json_schema_extra={"widget": "password", "importance": "simple"},
+    )
+    audio_format: JamendoAudioFormat = Field(
+        default=JamendoAudioFormat.MP3_VBR,
+        title="Audio quality",
+        description=(
+            "Streaming format. FLAC is only available for tracks whose "
+            "artist allowed lossless download and falls back to MP3 otherwise."
+        ),
+        json_schema_extra={"importance": "simple"},
+    )

--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
@@ -42,6 +42,12 @@ logger = logging.getLogger(__name__.split(".")[-1])
 SOURCE = "jamendo"
 BASE_URL = "https://api.jamendo.com/v3.0/"
 
+# Jamendo's documented audio-delivery endpoint (the same one the API returns in
+# each track's `audiodownload` field). It resolves a track by id alone — no
+# signed `from` token — and, crucially, works for tracks the /tracks/ endpoint
+# cannot yet resolve. Used as a last-resort fallback in get_track_info.
+DOWNLOAD_URL = "https://mp3d.jamendo.com/download/track/"
+
 # Jamendo caps page size at 200.
 MAX_LIMIT = 200
 
@@ -314,6 +320,10 @@ class JamendoInputModule(InputModule):
         # config.audio_format is the enum *value* (use_enum_values=True).
         self.audio_format = FORMAT_CODE.get(config.audio_format, "mp32")
         self.audio_mime = FORMAT_MIME[self.audio_format]
+        # The download fallback endpoint has no lossless tier, so FLAC degrades
+        # to a guaranteed lossy format there.
+        self.fallback_format = "mp32" if self.audio_format == "flac" else self.audio_format
+        self.fallback_mime = FORMAT_MIME[self.fallback_format]
         # Cache of (audio_url, metadata) keyed by track id, populated whenever
         # tracks are listed (browse/search). Jamendo's /tracks/ endpoint lags
         # behind /albums/tracks/ and /playlists/tracks/ for recently published
@@ -594,12 +604,15 @@ class JamendoInputModule(InputModule):
             for track in results:
                 all_tracks[str(track["id"])] = track
 
-        # Preserve the requested order. The /tracks/ endpoint is the
-        # authoritative source, but it lags for freshly published tracks —
-        # fall back to the browse cache (populated by browse/search) so those
-        # still play. Anything resolvable by neither is dropped and logged.
+        # Preserve the requested order. Resolution is tried in three tiers:
+        #   1. the /tracks/ endpoint  — authoritative, fresh URL + full metadata
+        #   2. the browse cache       — warm for the browse->add flow
+        #   3. the download endpoint  — built from the bare id, no metadata,
+        #                               but plays tracks neither (1) nor (2)
+        #                               can resolve (e.g. a saved queue restored
+        #                               before anything was browsed).
         infos: List[TrackInfo] = []
-        unresolved: List[str] = []
+        fallback: List[str] = []
         for tid in track_ids:
             if tid in all_tracks:
                 infos.append(self._track_to_track_info(all_tracks[tid]))
@@ -607,15 +620,17 @@ class JamendoInputModule(InputModule):
                 audio_url, metadata = self._track_cache[tid]
                 infos.append(self._cached_track_info(tid, audio_url, metadata))
             else:
-                unresolved.append(tid)
+                infos.append(self._fallback_track_info(tid))
+                fallback.append(tid)
 
-        if unresolved:
+        if fallback:
             logger.warning(
                 "Jamendo get_track_info: %d/%d track(s) unresolved via the "
-                "tracks endpoint or browse cache and were skipped: %s",
-                len(unresolved),
+                "tracks endpoint or browse cache; using the download fallback "
+                "URL (metadata unavailable) for: %s",
+                len(fallback),
                 len(track_ids),
-                unresolved,
+                fallback,
             )
         logger.info(
             "Jamendo get_track_info: resolved %d/%d track(s)",
@@ -642,6 +657,30 @@ class JamendoInputModule(InputModule):
             id=track_id(tid),
             link_retriever=link_retriever,
             metadata=metadata,
+        )
+
+    def _fallback_track_info(self, tid: str) -> TrackInfo:
+        """Last-resort TrackInfo built from a bare track id.
+
+        Uses Jamendo's tokenless download endpoint, which resolves tracks the
+        /tracks/ endpoint can't. We have no metadata in this path, so we emit a
+        minimal placeholder Track; the audio still plays.
+        """
+        url = f"{DOWNLOAD_URL}{tid}/{self.fallback_format}/"
+        mime = self.fallback_mime
+
+        async def link_retriever() -> TrackUrl:
+            return TrackUrl(url=url, format=mime)
+
+        return TrackInfo(
+            id=track_id(tid),
+            link_retriever=link_retriever,
+            metadata=Track(
+                id=track_id(tid),
+                title="",
+                duration=0,
+                album=Album(id=album_id(""), title=""),
+            ),
         )
 
     # ------------------------------------------------------------------

--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
@@ -110,6 +110,10 @@ class RetryTransport(httpx.AsyncHTTPTransport):
             try:
                 response = await super().handle_async_request(request)
                 if 500 <= response.status_code < 600:
+                    # Release the connection before retrying; abandoning the
+                    # response leaks the connection back-pressure under repeated
+                    # 5xx and can eventually stall further requests.
+                    await response.aclose()
                     read_retries += 1
                     await asyncio.sleep(self.backoff_factor * read_retries)
                     logger.warning(
@@ -175,7 +179,13 @@ class JamendoClient:
             )
             return []
 
-        rjson = response.json()
+        try:
+            rjson = response.json()
+        except ValueError as exc:
+            # Truncated body, HTML error page, etc. Degrade to "no results"
+            # rather than breaking browse/search.
+            logger.warning("Jamendo %s returned non-JSON body: %s", path, exc)
+            return []
         headers = rjson.get("headers", {})
         if headers.get("status") != "success":
             logger.warning(
@@ -663,6 +673,13 @@ class JamendoInputModule(InputModule):
 
         async def link_retriever() -> TrackUrl:
             url = await self.client.resolve_audio_url(tid, self.audio_format)
+            if not url:
+                # Raise rather than return an empty URL: the server treats any
+                # non-exception return as playable, so it would try to stream
+                # "". Raising lets it mark the track unavailable and skip it.
+                raise RuntimeError(
+                    f"Could not resolve audio URL for Jamendo track {tid}"
+                )
             return TrackUrl(url=url, format=self.audio_mime)
 
         return TrackInfo(

--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
@@ -3,6 +3,7 @@ import logging
 import re
 from collections import OrderedDict
 from typing import List, Optional
+from urllib.parse import urlsplit
 
 import httpx
 from pydantic import PositiveInt
@@ -42,11 +43,19 @@ logger = logging.getLogger(__name__.split(".")[-1])
 SOURCE = "jamendo"
 BASE_URL = "https://api.jamendo.com/v3.0/"
 
-# Jamendo's documented audio-delivery endpoint (the same one the API returns in
-# each track's `audiodownload` field). It resolves a track by id alone — no
-# signed `from` token — and, crucially, works for tracks the /tracks/ endpoint
-# cannot yet resolve. Used as a last-resort fallback in get_track_info.
-DOWNLOAD_URL = "https://mp3d.jamendo.com/download/track/"
+# Seed for the streaming storage origin. The per-track `audio` field the API
+# returns points at this origin with a signed `from` token, but the origin also
+# serves a track addressed by id alone (no token), honours the requested format
+# (including flac), and supports HTTP range requests — making it a solid
+# fallback for tracks the /tracks/ endpoint can't resolve. It's the same host
+# the API hands out, so the native libcurl player streams it fine (unlike the
+# mp3d.jamendo.com download endpoint, which returns a non-range full-file
+# response the player rejects with "Invalid status line").
+#
+# This is only a seed: the module learns the *current* origin from the `audio`
+# URLs the API actually returns (see _remember_origin), so the fallback follows
+# Jamendo if they move off this shard rather than betting on the literal.
+DEFAULT_STREAM_ORIGIN = "https://prod-1.storage.jamendo.com/"
 
 # Jamendo caps page size at 200.
 MAX_LIMIT = 200
@@ -320,10 +329,9 @@ class JamendoInputModule(InputModule):
         # config.audio_format is the enum *value* (use_enum_values=True).
         self.audio_format = FORMAT_CODE.get(config.audio_format, "mp32")
         self.audio_mime = FORMAT_MIME[self.audio_format]
-        # The download fallback endpoint has no lossless tier, so FLAC degrades
-        # to a guaranteed lossy format there.
-        self.fallback_format = "mp32" if self.audio_format == "flac" else self.audio_format
-        self.fallback_mime = FORMAT_MIME[self.fallback_format]
+        # Current streaming origin, learned from real `audio` URLs and used to
+        # build fallback URLs for tracks the /tracks/ endpoint can't resolve.
+        self._stream_origin = DEFAULT_STREAM_ORIGIN
         # Cache of (audio_url, metadata) keyed by track id, populated whenever
         # tracks are listed (browse/search). Jamendo's /tracks/ endpoint lags
         # behind /albums/tracks/ and /playlists/tracks/ for recently published
@@ -334,9 +342,22 @@ class JamendoInputModule(InputModule):
         self._cache_max = 5000
         logger.info("Jamendo audio format: %s", self.audio_format)
 
+    def _remember_origin(self, audio_url: str) -> None:
+        """Track the storage origin (scheme://host/) from a real `audio` URL.
+
+        Keeps the fallback in step with whatever host the API is currently
+        handing out instead of relying on the hardcoded seed forever.
+        """
+        if not audio_url:
+            return
+        parts = urlsplit(audio_url)
+        if parts.scheme and parts.netloc:
+            self._stream_origin = f"{parts.scheme}://{parts.netloc}/"
+
     def _cache_track(self, tid: str, audio_url: str, metadata: Track) -> None:
         if not audio_url:
             return
+        self._remember_origin(audio_url)
         cache = self._track_cache
         cache[tid] = (audio_url, metadata)
         cache.move_to_end(tid)
@@ -603,11 +624,14 @@ class JamendoInputModule(InputModule):
             )
             for track in results:
                 all_tracks[str(track["id"])] = track
+                # Learn the current storage origin so any fallback URLs built
+                # below (tier 3) target the same host the API is handing out.
+                self._remember_origin(track.get("audio", ""))
 
         # Preserve the requested order. Resolution is tried in three tiers:
         #   1. the /tracks/ endpoint  — authoritative, fresh URL + full metadata
         #   2. the browse cache       — warm for the browse->add flow
-        #   3. the download endpoint  — built from the bare id, no metadata,
+        #   3. the storage origin     — URL built from the bare id, no metadata,
         #                               but plays tracks neither (1) nor (2)
         #                               can resolve (e.g. a saved queue restored
         #                               before anything was browsed).
@@ -626,8 +650,8 @@ class JamendoInputModule(InputModule):
         if fallback:
             logger.warning(
                 "Jamendo get_track_info: %d/%d track(s) unresolved via the "
-                "tracks endpoint or browse cache; using the download fallback "
-                "URL (metadata unavailable) for: %s",
+                "tracks endpoint or browse cache; using the storage-origin "
+                "fallback URL (metadata unavailable) for: %s",
                 len(fallback),
                 len(track_ids),
                 fallback,
@@ -662,12 +686,14 @@ class JamendoInputModule(InputModule):
     def _fallback_track_info(self, tid: str) -> TrackInfo:
         """Last-resort TrackInfo built from a bare track id.
 
-        Uses Jamendo's tokenless download endpoint, which resolves tracks the
-        /tracks/ endpoint can't. We have no metadata in this path, so we emit a
-        minimal placeholder Track; the audio still plays.
+        Streams from the storage origin addressed by id alone (no token),
+        honouring the configured format — including flac — and supporting range
+        requests, so it resolves and plays tracks the /tracks/ endpoint can't.
+        We have no metadata in this path, so we emit a minimal placeholder
+        Track; the server keeps the saved queue metadata on restore.
         """
-        url = f"{DOWNLOAD_URL}{tid}/{self.fallback_format}/"
-        mime = self.fallback_mime
+        url = f"{self._stream_origin}?trackid={tid}&format={self.audio_format}"
+        mime = self.audio_mime
 
         async def link_retriever() -> TrackUrl:
             return TrackUrl(url=url, format=mime)

--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
@@ -3,7 +3,6 @@ import logging
 import re
 from collections import OrderedDict
 from typing import List, Optional
-from urllib.parse import urlsplit
 
 import httpx
 from pydantic import PositiveInt
@@ -43,19 +42,6 @@ logger = logging.getLogger(__name__.split(".")[-1])
 SOURCE = "jamendo"
 BASE_URL = "https://api.jamendo.com/v3.0/"
 
-# Seed for the streaming storage origin. The per-track `audio` field the API
-# returns points at this origin with a signed `from` token, but the origin also
-# serves a track addressed by id alone (no token), honours the requested format
-# (including flac), and supports HTTP range requests — making it a solid
-# fallback for tracks the /tracks/ endpoint can't resolve. It's the same host
-# the API hands out, so the native libcurl player streams it fine (unlike the
-# mp3d.jamendo.com download endpoint, which returns a non-range full-file
-# response the player rejects with "Invalid status line").
-#
-# This is only a seed: the module learns the *current* origin from the `audio`
-# URLs the API actually returns (see _remember_origin), so the fallback follows
-# Jamendo if they move off this shard rather than betting on the literal.
-DEFAULT_STREAM_ORIGIN = "https://prod-1.storage.jamendo.com/"
 
 # Jamendo caps page size at 200.
 MAX_LIMIT = 200
@@ -201,6 +187,43 @@ class JamendoClient:
 
         return rjson.get("results", [])
 
+    async def resolve_audio_url(self, track_id: str, audioformat: str) -> str:
+        """Resolve a track's playable audio URL via the /tracks/file/ endpoint.
+
+        This is the documented audio-delivery endpoint: it 302-redirects to the
+        actual storage URL (tokenised, range-capable). Crucially it resolves a
+        track by id alone and works for tracks the /tracks/ metadata index
+        doesn't return (old or freshly published). We read the redirect target
+        rather than following it, since the native player streams the storage
+        URL directly but does not follow redirects itself.
+        """
+        params = {
+            "client_id": self.client_id,
+            "id": track_id,
+            "audioformat": audioformat,
+        }
+        try:
+            response = await self.session.get(
+                self.base + "tracks/file/", params=params
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("Jamendo tracks/file failed for %s: %s", track_id, exc)
+            return ""
+
+        location = response.headers.get("location")
+        if location:
+            return location
+        # No redirect: either the body already is the audio (use the request
+        # URL) or it's an error page we can't use.
+        if response.is_success:
+            return str(response.request.url)
+        logger.warning(
+            "Jamendo tracks/file for %s returned HTTP %s with no redirect",
+            track_id,
+            response.status_code,
+        )
+        return ""
+
 
 async def get_client(config: JamendoConfig) -> JamendoClient:
     if not config.client_id:
@@ -329,38 +352,20 @@ class JamendoInputModule(InputModule):
         # config.audio_format is the enum *value* (use_enum_values=True).
         self.audio_format = FORMAT_CODE.get(config.audio_format, "mp32")
         self.audio_mime = FORMAT_MIME[self.audio_format]
-        # Current streaming origin, learned from real `audio` URLs and used to
-        # build fallback URLs for tracks the /tracks/ endpoint can't resolve.
-        self._stream_origin = DEFAULT_STREAM_ORIGIN
-        # Cache of (audio_url, metadata) keyed by track id, populated whenever
-        # tracks are listed (browse/search). Jamendo's /tracks/ endpoint lags
-        # behind /albums/tracks/ and /playlists/tracks/ for recently published
-        # tracks — querying such a track id by itself returns nothing even
-        # though it streams fine in album/playlist context. get_track_info
-        # falls back to this cache so adding a fresh album to the queue works.
-        self._track_cache: "OrderedDict[str, tuple[str, Track]]" = OrderedDict()
+        # Cache of track metadata keyed by track id, populated whenever tracks
+        # are listed (browse/search). The /tracks/ metadata endpoint is an
+        # incomplete index — it returns nothing for many valid tracks (old or
+        # freshly published) — so get_track_info reads metadata from here first
+        # and only queries /tracks/ for ids it hasn't already seen. Playback
+        # URLs come from /tracks/file/, which resolves every track by id.
+        self._track_cache: "OrderedDict[str, Track]" = OrderedDict()
         self._cache_max = 5000
         logger.info("Jamendo audio format: %s", self.audio_format)
 
-    def _remember_origin(self, audio_url: str) -> None:
-        """Track the storage origin (scheme://host/) from a real `audio` URL.
-
-        Keeps the fallback in step with whatever host the API is currently
-        handing out instead of relying on the hardcoded seed forever.
-        """
-        if not audio_url:
-            return
-        parts = urlsplit(audio_url)
-        if parts.scheme and parts.netloc:
-            self._stream_origin = f"{parts.scheme}://{parts.netloc}/"
-
-    def _cache_track(self, tid: str, audio_url: str, metadata: Track) -> None:
-        if not audio_url:
-            return
-        self._remember_origin(audio_url)
+    def _cache_track(self, metadata: Track) -> None:
         cache = self._track_cache
-        cache[tid] = (audio_url, metadata)
-        cache.move_to_end(tid)
+        cache[metadata.id.id] = metadata
+        cache.move_to_end(metadata.id.id)
         while len(cache) > self._cache_max:
             cache.popitem(last=False)
 
@@ -609,73 +614,60 @@ class JamendoInputModule(InputModule):
         if not track_ids:
             return []
 
-        # Jamendo accepts multiple ids in a single call, space-separated.
-        all_tracks: dict[str, dict] = {}
-        chunk_size = MAX_LIMIT
-        for i in range(0, len(track_ids), chunk_size):
-            chunk = track_ids[i : i + chunk_size]
+        # Metadata: prefer the cache (populated by the browse/search the user
+        # did to find these tracks — reliable and complete), and only query the
+        # /tracks/ metadata index for ids we haven't seen. That index is
+        # incomplete (returns nothing for many valid tracks), so it's a
+        # best-effort enrichment, not the source of truth.
+        missing = [tid for tid in track_ids if tid not in self._track_cache]
+        fetched: dict[str, Track] = {}
+        for i in range(0, len(missing), MAX_LIMIT):
+            chunk = missing[i : i + MAX_LIMIT]
             results = await self.client.request(
-                "tracks",
-                {
-                    "id": " ".join(chunk),
-                    "limit": len(chunk),
-                    "audioformat": self.audio_format,
-                },
+                "tracks", {"id": " ".join(chunk), "limit": len(chunk)}
             )
             for track in results:
-                all_tracks[str(track["id"])] = track
-                # Learn the current storage origin so any fallback URLs built
-                # below (tier 3) target the same host the API is handing out.
-                self._remember_origin(track.get("audio", ""))
+                meta = self._track_metadata(track)
+                fetched[meta.id.id] = meta
 
-        # Preserve the requested order. Resolution is tried in three tiers:
-        #   1. the /tracks/ endpoint  — authoritative, fresh URL + full metadata
-        #   2. the browse cache       — warm for the browse->add flow
-        #   3. the storage origin     — URL built from the bare id, no metadata,
-        #                               but plays tracks neither (1) nor (2)
-        #                               can resolve (e.g. a saved queue restored
-        #                               before anything was browsed).
+        # Playback URLs always come from /tracks/file/ (resolved lazily at play
+        # time), which handles every track by id regardless of the metadata
+        # index. Tracks with no metadata from cache or /tracks/ get a
+        # placeholder; on a queue restore the server keeps the saved metadata.
         infos: List[TrackInfo] = []
-        fallback: List[str] = []
+        without_metadata: List[str] = []
         for tid in track_ids:
-            if tid in all_tracks:
-                infos.append(self._track_to_track_info(all_tracks[tid]))
-            elif tid in self._track_cache:
-                audio_url, metadata = self._track_cache[tid]
-                infos.append(self._cached_track_info(tid, audio_url, metadata))
+            if tid in self._track_cache:
+                metadata = self._track_cache[tid]
+            elif tid in fetched:
+                metadata = fetched[tid]
             else:
-                infos.append(self._fallback_track_info(tid))
-                fallback.append(tid)
+                metadata = self._placeholder_metadata(tid)
+                without_metadata.append(tid)
+            infos.append(self._make_track_info(tid, metadata))
 
-        if fallback:
+        if without_metadata:
             logger.warning(
-                "Jamendo get_track_info: %d/%d track(s) unresolved via the "
-                "tracks endpoint or browse cache; using the storage-origin "
-                "fallback URL (metadata unavailable) for: %s",
-                len(fallback),
+                "Jamendo get_track_info: no metadata for %d/%d track(s) "
+                "(not in cache or the tracks index); they remain playable via "
+                "the file endpoint: %s",
+                len(without_metadata),
                 len(track_ids),
-                fallback,
+                without_metadata,
             )
         logger.info(
-            "Jamendo get_track_info: resolved %d/%d track(s)",
+            "Jamendo get_track_info: returning %d/%d track(s)",
             len(infos),
             len(track_ids),
         )
         return infos
 
-    def _track_to_track_info(self, track) -> TrackInfo:
-        metadata = self._track_metadata(track)
-        return self._cached_track_info(
-            metadata.id.id, track.get("audio", ""), metadata
-        )
-
-    def _cached_track_info(
-        self, tid: str, audio_url: str, metadata: Track
-    ) -> TrackInfo:
-        mime = self.audio_mime
+    def _make_track_info(self, tid: str, metadata: Track) -> TrackInfo:
+        """Build a TrackInfo whose link resolves via /tracks/file/ at play time."""
 
         async def link_retriever() -> TrackUrl:
-            return TrackUrl(url=audio_url, format=mime)
+            url = await self.client.resolve_audio_url(tid, self.audio_format)
+            return TrackUrl(url=url, format=self.audio_mime)
 
         return TrackInfo(
             id=track_id(tid),
@@ -683,30 +675,12 @@ class JamendoInputModule(InputModule):
             metadata=metadata,
         )
 
-    def _fallback_track_info(self, tid: str) -> TrackInfo:
-        """Last-resort TrackInfo built from a bare track id.
-
-        Streams from the storage origin addressed by id alone (no token),
-        honouring the configured format — including flac — and supporting range
-        requests, so it resolves and plays tracks the /tracks/ endpoint can't.
-        We have no metadata in this path, so we emit a minimal placeholder
-        Track; the server keeps the saved queue metadata on restore.
-        """
-        url = f"{self._stream_origin}?trackid={tid}&format={self.audio_format}"
-        mime = self.audio_mime
-
-        async def link_retriever() -> TrackUrl:
-            return TrackUrl(url=url, format=mime)
-
-        return TrackInfo(
+    def _placeholder_metadata(self, tid: str) -> Track:
+        return Track(
             id=track_id(tid),
-            link_retriever=link_retriever,
-            metadata=Track(
-                id=track_id(tid),
-                title="",
-                duration=0,
-                album=Album(id=album_id(""), title=""),
-            ),
+            title="",
+            duration=0,
+            album=Album(id=album_id(""), title=""),
         )
 
     # ------------------------------------------------------------------
@@ -772,9 +746,10 @@ class JamendoInputModule(InputModule):
         result = []
         for track in tracks:
             meta = self._track_metadata(track, album_meta)
-            # Stash the streaming URL so get_track_info can play this track
-            # even if the /tracks/ endpoint can't resolve its id yet.
-            self._cache_track(meta.id.id, track.get("audio", ""), meta)
+            # Cache metadata so get_track_info can label this track even if the
+            # /tracks/ index can't resolve its id. (Playback always goes through
+            # /tracks/file/, so no URL needs caching.)
+            self._cache_track(meta)
             result.append(
                 BrowseItem(
                     id=meta.id,

--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
@@ -451,24 +451,20 @@ class JamendoInputModule(InputModule):
     async def _browse_artist(
         self, id: str, offset: int, limit: int
     ) -> BrowseItemList:
-        # offset/limit on artists/albums paginate the *artist* list, not the
-        # nested albums — so we fetch the artist's albums and paginate them
-        # client-side (same approach as album tracks / playlist tracks).
-        results = await self.client.request("artists/albums", {"id": id})
-        if not results:
-            return EmptyList(offset, limit)
-        albums = results[0].get("albums", [])
-        # Stamp the parent artist so album cards carry the artist name.
-        artist_name = results[0].get("name")
-        for album in albums:
-            album.setdefault("artist_id", id)
-            album.setdefault("artist_name", artist_name)
-        page = albums[offset : offset + limit]
+        # Use /albums/?artist_id= rather than /artists/albums/: the latter's
+        # nested albums carry only a placeholder cover URL (no representative
+        # trackid, which Jamendo album art is keyed on), so cards showed a
+        # generic icon. /albums/ returns the real trackid-bearing cover, plus
+        # artist_name and native offset/limit pagination over albums.
+        albums = await self.client.request(
+            "albums",
+            {"artist_id": id, "offset": offset, "limit": limit},
+        )
         return BrowseItemList(
             offset=offset,
             limit=limit,
-            total=len(albums),
-            items=self._albums_to_browse_items(page),
+            total=_estimated_total(offset, limit, len(albums)),
+            items=self._albums_to_browse_items(albums),
         )
 
     async def _browse_playlist(

--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
@@ -1,0 +1,812 @@
+import asyncio
+import logging
+import re
+from typing import List, Optional
+
+import httpx
+from pydantic import PositiveInt
+
+from kalinka_plugin_sdk.datamodel import (
+    Album,
+    Artist,
+    BrowseItem,
+    BrowseItemList,
+    CardSize,
+    Catalog,
+    CatalogRole,
+    CoverImage,
+    EmptyList,
+    EntityId,
+    EntityType,
+    FavoriteIds,
+    GenreList,
+    Owner,
+    Playlist,
+    Preview,
+    PreviewContentType,
+    PreviewType,
+    Track,
+)
+from kalinka_plugin_sdk.inputmodule import (
+    InputModule,
+    SearchType,
+    TrackInfo,
+    TrackUrl,
+)
+
+from .config_model import JamendoConfig
+
+logger = logging.getLogger(__name__.split(".")[-1])
+
+SOURCE = "jamendo"
+BASE_URL = "https://api.jamendo.com/v3.0/"
+
+# Jamendo caps page size at 200.
+MAX_LIMIT = 200
+
+# Map the user-facing audio quality label (config.audio_format, stored as the
+# enum *value* because the config uses use_enum_values=True) to Jamendo's
+# audioformat code and the MIME type we report back to the player.
+FORMAT_CODE = {
+    "MP3 (VBR ~V0)": "mp32",
+    "MP3 (96 kbps)": "mp31",
+    "OGG Vorbis": "ogg",
+    "FLAC": "flac",
+}
+FORMAT_MIME = {
+    "mp31": "audio/mpeg",
+    "mp32": "audio/mpeg",
+    "ogg": "audio/ogg",
+    "flac": "audio/flac",
+}
+
+
+# ---------------------------------------------------------------------------
+# EntityId helpers
+# ---------------------------------------------------------------------------
+
+
+def artist_id(id: str) -> EntityId:
+    return EntityId(id=id, type=EntityType.ARTIST, source=SOURCE)
+
+
+def album_id(id: str) -> EntityId:
+    return EntityId(id=id, type=EntityType.ALBUM, source=SOURCE)
+
+
+def track_id(id: str) -> EntityId:
+    return EntityId(id=id, type=EntityType.TRACK, source=SOURCE)
+
+
+def playlist_id(id: str) -> EntityId:
+    return EntityId(id=id, type=EntityType.PLAYLIST, source=SOURCE)
+
+
+def user_id(id: str) -> EntityId:
+    return EntityId(id=id, type=EntityType.USER, source=SOURCE)
+
+
+def catalog_id(id: str) -> EntityId:
+    return EntityId(id=id, type=EntityType.CATALOG, source=SOURCE)
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport with retry on transient failures (mirrors the qobuz plugin)
+# ---------------------------------------------------------------------------
+
+
+class RetryTransport(httpx.AsyncHTTPTransport):
+    def __init__(self, read_retries=3, **kwargs):
+        super().__init__(**kwargs)
+        self.read_retries = read_retries
+        self.backoff_factor = 0.5
+
+    async def handle_async_request(self, request) -> httpx.Response:
+        read_retries = 0
+        last_exception = None
+        while read_retries < self.read_retries:
+            try:
+                response = await super().handle_async_request(request)
+                if 500 <= response.status_code < 600:
+                    read_retries += 1
+                    await asyncio.sleep(self.backoff_factor * read_retries)
+                    logger.warning(
+                        f"Retry {read_retries} due to status code={response.status_code}"
+                    )
+                    continue
+                return response
+            except (
+                httpx.ProtocolError,
+                httpx.ConnectError,
+                httpx.ReadTimeout,
+                httpx.WriteTimeout,
+                httpx.ConnectTimeout,
+                httpx.ProxyError,
+                httpx.ReadError,
+            ) as exc:
+                last_exception = exc
+                read_retries += 1
+                await asyncio.sleep(self.backoff_factor * read_retries)
+                logger.warning(f"Retry {read_retries} due to {exc}")
+        if last_exception is not None:
+            raise last_exception
+        raise RuntimeError("handle_async_request failed without exception")
+
+
+class JamendoClient:
+    """Thin async wrapper over the Jamendo v3.0 REST API.
+
+    Only a ``client_id`` is needed for search/browse/playback. Favourites and
+    playlist mutation would require an OAuth2 user flow and are out of scope.
+    """
+
+    def __init__(self, client_id: str):
+        self.client_id = client_id
+        self.base = BASE_URL
+        self.session = httpx.AsyncClient(
+            transport=RetryTransport(read_retries=3, retries=3),
+            timeout=10,
+        )
+        self.session.headers.update(
+            {
+                "User-Agent": "kalinka-plugin-jamendo",
+            }
+        )
+
+    async def aclose(self) -> None:
+        await self.session.aclose()
+
+    async def request(self, path: str, params: dict) -> list:
+        """GET an endpoint and return its ``results`` array.
+
+        Jamendo wraps every response in ``{"headers": {...}, "results": [...]}``.
+        A failed call still returns HTTP 200 with ``headers.status == "failed"``;
+        we log and return an empty list so the UI degrades to "no results"
+        rather than throwing.
+        """
+        merged = {"client_id": self.client_id, "format": "json", **params}
+        response = await self.session.get(self.base + path, params=merged)
+
+        if not response.is_success:
+            logger.warning(
+                "Jamendo %s failed: HTTP %s", path, response.status_code
+            )
+            return []
+
+        rjson = response.json()
+        headers = rjson.get("headers", {})
+        if headers.get("status") != "success":
+            logger.warning(
+                "Jamendo %s error: %s",
+                path,
+                headers.get("error_message") or headers,
+            )
+            return []
+
+        return rjson.get("results", [])
+
+
+async def get_client(config: JamendoConfig) -> JamendoClient:
+    if not config.client_id:
+        logger.warning(
+            "Jamendo client_id is not configured — requests will return empty."
+        )
+    return JamendoClient(config.client_id)
+
+
+# ---------------------------------------------------------------------------
+# Image helpers
+# ---------------------------------------------------------------------------
+
+
+def _resize(url: Optional[str], width: int) -> Optional[str]:
+    """Return ``url`` requesting a specific image width.
+
+    Jamendo image URLs carry a ``width=`` query param we can rewrite to get
+    different sizes from the single URL the API returns.
+    """
+    if not url:
+        return None
+    if "width=" in url:
+        return re.sub(r"width=\d+", f"width={width}", url)
+    sep = "&" if "?" in url else "?"
+    return f"{url}{sep}width={width}"
+
+
+def _cover(url: Optional[str]) -> Optional[CoverImage]:
+    if not url:
+        return None
+    return CoverImage(
+        thumbnail=_resize(url, 100),
+        small=_resize(url, 200),
+        large=_resize(url, 600),
+    )
+
+
+def _estimated_total(offset: int, limit: int, count: int) -> int:
+    """Estimate a result total.
+
+    Jamendo never reports a grand total — only the size of the current page.
+    Report ``offset + count``, and when the page came back full assume there's
+    at least one more page so clients keep paginating.
+    """
+    total = offset + count
+    if limit and count >= limit:
+        total += limit
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Preview configs reused across catalog sections
+# ---------------------------------------------------------------------------
+
+
+def _album_tracks_section(aid: str) -> BrowseItem:
+    return BrowseItem(
+        id=album_id(aid),
+        name="Tracks",
+        can_browse=True,
+        can_add=True,
+        catalog=Catalog(
+            id=album_id(aid),
+            title="Tracks",
+            can_genre_filter=False,
+            preview_config=Preview(
+                type=PreviewType.TILE_NUMBERED,
+                content_type=PreviewContentType.TRACK,
+                items_count=10,
+                rows_count=1,
+                aspect_ratio=1.0,
+                card_size=CardSize.SMALL,
+            ),
+        ),
+    )
+
+
+def _artist_albums_section(aid: str) -> BrowseItem:
+    return BrowseItem(
+        id=artist_id(aid),
+        name="Albums",
+        can_browse=True,
+        can_add=False,
+        catalog=Catalog(
+            id=artist_id(aid),
+            title="Albums",
+            can_genre_filter=False,
+            preview_config=Preview(
+                type=PreviewType.TILE,
+                content_type=PreviewContentType.ALBUM,
+                items_count=10,
+                rows_count=1,
+                aspect_ratio=1.0,
+                card_size=CardSize.SMALL,
+            ),
+        ),
+    )
+
+
+def _playlist_tracks_section(pid: str) -> BrowseItem:
+    return BrowseItem(
+        id=playlist_id(pid),
+        name="Tracks",
+        can_browse=True,
+        can_add=True,
+        catalog=Catalog(
+            id=playlist_id(pid),
+            title="Tracks",
+            can_genre_filter=False,
+            preview_config=Preview(
+                type=PreviewType.TILE,
+                content_type=PreviewContentType.TRACK,
+                items_count=15,
+                rows_count=1,
+                aspect_ratio=1.0,
+                card_size=CardSize.SMALL,
+            ),
+        ),
+    )
+
+
+class JamendoInputModule(InputModule):
+    def __init__(self, config: JamendoConfig, client: JamendoClient):
+        self.client = client
+        # config.audio_format is the enum *value* (use_enum_values=True).
+        self.audio_format = FORMAT_CODE.get(config.audio_format, "mp32")
+        self.audio_mime = FORMAT_MIME[self.audio_format]
+        logger.info("Jamendo audio format: %s", self.audio_format)
+
+    def module_name(self) -> str:
+        return "Jamendo"
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    async def search(
+        self, type: SearchType, query: str, offset=0, limit=50
+    ) -> BrowseItemList:
+        limit = min(limit, MAX_LIMIT)
+        endpoint = type.value + "s"  # track -> tracks, album -> albums, ...
+        params = {"namesearch": query, "offset": offset, "limit": limit}
+        if type == SearchType.track:
+            params["audioformat"] = self.audio_format
+        results = await self.client.request(endpoint, params)
+
+        if type == SearchType.track:
+            items = self._tracks_to_browse_items(results)
+        elif type == SearchType.album:
+            items = self._albums_to_browse_items(results)
+        elif type == SearchType.artist:
+            items = self._artists_to_browse_items(results)
+        elif type == SearchType.playlist:
+            items = self._playlists_to_browse_items(results)
+        else:
+            return EmptyList(offset, limit)
+
+        return BrowseItemList(
+            offset=offset,
+            limit=limit,
+            total=_estimated_total(offset, limit, len(items)),
+            items=items,
+        )
+
+    # ------------------------------------------------------------------
+    # Browse
+    # ------------------------------------------------------------------
+
+    async def browse(
+        self,
+        entity_id: EntityId,
+        offset: PositiveInt = 0,
+        limit: PositiveInt = 50,
+        genre_ids: List[EntityId] = [],
+    ) -> BrowseItemList:
+        limit = min(limit, MAX_LIMIT)
+        if entity_id.type == EntityType.ALBUM:
+            return await self._browse_album(entity_id.id, offset, limit)
+        elif entity_id.type == EntityType.ARTIST:
+            return await self._browse_artist(entity_id.id, offset, limit)
+        elif entity_id.type == EntityType.PLAYLIST:
+            return await self._browse_playlist(entity_id.id, offset, limit)
+        elif entity_id.type == EntityType.CATALOG:
+            return await self._browse_catalog(entity_id.id, offset, limit)
+        return EmptyList(offset, limit)
+
+    async def _browse_album(
+        self, id: str, offset: int, limit: int
+    ) -> BrowseItemList:
+        results = await self.client.request(
+            "albums/tracks",
+            {
+                "id": id,
+                "track_type": "albumtrack",
+                "audioformat": self.audio_format,
+            },
+        )
+        if not results:
+            return EmptyList(offset, limit)
+        tracks = results[0].get("tracks", [])
+        page = tracks[offset : offset + limit]
+        return BrowseItemList(
+            offset=offset,
+            limit=limit,
+            total=len(tracks),
+            items=self._tracks_to_browse_items(page, album_meta=results[0]),
+        )
+
+    async def _browse_artist(
+        self, id: str, offset: int, limit: int
+    ) -> BrowseItemList:
+        # offset/limit on artists/albums paginate the *artist* list, not the
+        # nested albums — so we fetch the artist's albums and paginate them
+        # client-side (same approach as album tracks / playlist tracks).
+        results = await self.client.request("artists/albums", {"id": id})
+        if not results:
+            return EmptyList(offset, limit)
+        albums = results[0].get("albums", [])
+        # Stamp the parent artist so album cards carry the artist name.
+        artist_name = results[0].get("name")
+        for album in albums:
+            album.setdefault("artist_id", id)
+            album.setdefault("artist_name", artist_name)
+        page = albums[offset : offset + limit]
+        return BrowseItemList(
+            offset=offset,
+            limit=limit,
+            total=len(albums),
+            items=self._albums_to_browse_items(page),
+        )
+
+    async def _browse_playlist(
+        self, id: str, offset: int, limit: int
+    ) -> BrowseItemList:
+        results = await self.client.request(
+            "playlists/tracks",
+            {"id": id, "audioformat": self.audio_format},
+        )
+        if not results:
+            return EmptyList(offset, limit)
+        tracks = results[0].get("tracks", [])
+        page = tracks[offset : offset + limit]
+        return BrowseItemList(
+            offset=offset,
+            limit=limit,
+            total=len(tracks),
+            items=self._tracks_to_browse_items(page),
+        )
+
+    async def _browse_catalog(
+        self, endpoint: str, offset: int, limit: int
+    ) -> BrowseItemList:
+        if endpoint == "root":
+            return self._root_catalog(offset, limit)
+        elif endpoint == "popular-tracks":
+            results = await self.client.request(
+                "tracks",
+                {
+                    "order": "popularity_month",
+                    "offset": offset,
+                    "limit": limit,
+                    "audioformat": self.audio_format,
+                },
+            )
+            items = self._tracks_to_browse_items(results)
+        elif endpoint == "popular-albums":
+            results = await self.client.request(
+                "albums",
+                {"order": "popularity_month", "offset": offset, "limit": limit},
+            )
+            items = self._albums_to_browse_items(results)
+        elif endpoint == "new-releases":
+            results = await self.client.request(
+                "albums",
+                {"order": "releasedate_desc", "offset": offset, "limit": limit},
+            )
+            items = self._albums_to_browse_items(results)
+        elif endpoint == "popular-artists":
+            results = await self.client.request(
+                "artists",
+                {"order": "popularity_total", "offset": offset, "limit": limit},
+            )
+            items = self._artists_to_browse_items(results)
+        elif endpoint == "featured-playlists":
+            results = await self.client.request(
+                "playlists",
+                {"order": "creationdate_desc", "offset": offset, "limit": limit},
+            )
+            items = self._playlists_to_browse_items(results)
+        else:
+            return EmptyList(offset, limit)
+
+        return BrowseItemList(
+            offset=offset,
+            limit=limit,
+            total=_estimated_total(offset, limit, len(items)),
+            items=items,
+        )
+
+    def _root_catalog(self, offset: int, limit: int) -> BrowseItemList:
+        shelves = [
+            (
+                "popular-tracks",
+                "Popular Tracks",
+                PreviewType.TILE,
+                PreviewContentType.TRACK,
+                CatalogRole.DISCOVERY,
+            ),
+            (
+                "new-releases",
+                "New Releases",
+                PreviewType.IMAGE_TEXT,
+                PreviewContentType.ALBUM,
+                CatalogRole.DISCOVERY,
+            ),
+            (
+                "popular-albums",
+                "Popular Albums",
+                PreviewType.IMAGE_TEXT,
+                PreviewContentType.ALBUM,
+                CatalogRole.DISCOVERY,
+            ),
+            (
+                "popular-artists",
+                "Popular Artists",
+                PreviewType.IMAGE_TEXT,
+                PreviewContentType.ARTIST,
+                CatalogRole.DISCOVERY,
+            ),
+            (
+                "featured-playlists",
+                "Featured Playlists",
+                PreviewType.IMAGE_TEXT,
+                PreviewContentType.PLAYLIST,
+                CatalogRole.HIDE_ON_HOME,
+            ),
+        ]
+        all_items = [
+            BrowseItem(
+                id=catalog_id(slug),
+                name=title,
+                can_browse=True,
+                can_add=False,
+                catalog=Catalog(
+                    id=catalog_id(slug),
+                    title=title,
+                    can_genre_filter=False,
+                    preview_config=Preview(
+                        type=ptype,
+                        content_type=ctype,
+                        items_count=20,
+                        rows_count=2,
+                        aspect_ratio=1.0,
+                    ),
+                    role=role,
+                ),
+            )
+            for slug, title, ptype, ctype, role in shelves
+        ]
+        return BrowseItemList(
+            offset=offset,
+            limit=limit,
+            total=len(all_items),
+            items=all_items[offset : offset + limit],
+        )
+
+    # ------------------------------------------------------------------
+    # Track playback
+    # ------------------------------------------------------------------
+
+    async def get_track_info(self, track_ids: List[str]) -> List[TrackInfo]:
+        if not track_ids:
+            return []
+
+        # Jamendo accepts multiple ids in a single call, space-separated.
+        all_tracks: dict[str, dict] = {}
+        chunk_size = MAX_LIMIT
+        for i in range(0, len(track_ids), chunk_size):
+            chunk = track_ids[i : i + chunk_size]
+            results = await self.client.request(
+                "tracks",
+                {
+                    "id": " ".join(chunk),
+                    "limit": len(chunk),
+                    "audioformat": self.audio_format,
+                },
+            )
+            for track in results:
+                all_tracks[str(track["id"])] = track
+
+        # Preserve the requested order; drop ids Jamendo didn't return.
+        return [
+            self._track_to_track_info(all_tracks[tid])
+            for tid in track_ids
+            if tid in all_tracks
+        ]
+
+    def _track_to_track_info(self, track) -> TrackInfo:
+        audio_url = track.get("audio", "")
+        mime = self.audio_mime
+
+        async def link_retriever() -> TrackUrl:
+            return TrackUrl(url=audio_url, format=mime)
+
+        return TrackInfo(
+            id=track_id(str(track["id"])),
+            link_retriever=link_retriever,
+            metadata=self._track_metadata(track),
+        )
+
+    # ------------------------------------------------------------------
+    # get(entity_id)
+    # ------------------------------------------------------------------
+
+    async def get(self, entity_id: EntityId) -> BrowseItem:
+        if entity_id.type == EntityType.TRACK:
+            results = await self.client.request(
+                "tracks",
+                {"id": entity_id.id, "audioformat": self.audio_format},
+            )
+            items = self._tracks_to_browse_items(results)
+        elif entity_id.type == EntityType.ALBUM:
+            results = await self.client.request("albums", {"id": entity_id.id})
+            items = self._albums_to_browse_items(results)
+        elif entity_id.type == EntityType.ARTIST:
+            results = await self.client.request("artists", {"id": entity_id.id})
+            items = self._artists_to_browse_items(results)
+        elif entity_id.type == EntityType.PLAYLIST:
+            results = await self.client.request("playlists", {"id": entity_id.id})
+            items = self._playlists_to_browse_items(results)
+        else:
+            raise ValueError(f"Unsupported EntityId type: {entity_id.type.name}")
+
+        if not items:
+            raise ValueError(f"Entity not found: {entity_id.to_string}")
+        return items[0]
+
+    # ------------------------------------------------------------------
+    # Mapping helpers
+    # ------------------------------------------------------------------
+
+    def _track_metadata(self, track, album_meta: Optional[dict] = None) -> Track:
+        album_meta = album_meta or {}
+        aid = str(track.get("album_id") or album_meta.get("id") or "")
+        album_name = track.get("album_name") or album_meta.get("name") or ""
+        image = (
+            track.get("album_image")
+            or track.get("image")
+            or album_meta.get("image")
+        )
+        performer = Artist(
+            id=artist_id(str(track.get("artist_id", ""))),
+            name=track.get("artist_name", ""),
+        )
+        return Track(
+            id=track_id(str(track["id"])),
+            title=track.get("name", ""),
+            duration=int(track.get("duration", 0) or 0),
+            performer=performer,
+            album=Album(
+                id=album_id(aid),
+                title=album_name,
+                artist=performer,
+                image=_cover(image),
+            ),
+        )
+
+    def _tracks_to_browse_items(
+        self, tracks, album_meta: Optional[dict] = None
+    ) -> List[BrowseItem]:
+        result = []
+        for track in tracks:
+            meta = self._track_metadata(track, album_meta)
+            result.append(
+                BrowseItem(
+                    id=meta.id,
+                    name=meta.title,
+                    subname=meta.performer.name if meta.performer else None,
+                    can_browse=False,
+                    can_add=True,
+                    track=meta,
+                )
+            )
+        return result
+
+    def _albums_to_browse_items(self, albums) -> List[BrowseItem]:
+        result = []
+        for album in albums:
+            aid = str(album["id"])
+            artist = Artist(
+                id=artist_id(str(album.get("artist_id", ""))),
+                name=album.get("artist_name", ""),
+            )
+            result.append(
+                BrowseItem(
+                    id=album_id(aid),
+                    name=album.get("name", ""),
+                    subname=artist.name,
+                    can_browse=True,
+                    can_add=True,
+                    album=Album(
+                        id=album_id(aid),
+                        title=album.get("name", ""),
+                        artist=artist,
+                        image=_cover(album.get("image")),
+                    ),
+                    sections=[_album_tracks_section(aid)],
+                )
+            )
+        return result
+
+    def _artists_to_browse_items(self, artists) -> List[BrowseItem]:
+        result = []
+        for artist in artists:
+            aid = str(artist["id"])
+            result.append(
+                BrowseItem(
+                    id=artist_id(aid),
+                    name=artist.get("name", ""),
+                    subname=None,
+                    can_browse=True,
+                    can_add=False,
+                    artist=Artist(
+                        id=artist_id(aid),
+                        name=artist.get("name", ""),
+                        image=_cover(artist.get("image")),
+                    ),
+                    sections=[_artist_albums_section(aid)],
+                )
+            )
+        return result
+
+    def _playlists_to_browse_items(self, playlists) -> List[BrowseItem]:
+        result = []
+        for playlist in playlists:
+            pid = str(playlist["id"])
+            tracks = playlist.get("tracks", [])
+            owner = Owner(
+                name=playlist.get("user_name", ""),
+                id=user_id(str(playlist.get("user_id", ""))),
+            )
+            result.append(
+                BrowseItem(
+                    id=playlist_id(pid),
+                    name=playlist.get("name", ""),
+                    subname=owner.name,
+                    can_browse=True,
+                    can_add=True,
+                    playlist=Playlist(
+                        id=playlist_id(pid),
+                        name=playlist.get("name", ""),
+                        owner=owner,
+                        description=None,
+                        track_count=len(tracks),
+                    ),
+                    sections=[_playlist_tracks_section(pid)],
+                )
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # Unsupported capabilities — favourites, playlist mutation, genres.
+    # These need an OAuth2 user session (favourites/playlists) or have no
+    # Jamendo endpoint (genre list), so they degrade gracefully.
+    # ai_search is intentionally not overridden; the Protocol default returns
+    # an empty list until the semantic backend is wired up.
+    # ------------------------------------------------------------------
+
+    async def list_favorite(
+        self, type: SearchType, filter: str, offset: int = 0, limit: int = 50
+    ) -> BrowseItemList:
+        return EmptyList(offset, limit)
+
+    async def get_favorite_ids(self) -> FavoriteIds:
+        return FavoriteIds()
+
+    async def add_to_favorite(self, id: str):
+        logger.warning("Favorites are not supported in the Jamendo input module")
+
+    async def remove_from_favorite(self, id: str):
+        logger.warning("Favorites are not supported in the Jamendo input module")
+
+    async def list_genre(self, offset: int = 0, limit: int = 25) -> GenreList:
+        # Jamendo has no genre taxonomy — it uses free-form tags.
+        return GenreList(offset=offset, limit=limit, total=0, items=[])
+
+    async def playlist_user_list(
+        self, offset: int = 0, limit: int = 25
+    ) -> BrowseItemList:
+        return EmptyList(offset, limit)
+
+    async def playlist_create(self, name: str, description: str) -> Playlist:
+        raise NotImplementedError(
+            "Playlist management is not supported in the Jamendo input module"
+        )
+
+    async def playlist_update(
+        self, id: str, name: Optional[str], description: Optional[str]
+    ) -> Playlist:
+        raise NotImplementedError(
+            "Playlist management is not supported in the Jamendo input module"
+        )
+
+    async def playlist_delete(self, id: str):
+        raise NotImplementedError(
+            "Playlist management is not supported in the Jamendo input module"
+        )
+
+    async def playlist_add_tracks(
+        self, id: str, track_ids: List[str], allow_duplicates: bool
+    ) -> Playlist:
+        raise NotImplementedError(
+            "Playlist management is not supported in the Jamendo input module"
+        )
+
+    async def playlist_remove_tracks(
+        self, id: str, playlist_track_ids: List[str]
+    ) -> Playlist:
+        raise NotImplementedError(
+            "Playlist management is not supported in the Jamendo input module"
+        )
+
+    async def get_resource_path(self, id: str) -> str | None:
+        return None

--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import re
+from collections import OrderedDict
 from typing import List, Optional
 
 import httpx
@@ -313,7 +314,24 @@ class JamendoInputModule(InputModule):
         # config.audio_format is the enum *value* (use_enum_values=True).
         self.audio_format = FORMAT_CODE.get(config.audio_format, "mp32")
         self.audio_mime = FORMAT_MIME[self.audio_format]
+        # Cache of (audio_url, metadata) keyed by track id, populated whenever
+        # tracks are listed (browse/search). Jamendo's /tracks/ endpoint lags
+        # behind /albums/tracks/ and /playlists/tracks/ for recently published
+        # tracks — querying such a track id by itself returns nothing even
+        # though it streams fine in album/playlist context. get_track_info
+        # falls back to this cache so adding a fresh album to the queue works.
+        self._track_cache: "OrderedDict[str, tuple[str, Track]]" = OrderedDict()
+        self._cache_max = 5000
         logger.info("Jamendo audio format: %s", self.audio_format)
+
+    def _cache_track(self, tid: str, audio_url: str, metadata: Track) -> None:
+        if not audio_url:
+            return
+        cache = self._track_cache
+        cache[tid] = (audio_url, metadata)
+        cache.move_to_end(tid)
+        while len(cache) > self._cache_max:
+            cache.popitem(last=False)
 
     def module_name(self) -> str:
         return "Jamendo"
@@ -576,24 +594,54 @@ class JamendoInputModule(InputModule):
             for track in results:
                 all_tracks[str(track["id"])] = track
 
-        # Preserve the requested order; drop ids Jamendo didn't return.
-        return [
-            self._track_to_track_info(all_tracks[tid])
-            for tid in track_ids
-            if tid in all_tracks
-        ]
+        # Preserve the requested order. The /tracks/ endpoint is the
+        # authoritative source, but it lags for freshly published tracks —
+        # fall back to the browse cache (populated by browse/search) so those
+        # still play. Anything resolvable by neither is dropped and logged.
+        infos: List[TrackInfo] = []
+        unresolved: List[str] = []
+        for tid in track_ids:
+            if tid in all_tracks:
+                infos.append(self._track_to_track_info(all_tracks[tid]))
+            elif tid in self._track_cache:
+                audio_url, metadata = self._track_cache[tid]
+                infos.append(self._cached_track_info(tid, audio_url, metadata))
+            else:
+                unresolved.append(tid)
+
+        if unresolved:
+            logger.warning(
+                "Jamendo get_track_info: %d/%d track(s) unresolved via the "
+                "tracks endpoint or browse cache and were skipped: %s",
+                len(unresolved),
+                len(track_ids),
+                unresolved,
+            )
+        logger.info(
+            "Jamendo get_track_info: resolved %d/%d track(s)",
+            len(infos),
+            len(track_ids),
+        )
+        return infos
 
     def _track_to_track_info(self, track) -> TrackInfo:
-        audio_url = track.get("audio", "")
+        metadata = self._track_metadata(track)
+        return self._cached_track_info(
+            metadata.id.id, track.get("audio", ""), metadata
+        )
+
+    def _cached_track_info(
+        self, tid: str, audio_url: str, metadata: Track
+    ) -> TrackInfo:
         mime = self.audio_mime
 
         async def link_retriever() -> TrackUrl:
             return TrackUrl(url=audio_url, format=mime)
 
         return TrackInfo(
-            id=track_id(str(track["id"])),
+            id=track_id(tid),
             link_retriever=link_retriever,
-            metadata=self._track_metadata(track),
+            metadata=metadata,
         )
 
     # ------------------------------------------------------------------
@@ -659,6 +707,9 @@ class JamendoInputModule(InputModule):
         result = []
         for track in tracks:
             meta = self._track_metadata(track, album_meta)
+            # Stash the streaming URL so get_track_info can play this track
+            # even if the /tracks/ endpoint can't resolve its id yet.
+            self._cache_track(meta.id.id, track.get("audio", ""), meta)
             result.append(
                 BrowseItem(
                     id=meta.id,

--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/module_setup.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/module_setup.py
@@ -1,0 +1,64 @@
+import logging
+from typing import Optional
+
+from kalinka_plugin_sdk import ModuleHealthState, ModuleState
+from kalinka_plugin_sdk.plugin import InputModulePlugin, InputPluginContext
+from kalinka_plugin_sdk.inputmodule import InputModule
+
+from .config_model import JamendoConfig
+from .jamendo import JamendoInputModule, get_client
+
+logger = logging.getLogger(__name__.split(".")[-1])
+
+
+class KalinkaPluginJamendo(InputModulePlugin):
+    REQUIRES_SDK = ">=1,<2"
+    PLUGIN_ID = "jamendo"
+    CONFIG_MODEL = JamendoConfig
+
+    def __init__(self):
+        self.interface: Optional[InputModule] = None
+        self._client = None
+        # Captured at setup so get_state() can read the current config.
+        self._context: Optional[InputPluginContext] = None
+
+    def module_name(self) -> str:
+        return "Jamendo Input Module"
+
+    def get_interface(self) -> Optional[InputModule]:
+        return self.interface
+
+    async def setup(self, context: InputPluginContext) -> None:
+        self._context = context
+        config = JamendoConfig(**context.config.model_dump())
+        logger.info("Setting up Jamendo input module")
+        self._client = await get_client(config)
+        self.interface = JamendoInputModule(config, self._client)
+
+    async def get_state(self) -> ModuleState:
+        """Surface the "no client_id configured" case as an ERROR.
+
+        Without a client_id every Jamendo request returns empty, which is
+        indistinguishable from "no results" in the UI. Reporting it here lets
+        the modules page tell the user to set their key instead of silently
+        showing an empty catalog.
+        """
+        client_id = ""
+        if self._context is not None:
+            client_id = getattr(self._context.config, "client_id", "") or ""
+
+        if not client_id:
+            return ModuleState(
+                state=ModuleHealthState.ERROR,
+                message=(
+                    "No Jamendo client_id configured. Create a free application "
+                    "at https://devportal.jamendo.com and paste its Client ID "
+                    "into this module's settings."
+                ),
+            )
+        return ModuleState(state=ModuleHealthState.READY)
+
+    async def shutdown(self) -> None:
+        logger.info("Shutting down Jamendo input module")
+        if self._client is not None:
+            await self._client.aclose()

--- a/packages/kalinka-plugin-jamendo/tests/test_mapping.py
+++ b/packages/kalinka-plugin-jamendo/tests/test_mapping.py
@@ -1,0 +1,196 @@
+"""Offline unit tests for the Jamendo mapping/browse logic.
+
+These stub JamendoClient.request so no network or client_id is needed.
+"""
+
+import pytest
+
+from kalinka_plugin_sdk.datamodel import EntityType
+from kalinka_plugin_sdk.inputmodule import SearchType, TrackUrl
+
+from kalinka_plugin_jamendo.config_model import JamendoConfig, JamendoAudioFormat
+from kalinka_plugin_jamendo import jamendo as jm
+
+
+class FakeClient:
+    """Records the last (path, params) and returns canned results."""
+
+    def __init__(self, results):
+        self._results = results
+        self.calls = []
+
+    async def request(self, path, params):
+        self.calls.append((path, params))
+        return self._results
+
+
+def make_module(results, fmt=JamendoAudioFormat.FLAC):
+    config = JamendoConfig(client_id="x", audio_format=fmt)
+    module = jm.JamendoInputModule(config, FakeClient(results))
+    return module
+
+
+TRACK = {
+    "id": "100",
+    "name": "Sunrise",
+    "duration": "212",
+    "artist_id": "10",
+    "artist_name": "The Band",
+    "album_id": "5",
+    "album_name": "Mornings",
+    "album_image": "https://usercontent.jamendo.com?type=album&id=5&width=300",
+    "audio": "https://prod.jamendo.com/?trackid=100&format=flac",
+}
+
+ALBUM = {
+    "id": "5",
+    "name": "Mornings",
+    "artist_id": "10",
+    "artist_name": "The Band",
+    "image": "https://usercontent.jamendo.com?type=album&id=5&width=300",
+}
+
+ARTIST = {
+    "id": "10",
+    "name": "The Band",
+    "image": "https://usercontent.jamendo.com?type=artist&id=10&width=300",
+}
+
+PLAYLIST = {
+    "id": "7",
+    "name": "Chill",
+    "user_id": "99",
+    "user_name": "dj",
+    "tracks": [TRACK, TRACK],
+}
+
+
+def test_format_code_mapping():
+    m = make_module([], fmt=JamendoAudioFormat.MP3_96)
+    assert m.audio_format == "mp31"
+    assert m.audio_mime == "audio/mpeg"
+
+
+@pytest.mark.asyncio
+async def test_search_tracks():
+    m = make_module([TRACK])
+    res = await m.search(SearchType.track, "sunrise", offset=0, limit=50)
+    assert res.items[0].track.title == "Sunrise"
+    assert res.items[0].track.id.type == EntityType.TRACK
+    assert res.items[0].track.id.source == "jamendo"
+    assert res.items[0].subname == "The Band"
+    # audioformat must be forwarded for track search
+    assert m.client.calls[0][1]["audioformat"] == "flac"
+
+
+@pytest.mark.asyncio
+async def test_search_albums_have_sections():
+    m = make_module([ALBUM])
+    res = await m.search(SearchType.album, "mornings")
+    item = res.items[0]
+    assert item.can_browse is True
+    assert item.album.title == "Mornings"
+    assert item.sections and item.sections[0].name == "Tracks"
+
+
+@pytest.mark.asyncio
+async def test_estimated_total_full_page_bumps():
+    # A full page (count == limit) should advertise more pages.
+    m = make_module([TRACK] * 2)
+    res = await m.search(SearchType.track, "x", offset=0, limit=2)
+    assert res.total == 4  # offset(0) + count(2) + limit(2)
+
+
+@pytest.mark.asyncio
+async def test_root_catalog():
+    m = make_module([])
+    root = jm.catalog_id("root")
+    res = await m.browse(root)
+    slugs = {i.id.id for i in res.items}
+    assert {"popular-tracks", "new-releases", "popular-artists"} <= slugs
+    # Root is built locally, no API call.
+    assert m.client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_browse_album_paginates_tracks():
+    album_with_tracks = {**ALBUM, "tracks": [TRACK, TRACK, TRACK]}
+    m = make_module([album_with_tracks])
+    res = await m.browse(jm.album_id("5"), offset=1, limit=1)
+    assert res.total == 3
+    assert len(res.items) == 1
+
+
+@pytest.mark.asyncio
+async def test_browse_artist_paginates_albums():
+    # artists/albums nests all albums under one artist; we paginate locally.
+    artist_with_albums = {**ARTIST, "albums": [ALBUM, ALBUM, ALBUM]}
+    m = make_module([artist_with_albums])
+    res = await m.browse(jm.artist_id("10"), offset=2, limit=5)
+    assert res.total == 3
+    assert len(res.items) == 1
+    # No offset/limit forwarded to the API — full album list is fetched.
+    assert "offset" not in m.client.calls[0][1]
+
+
+@pytest.mark.asyncio
+async def test_get_track_info_preserves_order_and_url():
+    t2 = {**TRACK, "id": "200", "name": "Dusk"}
+    m = make_module([TRACK, t2])
+    infos = await m.get_track_info(["200", "100"])
+    assert [i.id.id for i in infos] == ["200", "100"]
+    url = await infos[0].link_retriever()
+    assert isinstance(url, TrackUrl)
+    assert url.format == "audio/flac"
+    assert "trackid=" in url.url
+
+
+@pytest.mark.asyncio
+async def test_get_playlist():
+    m = make_module([PLAYLIST])
+    item = await m.get(jm.playlist_id("7"))
+    assert item.playlist.track_count == 2
+    assert item.playlist.owner.name == "dj"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_get_type_raises():
+    m = make_module([])
+    with pytest.raises(ValueError):
+        await m.get(jm.user_id("1"))
+
+
+@pytest.mark.asyncio
+async def test_get_state_reports_missing_client_id():
+    from types import SimpleNamespace
+
+    from kalinka_plugin_sdk import ModuleHealthState
+    from kalinka_plugin_jamendo.module_setup import KalinkaPluginJamendo
+
+    plugin = KalinkaPluginJamendo()
+
+    # No context yet (not set up) -> treated as missing key -> ERROR.
+    state = await plugin.get_state()
+    assert state.state == ModuleHealthState.ERROR
+    assert "client_id" in state.message
+
+    # Empty client_id -> ERROR with the registration URL.
+    plugin._context = SimpleNamespace(config=SimpleNamespace(client_id=""))
+    state = await plugin.get_state()
+    assert state.state == ModuleHealthState.ERROR
+    assert "devportal.jamendo.com" in state.message
+
+    # Configured client_id -> READY.
+    plugin._context = SimpleNamespace(config=SimpleNamespace(client_id="abc"))
+    state = await plugin.get_state()
+    assert state.state == ModuleHealthState.READY
+
+
+@pytest.mark.asyncio
+async def test_stubs_are_graceful():
+    m = make_module([])
+    assert (await m.list_genre()).total == 0
+    assert (await m.get_favorite_ids()).tracks == []
+    assert (await m.list_favorite(SearchType.track, "")).total == 0
+    assert (await m.playlist_user_list()).total == 0
+    assert await m.get_resource_path("x") is None

--- a/packages/kalinka-plugin-jamendo/tests/test_mapping.py
+++ b/packages/kalinka-plugin-jamendo/tests/test_mapping.py
@@ -24,6 +24,18 @@ class FakeClient:
         return self._results
 
 
+class PathClient:
+    """Returns canned results per endpoint path (first path segment)."""
+
+    def __init__(self, by_path):
+        self._by_path = by_path
+        self.calls = []
+
+    async def request(self, path, params):
+        self.calls.append((path, params))
+        return self._by_path.get(path, [])
+
+
 def make_module(results, fmt=JamendoAudioFormat.FLAC):
     config = JamendoConfig(client_id="x", audio_format=fmt)
     module = jm.JamendoInputModule(config, FakeClient(results))
@@ -143,6 +155,42 @@ async def test_get_track_info_preserves_order_and_url():
     assert isinstance(url, TrackUrl)
     assert url.format == "audio/flac"
     assert "trackid=" in url.url
+
+
+@pytest.mark.asyncio
+async def test_get_track_info_falls_back_to_browse_cache():
+    # Simulate Jamendo's indexing lag: albums/tracks returns the track (with
+    # audio), but the /tracks/ endpoint returns nothing for that id.
+    album_with_tracks = {**ALBUM, "tracks": [TRACK]}
+    config = JamendoConfig(client_id="x", audio_format=JamendoAudioFormat.MP3_VBR)
+    client = PathClient({"albums/tracks": [album_with_tracks], "tracks": []})
+    m = jm.JamendoInputModule(config, client)
+
+    # Nothing cached yet -> /tracks/ miss -> unresolved -> empty.
+    assert await m.get_track_info(["100"]) == []
+
+    # Browsing the album warms the cache with the streaming URL.
+    await m.browse(jm.album_id("5"), 0, 50)
+    infos = await m.get_track_info(["100"])
+    assert len(infos) == 1
+    url = await infos[0].link_retriever()
+    assert url.url == TRACK["audio"]
+    assert infos[0].metadata.title == "Sunrise"
+
+
+@pytest.mark.asyncio
+async def test_get_track_info_prefers_live_endpoint_over_cache():
+    # When the /tracks/ endpoint resolves the id, its result wins.
+    fresh = {**TRACK, "audio": "https://fresh.example/?trackid=100"}
+    config = JamendoConfig(client_id="x", audio_format=JamendoAudioFormat.MP3_VBR)
+    client = PathClient(
+        {"albums/tracks": [{**ALBUM, "tracks": [TRACK]}], "tracks": [fresh]}
+    )
+    m = jm.JamendoInputModule(config, client)
+    await m.browse(jm.album_id("5"), 0, 50)  # caches stale audio
+    infos = await m.get_track_info(["100"])
+    url = await infos[0].link_retriever()
+    assert url.url == "https://fresh.example/?trackid=100"
 
 
 @pytest.mark.asyncio

--- a/packages/kalinka-plugin-jamendo/tests/test_mapping.py
+++ b/packages/kalinka-plugin-jamendo/tests/test_mapping.py
@@ -140,15 +140,16 @@ async def test_browse_album_paginates_tracks():
 
 
 @pytest.mark.asyncio
-async def test_browse_artist_paginates_albums():
-    # artists/albums nests all albums under one artist; we paginate locally.
-    artist_with_albums = {**ARTIST, "albums": [ALBUM, ALBUM, ALBUM]}
-    m = make_module([artist_with_albums])
-    res = await m.browse(jm.artist_id("10"), offset=2, limit=5)
-    assert res.total == 3
-    assert len(res.items) == 1
-    # No offset/limit forwarded to the API — full album list is fetched.
-    assert "offset" not in m.client.calls[0][1]
+async def test_browse_artist_uses_albums_endpoint():
+    # Artist browse goes through /albums/?artist_id= so cards get the real
+    # trackid-bearing cover; offset/limit are forwarded for native pagination.
+    m = make_module([ALBUM, ALBUM])
+    res = await m.browse(jm.artist_id("10"), offset=5, limit=2)
+    path, params = m.client.calls[0]
+    assert path == "albums"
+    assert params["artist_id"] == "10"
+    assert params["offset"] == 5 and params["limit"] == 2
+    assert res.items[0].album.title == "Mornings"
 
 
 @pytest.mark.asyncio

--- a/packages/kalinka-plugin-jamendo/tests/test_mapping.py
+++ b/packages/kalinka-plugin-jamendo/tests/test_mapping.py
@@ -166,11 +166,11 @@ async def test_get_track_info_falls_back_to_browse_cache():
     client = PathClient({"albums/tracks": [album_with_tracks], "tracks": []})
     m = jm.JamendoInputModule(config, client)
 
-    # Nothing cached yet -> /tracks/ miss -> download-endpoint fallback.
+    # Nothing cached yet -> /tracks/ miss -> storage-origin fallback.
     cold = await m.get_track_info(["100"])
     assert len(cold) == 1
     cold_url = await cold[0].link_retriever()
-    assert cold_url.url == "https://mp3d.jamendo.com/download/track/100/mp32/"
+    assert cold_url.url == "https://prod-1.storage.jamendo.com/?trackid=100&format=mp32"
 
     # Browsing the album warms the cache with the real streaming URL + metadata.
     await m.browse(jm.album_id("5"), 0, 50)
@@ -182,15 +182,16 @@ async def test_get_track_info_falls_back_to_browse_cache():
 
 
 @pytest.mark.asyncio
-async def test_fallback_format_drops_flac_to_lossy():
-    # FLAC isn't on the download endpoint, so the fallback uses a lossy format.
+async def test_fallback_honors_flac():
+    # The storage origin serves flac, so the fallback keeps the configured
+    # format (and the audio/flac mime that selects the FLAC decoder).
     config = JamendoConfig(client_id="x", audio_format=JamendoAudioFormat.FLAC)
     client = PathClient({"tracks": []})
     m = jm.JamendoInputModule(config, client)
     infos = await m.get_track_info(["999"])
     url = await infos[0].link_retriever()
-    assert url.url == "https://mp3d.jamendo.com/download/track/999/mp32/"
-    assert url.format == "audio/mpeg"
+    assert url.url == "https://prod-1.storage.jamendo.com/?trackid=999&format=flac"
+    assert url.format == "audio/flac"
 
 
 @pytest.mark.asyncio
@@ -206,6 +207,24 @@ async def test_get_track_info_prefers_live_endpoint_over_cache():
     infos = await m.get_track_info(["100"])
     url = await infos[0].link_retriever()
     assert url.url == "https://fresh.example/?trackid=100"
+
+
+@pytest.mark.asyncio
+async def test_fallback_origin_learned_from_live_audio():
+    # The fallback host is not pinned to the seed: it follows whatever origin
+    # the API's real `audio` URLs use. Here a resolved track reports prod-9, so
+    # an unresolved track's fallback must target prod-9 too.
+    live = {
+        **TRACK,
+        "id": "100",
+        "audio": "https://prod-9.storage.jamendo.com/?trackid=100&format=mp32&from=x",
+    }
+    config = JamendoConfig(client_id="x", audio_format=JamendoAudioFormat.MP3_VBR)
+    client = PathClient({"tracks": [live]})
+    m = jm.JamendoInputModule(config, client)
+    infos = await m.get_track_info(["100", "999"])  # 999 unresolved -> fallback
+    fb_url = await infos[1].link_retriever()
+    assert fb_url.url == "https://prod-9.storage.jamendo.com/?trackid=999&format=mp32"
 
 
 @pytest.mark.asyncio

--- a/packages/kalinka-plugin-jamendo/tests/test_mapping.py
+++ b/packages/kalinka-plugin-jamendo/tests/test_mapping.py
@@ -166,16 +166,31 @@ async def test_get_track_info_falls_back_to_browse_cache():
     client = PathClient({"albums/tracks": [album_with_tracks], "tracks": []})
     m = jm.JamendoInputModule(config, client)
 
-    # Nothing cached yet -> /tracks/ miss -> unresolved -> empty.
-    assert await m.get_track_info(["100"]) == []
+    # Nothing cached yet -> /tracks/ miss -> download-endpoint fallback.
+    cold = await m.get_track_info(["100"])
+    assert len(cold) == 1
+    cold_url = await cold[0].link_retriever()
+    assert cold_url.url == "https://mp3d.jamendo.com/download/track/100/mp32/"
 
-    # Browsing the album warms the cache with the streaming URL.
+    # Browsing the album warms the cache with the real streaming URL + metadata.
     await m.browse(jm.album_id("5"), 0, 50)
     infos = await m.get_track_info(["100"])
     assert len(infos) == 1
     url = await infos[0].link_retriever()
     assert url.url == TRACK["audio"]
     assert infos[0].metadata.title == "Sunrise"
+
+
+@pytest.mark.asyncio
+async def test_fallback_format_drops_flac_to_lossy():
+    # FLAC isn't on the download endpoint, so the fallback uses a lossy format.
+    config = JamendoConfig(client_id="x", audio_format=JamendoAudioFormat.FLAC)
+    client = PathClient({"tracks": []})
+    m = jm.JamendoInputModule(config, client)
+    infos = await m.get_track_info(["999"])
+    url = await infos[0].link_retriever()
+    assert url.url == "https://mp3d.jamendo.com/download/track/999/mp32/"
+    assert url.format == "audio/mpeg"
 
 
 @pytest.mark.asyncio

--- a/packages/kalinka-plugin-jamendo/tests/test_mapping.py
+++ b/packages/kalinka-plugin-jamendo/tests/test_mapping.py
@@ -206,6 +206,43 @@ async def test_link_resolves_via_file_endpoint_honoring_format():
 
 
 @pytest.mark.asyncio
+async def test_link_raises_when_url_unresolved():
+    # If the file endpoint can't resolve a URL, link_retriever must raise so the
+    # server marks the track unavailable instead of trying to play "".
+    class NoUrlClient(PathClient):
+        async def resolve_audio_url(self, track_id, audioformat):
+            return ""
+
+    config = JamendoConfig(client_id="x", audio_format=JamendoAudioFormat.MP3_VBR)
+    m = jm.JamendoInputModule(config, NoUrlClient({"tracks": []}))
+    infos = await m.get_track_info(["999"])
+    with pytest.raises(RuntimeError):
+        await infos[0].link_retriever()
+
+
+@pytest.mark.asyncio
+async def test_request_degrades_on_non_json(monkeypatch):
+    # A non-JSON body (HTML error page, truncated response) degrades to an empty
+    # result set rather than raising.
+    from kalinka_plugin_jamendo.jamendo import JamendoClient
+
+    client = JamendoClient("x")
+
+    class FakeResp:
+        is_success = True
+
+        def json(self):
+            raise ValueError("not json")
+
+    async def fake_get(url, params=None):
+        return FakeResp()
+
+    monkeypatch.setattr(client.session, "get", fake_get)
+    assert await client.request("tracks", {"id": "1"}) == []
+    await client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_get_playlist():
     m = make_module([PLAYLIST])
     item = await m.get(jm.playlist_id("7"))

--- a/packages/kalinka-plugin-jamendo/tests/test_mapping.py
+++ b/packages/kalinka-plugin-jamendo/tests/test_mapping.py
@@ -23,6 +23,9 @@ class FakeClient:
         self.calls.append((path, params))
         return self._results
 
+    async def resolve_audio_url(self, track_id, audioformat):
+        return f"https://files.test/{track_id}.{audioformat}"
+
 
 class PathClient:
     """Returns canned results per endpoint path (first path segment)."""
@@ -34,6 +37,9 @@ class PathClient:
     async def request(self, path, params):
         self.calls.append((path, params))
         return self._by_path.get(path, [])
+
+    async def resolve_audio_url(self, track_id, audioformat):
+        return f"https://files.test/{track_id}.{audioformat}"
 
 
 def make_module(results, fmt=JamendoAudioFormat.FLAC):
@@ -154,77 +160,48 @@ async def test_get_track_info_preserves_order_and_url():
     url = await infos[0].link_retriever()
     assert isinstance(url, TrackUrl)
     assert url.format == "audio/flac"
-    assert "trackid=" in url.url
+    # URL is resolved via the file endpoint (the fake returns a files.test URL).
+    assert url.url == "https://files.test/200.flac"
 
 
 @pytest.mark.asyncio
-async def test_get_track_info_falls_back_to_browse_cache():
-    # Simulate Jamendo's indexing lag: albums/tracks returns the track (with
-    # audio), but the /tracks/ endpoint returns nothing for that id.
+async def test_get_track_info_metadata_from_cache_then_index():
+    # Metadata for an id absent from the /tracks/ index still comes through,
+    # because the browse cache supplies it. Playback URLs always resolve via
+    # the file endpoint regardless.
     album_with_tracks = {**ALBUM, "tracks": [TRACK]}
     config = JamendoConfig(client_id="x", audio_format=JamendoAudioFormat.MP3_VBR)
     client = PathClient({"albums/tracks": [album_with_tracks], "tracks": []})
     m = jm.JamendoInputModule(config, client)
 
-    # Nothing cached yet -> /tracks/ miss -> storage-origin fallback.
+    # Cold: id not in cache and /tracks/ returns nothing -> placeholder metadata,
+    # but still playable via the file endpoint.
     cold = await m.get_track_info(["100"])
-    assert len(cold) == 1
+    assert cold[0].metadata.title == ""
     cold_url = await cold[0].link_retriever()
-    assert cold_url.url == "https://prod-1.storage.jamendo.com/?trackid=100&format=mp32"
+    assert cold_url.url == "https://files.test/100.mp32"
 
-    # Browsing the album warms the cache with the real streaming URL + metadata.
+    # After browsing the album, metadata comes from the cache.
     await m.browse(jm.album_id("5"), 0, 50)
     infos = await m.get_track_info(["100"])
-    assert len(infos) == 1
-    url = await infos[0].link_retriever()
-    assert url.url == TRACK["audio"]
     assert infos[0].metadata.title == "Sunrise"
+    # The /tracks/ index is not even queried for a cached id.
+    assert not any(
+        path == "tracks" for path, _ in client.calls[1:]
+    )
 
 
 @pytest.mark.asyncio
-async def test_fallback_honors_flac():
-    # The storage origin serves flac, so the fallback keeps the configured
-    # format (and the audio/flac mime that selects the FLAC decoder).
+async def test_link_resolves_via_file_endpoint_honoring_format():
+    # The playback URL always comes from /tracks/file/ (here stubbed), honouring
+    # the configured format and its mime (which selects the decoder).
     config = JamendoConfig(client_id="x", audio_format=JamendoAudioFormat.FLAC)
     client = PathClient({"tracks": []})
     m = jm.JamendoInputModule(config, client)
     infos = await m.get_track_info(["999"])
     url = await infos[0].link_retriever()
-    assert url.url == "https://prod-1.storage.jamendo.com/?trackid=999&format=flac"
+    assert url.url == "https://files.test/999.flac"
     assert url.format == "audio/flac"
-
-
-@pytest.mark.asyncio
-async def test_get_track_info_prefers_live_endpoint_over_cache():
-    # When the /tracks/ endpoint resolves the id, its result wins.
-    fresh = {**TRACK, "audio": "https://fresh.example/?trackid=100"}
-    config = JamendoConfig(client_id="x", audio_format=JamendoAudioFormat.MP3_VBR)
-    client = PathClient(
-        {"albums/tracks": [{**ALBUM, "tracks": [TRACK]}], "tracks": [fresh]}
-    )
-    m = jm.JamendoInputModule(config, client)
-    await m.browse(jm.album_id("5"), 0, 50)  # caches stale audio
-    infos = await m.get_track_info(["100"])
-    url = await infos[0].link_retriever()
-    assert url.url == "https://fresh.example/?trackid=100"
-
-
-@pytest.mark.asyncio
-async def test_fallback_origin_learned_from_live_audio():
-    # The fallback host is not pinned to the seed: it follows whatever origin
-    # the API's real `audio` URLs use. Here a resolved track reports prod-9, so
-    # an unresolved track's fallback must target prod-9 too.
-    live = {
-        **TRACK,
-        "id": "100",
-        "audio": "https://prod-9.storage.jamendo.com/?trackid=100&format=mp32&from=x",
-    }
-    config = JamendoConfig(client_id="x", audio_format=JamendoAudioFormat.MP3_VBR)
-    client = PathClient({"tracks": [live]})
-    m = jm.JamendoInputModule(config, client)
-    infos = await m.get_track_info(["100", "999"])  # 999 unresolved -> fallback
-    fb_url = await infos[1].link_retriever()
-    assert fb_url.url == "https://prod-9.storage.jamendo.com/?trackid=999&format=mp32"
 
 
 @pytest.mark.asyncio

--- a/packages/kalinka-plugin-jamendo/tests/test_smoke.py
+++ b/packages/kalinka-plugin-jamendo/tests/test_smoke.py
@@ -1,0 +1,31 @@
+"""
+Pytest smoke tests for kalinka-plugin-jamendo
+"""
+
+import pytest
+from importlib.metadata import entry_points
+
+
+@pytest.mark.smoke
+def test_entry_point_visible():
+    """The plugin entry point is discoverable and well-formed."""
+    eps = entry_points(group="kalinka.plugins")
+    assert any(
+        ep.name == "kalinka_plugin_jamendo" for ep in eps
+    ), "Plugin entry point 'kalinka_plugin_jamendo' not found in kalinka.plugins group"
+
+    for ep in eps:
+        if ep.name == "kalinka_plugin_jamendo":
+            plugin = ep.load()
+            assert plugin is not None
+            assert hasattr(plugin, "PLUGIN_ID")
+            assert plugin.PLUGIN_ID == "jamendo"
+            assert hasattr(plugin, "REQUIRES_SDK")
+            assert hasattr(plugin, "CONFIG_MODEL")
+            obj = plugin()
+            assert hasattr(obj, "setup")
+            assert hasattr(obj, "shutdown")
+
+            config = plugin.CONFIG_MODEL()
+            assert config is not None
+            break

--- a/packages/kalinka-server/src/kalinka_server/playqueue.py
+++ b/packages/kalinka-server/src/kalinka_server/playqueue.py
@@ -687,10 +687,23 @@ class PlayQueueImpl(PlayQueueController):
             for track in state.track_list:
                 try:
                     track_info = await track_info_retriever(track.id)
-                    track_infos.append(track_info)
                 except Exception as e:
                     logger.warning(f"Failed to retrieve track info for {track.id}: {e}")
                     continue
+
+                # The saved snapshot is authoritative for metadata: a module
+                # may be unable to re-fetch it on restore (e.g. source-side
+                # indexing lag, where the module can still produce a playback
+                # URL but not the title/artist/album). Use the module's
+                # TrackInfo only for playback (link_retriever) and keep the
+                # metadata the queue had when it was saved.
+                track_infos.append(
+                    TrackInfo(
+                        id=track.id,
+                        link_retriever=track_info.link_retriever,
+                        metadata=track,
+                    )
+                )
 
             if track_infos:
                 self._add(track_infos)

--- a/packages/kalinka-server/tests/test_state_restore.py
+++ b/packages/kalinka-server/tests/test_state_restore.py
@@ -105,6 +105,75 @@ async def test_restore_state_batches_track_info_requests(tmp_path, monkeypatch):
     assert restored_ids == [track.id.to_string for track in state.track_list]
 
 
+@pytest.mark.asyncio
+async def test_restore_prefers_saved_metadata_over_module():
+    """On restore the saved snapshot is authoritative for metadata; the module's
+    TrackInfo is used only for its playback link_retriever.
+
+    This is what lets queue entries survive a restart even when a module can
+    only re-resolve a playback URL but not the title/artist/album (e.g. Jamendo
+    tracks whose ids the /tracks/ endpoint temporarily can't resolve)."""
+    from types import SimpleNamespace
+
+    saved = [_make_track("a1", "jamendo"), _make_track("a2", "jamendo")]
+    state = PlayQueueState(
+        playback_state=PlaybackState(state=PlayerStateEnum.STOPPED, index=0),
+        playback_mode=PlaybackMode(
+            shuffle=False, repeat_single=False, repeat_all=False
+        ),
+        track_list=saved,
+    )
+
+    # The module returns *placeholder* metadata (empty title) — simulating a
+    # track it can only resolve a URL for, not real metadata.
+    async def _placeholder_link():
+        return TrackUrl(url="https://example.invalid/fallback.mp3", format="audio/mpeg")
+
+    def _retriever_factory(tid):
+        async def _retrieve(entity_id):
+            return TrackInfo(
+                id=entity_id,
+                metadata=Track(
+                    id=entity_id,
+                    title="",  # placeholder — must NOT win
+                    duration=0,
+                    album=Album(
+                        id=_album_entity("", "jamendo"), title=""
+                    ),
+                ),
+                link_retriever=_placeholder_link,
+            )
+
+        return _retrieve
+
+    added: list[TrackInfo] = []
+    fake_self = SimpleNamespace(
+        track_player=SimpleNamespace(
+            get_state=lambda: SimpleNamespace(state=None), stop=lambda: None
+        ),
+        current_stream_id=None,
+        track_list=[],
+        prepared_tracks={},
+        _unavailable_indices=set(),
+        _cancel_prefetch_timer=lambda: None,
+        current_track_id=0,
+        shuffle=False,
+        repeat_single=False,
+        repeat_all=False,
+        event_emitter=Mock(),
+        _add=lambda infos: added.extend(infos),
+    )
+
+    await PlayQueueImpl.restore_from_state(
+        fake_self, state, _retriever_factory(None)
+    )
+
+    assert [ti.metadata.title for ti in added] == ["track-a1", "track-a2"]
+    # The playback link comes from the module's TrackInfo, not the saved Track.
+    urls = [await ti.link_retriever() for ti in added]
+    assert all(u.url == "https://example.invalid/fallback.mp3" for u in urls)
+
+
 def test_restore_from_state_is_not_queue_wrapped():
     # serialised keeps async methods async; restore should stay undecorated.
     assert inspect.iscoroutinefunction(PlayQueueImpl.restore_from_state)


### PR DESCRIPTION
## Summary

Adds **`kalinka-plugin-jamendo`**, an input-module plugin that lets you search, browse and play music from [Jamendo](https://www.jamendo.com) (free / Creative-Commons catalogue) inside the Kalinka play queue, modeled on the qobuz plugin.

**Implemented:** search (track/album/artist/playlist), browse (discovery root catalog + album/artist/playlist drill-down), `get`, and `get_track_info`. Favorites, playlist mutation, `list_genre`, and `ai_search` are intentionally stubbed (OAuth-only, no genre taxonomy, or deferred). Requires a free `client_id` from devportal.jamendo.com.

## Notable design decisions, driven by Jamendo API quirks

- **Playback resolves via `/tracks/file/`.** The `/tracks/?id=` metadata endpoint is an incomplete index — it returns nothing for many valid, streamable tracks (old *and* freshly published), for every client_id. So playback URLs are resolved through the documented `/tracks/file/` endpoint (302 → storage URL), which handles any track by id. The plugin reads the redirect `Location` because the native player doesn't follow redirects. No hardcoded storage host.
- **Metadata vs. playback are decoupled.** `get_track_info` takes metadata from the browse/search cache first, then `/tracks/` as best-effort, then a placeholder; the playback link always resolves via `/tracks/file/`, honouring the configured format (incl. FLAC).
- **Saved queue metadata is authoritative on restore** (kalinka-server change in `playqueue.py`): restore keeps the snapshot's metadata and uses the module only for the playback link, so queues survive a restart even when a source can re-resolve a URL but not metadata. Benefits all sources.
- **Album art under artists** uses `/albums/?artist_id=` (real trackid-bearing covers) instead of `/artists/albums/` (placeholder covers).
- **Health status**: `get_state()` reports ERROR with a registration link when `client_id` is unset.

## Caveats (documented in the plugin README)

- No exact result totals (Jamendo reports only current-page size) → totals are estimates tuned for "load more".
- Free-tier rate limits.
- `get()` on a single non-indexed track can 404 (detail view only; playback/queueing unaffected).

## Tests

- Plugin: 15 offline mapping/smoke tests (`pytest`, no network/client_id needed).
- Server: restore-metadata behavior covered in `test_state_restore.py`.
- All endpoint behaviors verified against the live Jamendo API during development.

## Note for reviewers

This branch includes one **kalinka-server** change (`c09f02e`, restore trusts saved metadata) alongside the plugin. The `build-all-deb` / `kalinka-plugins-deb` Makefile target builds the new plugin automatically via the `packages/kalinka-plugin-*` glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)