### PR TITLE
Retry SQLite "database is locked" with jittered backoff

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
@@ -17,6 +17,7 @@ from typing import Optional
 import aiosqlite
 
 from ..config_model import LocalFilesConfig
+from ..worker_utils import retry_db_locked
 
 logger = logging.getLogger(__name__.split(".")[-1])
 
@@ -33,6 +34,7 @@ _VEC_TEXT_TABLES = {
     "artists": ("vec_artists_clap_text", "artist_id"),
 }
 
+@retry_db_locked
 class AsyncEmbedderDb:
     """
     Database manager for the CLAP + Essentia embedding pipeline.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
@@ -7,10 +7,12 @@ import time
 from typing import List, Dict, Optional, Any, Tuple
 
 from ..config_model import LocalFilesConfig
+from ..worker_utils import retry_db_locked
 
 logger = logging.getLogger(__name__.split(".")[-1])
 
 
+@retry_db_locked
 class AsyncEnricherDb:
     """
     Asynchronous database manager specifically for the metadata enricher.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -6,10 +6,12 @@ from typing import List, Dict, Optional, Any, Tuple
 
 
 from ..config_model import LocalFilesConfig
+from ..worker_utils import retry_db_locked
 
 logger = logging.getLogger(__name__.split(".")[-1])
 
 
+@retry_db_locked
 class AsyncIndexerDb:
     """
     Asynchronous database manager specifically for the file indexer.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
@@ -20,6 +20,7 @@ import aiosqlite
 from rapidfuzz import fuzz
 
 from ..config_model import LocalFilesConfig
+from ..worker_utils import retry_db_locked
 
 logger = logging.getLogger(__name__.split(".")[-1])
 
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__.split(".")[-1])
 _INDEX_BATCH_SIZE = 200
 
 
+@retry_db_locked
 class AsyncSearcherDb:
     """
     Async database layer for the search subprocess.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/worker_utils.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/worker_utils.py
@@ -4,12 +4,87 @@ from __future__ import annotations
 
 import asyncio
 import ctypes
+import functools
+import inspect
 import logging
 import multiprocessing
 import queue
+import random
+import sqlite3
 from typing import Optional
 
 logger = logging.getLogger(__name__.split(".")[-1])
+
+
+# ---------------------------------------------------------------------------
+# SQLite "database is locked" retry
+# ---------------------------------------------------------------------------
+#
+# The localfiles workers (indexer, enricher, searcher, embedder) run as
+# separate processes that all write the *same* SQLite file. WAL permits one
+# writer at a time, so during a burst — e.g. every scheduled scan cycle wakes
+# several workers at once — a writer can wait past ``busy_timeout`` and surface
+# ``sqlite3.OperationalError: database is locked``. Reopening a fresh
+# connection/transaction and trying again clears the vast majority of these.
+
+# How many times an operation is attempted in total (initial try + retries).
+_DB_LOCK_ATTEMPTS = 3
+# Base backoff; the per-attempt cap grows exponentially from here.
+_DB_LOCK_BASE_DELAY = 0.05
+# Upper bound on any single backoff wait.
+_DB_LOCK_MAX_DELAY = 1.0
+
+
+def _is_locked_error(exc: BaseException) -> bool:
+    return isinstance(exc, sqlite3.OperationalError) and "locked" in str(exc).lower()
+
+
+def retry_on_locked(fn):
+    """Wrap an async DB method so it retries on ``database is locked``.
+
+    Tries at most ``_DB_LOCK_ATTEMPTS`` times. Backoff is exponential with
+    *full jitter* (``random.uniform(0, cap)``) so the contending workers don't
+    resynchronise and collide again on the same retry tick. Any non-lock error
+    — or exhausting the attempts — re-raises immediately.
+    """
+
+    @functools.wraps(fn)
+    async def wrapper(*args, **kwargs):
+        for attempt in range(1, _DB_LOCK_ATTEMPTS + 1):
+            try:
+                return await fn(*args, **kwargs)
+            except sqlite3.OperationalError as exc:
+                if not _is_locked_error(exc) or attempt == _DB_LOCK_ATTEMPTS:
+                    raise
+                cap = min(_DB_LOCK_MAX_DELAY, _DB_LOCK_BASE_DELAY * 2 ** (attempt - 1))
+                delay = random.uniform(0, cap)
+                logger.warning(
+                    "%s: database is locked (attempt %d/%d), retrying in %.3fs",
+                    fn.__qualname__,
+                    attempt,
+                    _DB_LOCK_ATTEMPTS,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+    return wrapper
+
+
+def retry_db_locked(cls):
+    """Class decorator: wrap every public async method with ``retry_on_locked``.
+
+    Only public (non ``_``-prefixed) coroutine methods are wrapped — these own
+    their full connection lifecycle via ``_open()``, so a retry always reopens a
+    clean connection rather than reusing one mid-transaction. Internal helpers
+    (including the ``_open`` context manager and any method handed an existing
+    connection) are left untouched.
+    """
+    for name, member in list(vars(cls).items()):
+        if name.startswith("_"):
+            continue
+        if inspect.iscoroutinefunction(member):
+            setattr(cls, name, retry_on_locked(member))
+    return cls
 
 
 # Linux prctl op for setting the kernel-level process name (visible as


### PR DESCRIPTION
Fixes #57

## Problem

The `localfiles` plugin runs the indexer, enricher, searcher, and embedder as **four separate processes**, each opening its own connection to the **same SQLite file**. WAL mode permits one writer at a time, so after every scheduled scan — when the indexer nudges the enricher and searcher — the workers wake and write at once, and a writer can occasionally wait past the 5s `busy_timeout` and raise `database is locked`. Both call sites already caught the error and continued (no data loss), so it was noisy ERROR logging of a benign, transient condition.

## Fix

- Add `retry_on_locked` + a `retry_db_locked` class decorator in `worker_utils.py`.
- Apply `@retry_db_locked` to `AsyncEnricherDb`, `AsyncSearcherDb`, `AsyncIndexerDb`, `AsyncEmbedderDb`.

The decorator wraps each **public** coroutine method — those own their full connection lifecycle via `_open()`, so a retry reopens a clean connection/transaction. Internal `_`-prefixed helpers handed an existing connection are deliberately left unwrapped.

Retries **at most 3 times** with **exponential backoff + full jitter** (`random.uniform(0, cap)`, cap `0.05 → 0.1 → …` ≤ 1.0s) so contending workers don't resynchronise and collide again on the same tick. Non-lock errors and exhausted retries re-raise unchanged. Sits on top of the existing 5s `busy_timeout`. Tuning knobs are module constants (`_DB_LOCK_ATTEMPTS`, `_DB_LOCK_BASE_DELAY`, `_DB_LOCK_MAX_DELAY`).

## Caveat

Best effort by design — this absorbs *transient* contention (the case in #57). Sustained multi-writer overload beyond 3 retries will still surface the error intentionally, rather than masking a real problem. A proper long-term fix would funnel writes through a single owner.

## Testing

- Imports load and decoration verified: all public coroutine methods wrapped; `_check_vec_available`/`_load_vec`/`_upsert_vec_embedding` (connection-sharing internals) and the `_open` context manager correctly skipped.
- Helper behavior tested: recovers mid-sequence, caps at exactly 3 attempts, passes non-lock errors straight through, and jitter values differ per call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)