### PR TITLE
Stop indexer retrying broken files forever; support tagless MP3s

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
@@ -122,6 +122,24 @@ async def init_db(db_path: str) -> None:
             """
         )
 
+        # Negative cache for files whose metadata could not be extracted.
+        # Keyed by path + (size, mtime) so a still-uploading / partially
+        # written file — which changes size or mtime between scans — keeps
+        # missing this cache and is retried, while a stably broken file is
+        # parked and skipped instead of being re-read on every scan.
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS indexer_failures (
+                file_path     TEXT PRIMARY KEY,
+                file_size     BIGINT,
+                modified_time INTEGER,
+                error         TEXT,
+                attempts      INTEGER NOT NULL DEFAULT 1,
+                last_attempt  INTEGER
+            )
+            """
+        )
+
         await cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS playlists (

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -15,7 +15,7 @@ from PIL import Image
 
 from mutagen.mp3 import MP3
 from mutagen.flac import FLAC
-from mutagen.id3 import ID3
+from mutagen.id3 import ID3, ID3NoHeaderError
 
 try:
     from inotify_simple import INotify, flags
@@ -306,9 +306,32 @@ class FileIndexer:
             logger.debug(f"File unchanged, skipping: {file_path}")
             return None
 
+        # Negative cache: if this exact file (same size + mtime) already
+        # failed extraction, don't re-read it on every scan. A file that is
+        # still being uploaded changes size/mtime between scans, so it keeps
+        # a different key here and is retried until it stabilizes — only a
+        # genuinely broken, unchanging file stays parked.
+        failure = await self.db_manager.get_failure(file_path)
+        if (
+            failure
+            and failure["modified_time"] == modified_time
+            and failure["file_size"] == file_size
+        ):
+            logger.debug(
+                f"Skipping previously failed file (unchanged, "
+                f"{failure['attempts']} attempt(s)): {file_path}"
+            )
+            return None
+
         metadata = await asyncio.to_thread(self._extract_metadata, file_path)
         if not metadata:
-            logger.warning(f"Failed to extract metadata from {file_path}")
+            attempts = await self.db_manager.record_failure(
+                file_path, file_size, modified_time, "metadata extraction failed"
+            )
+            logger.warning(
+                f"Failed to extract metadata from {file_path} "
+                f"(attempt {attempts}); will retry only if the file changes"
+            )
             return None
 
         changes: Dict[str, Optional[str]] = {
@@ -386,6 +409,9 @@ class FileIndexer:
         changes["tracks"] = track_id
 
         await self.db_manager.update_album_stats(album_id)
+        # Successfully indexed — drop any stale failure record (e.g. an
+        # earlier partial upload that has since completed).
+        await self.db_manager.clear_failure(file_path)
         logger.debug(f"Processed file: {file_path}")
         return changes
 
@@ -416,7 +442,14 @@ class FileIndexer:
         """Extract metadata from an MP3 file"""
         try:
             mp3 = MP3(file_path)
-            id3 = ID3(file_path)
+            # A missing ID3 header is a valid, fully supported case — the
+            # audio plays fine, it just has no tags. Fall back to an empty
+            # tag set so the track still gets indexed (title derived from
+            # the filename, Unknown Artist/Album) instead of failing.
+            try:
+                id3 = ID3(file_path)
+            except ID3NoHeaderError:
+                id3 = ID3()
             metadata["duration"] = int(mp3.info.length)
             if "TIT2" in id3:
                 metadata["title"] = str(id3["TIT2"])
@@ -676,6 +709,12 @@ class FileIndexer:
                 track_id = track["id"]
                 await self.db_manager.delete_track(track_id)
                 removed_tracks += 1
+
+        # Drop failure-cache rows for files that have since been deleted,
+        # so the cache doesn't accumulate entries for vanished files.
+        for failed_path in await self.db_manager.get_failure_paths():
+            if not os.path.exists(failed_path):
+                await self.db_manager.clear_failure(failed_path)
 
         removed_albums, removed_artists = (
             await self.db_manager.delete_orphaned_albums_and_artists()

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -296,6 +296,12 @@ class FileIndexer:
 
         file_size = stat.st_size
         modified_time = int(stat.st_mtime)
+        # Nanosecond mtime for the failure-cache key. With second resolution a
+        # broken file that gets fixed within the same integer second and keeps
+        # the same size would collide on the key and never be retried. The
+        # tracks table deliberately stays on second-resolution modified_time
+        # (it's compared against search_indexed_at in the FTS staleness check).
+        mtime_ns = stat.st_mtime_ns
 
         existing_track = await self.db_manager.get_track_by_path(file_path)
         if (
@@ -314,7 +320,7 @@ class FileIndexer:
         failure = await self.db_manager.get_failure(file_path)
         if (
             failure
-            and failure["modified_time"] == modified_time
+            and failure["modified_time"] == mtime_ns
             and failure["file_size"] == file_size
         ):
             logger.debug(
@@ -326,7 +332,7 @@ class FileIndexer:
         metadata = await asyncio.to_thread(self._extract_metadata, file_path)
         if not metadata:
             attempts = await self.db_manager.record_failure(
-                file_path, file_size, modified_time, "metadata extraction failed"
+                file_path, file_size, mtime_ns, "metadata extraction failed"
             )
             logger.warning(
                 f"Failed to extract metadata from {file_path} "

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -231,9 +231,13 @@ class AsyncIndexerDb:
             return dict(row) if row else None
 
     async def record_failure(
-        self, file_path: str, file_size: int, modified_time: int, error: str
+        self, file_path: str, file_size: int, mtime_ns: int, error: str
     ) -> int:
         """Record (or update) a metadata-extraction failure for a file.
+
+        ``mtime_ns`` is the nanosecond-resolution mtime (``stat.st_mtime_ns``)
+        so a fixed-but-broken file re-written within the same integer second
+        doesn't collide on the key. Stored in the ``modified_time`` column.
 
         ``attempts`` is incremented only while the file is unchanged
         (same size + mtime); a changed file resets the counter so a
@@ -252,7 +256,7 @@ class AsyncIndexerDb:
             if (
                 row
                 and row["file_size"] == file_size
-                and row["modified_time"] == modified_time
+                and row["modified_time"] == mtime_ns
             ):
                 attempts = row["attempts"] + 1
             else:
@@ -263,7 +267,7 @@ class AsyncIndexerDb:
                     (file_path, file_size, modified_time, error, attempts, last_attempt)
                 VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (file_path, file_size, modified_time, error, attempts, int(time.time())),
+                (file_path, file_size, mtime_ns, error, attempts, int(time.time())),
             )
             await conn.commit()
             return attempts

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -1,4 +1,5 @@
 import os
+import time
 import aiosqlite
 import logging
 from contextlib import asynccontextmanager
@@ -216,6 +217,73 @@ class AsyncIndexerDb:
             deleted = cursor.rowcount > 0
             await conn.commit()
             return deleted
+
+    async def get_failure(self, file_path: str) -> Optional[Dict]:
+        """Get the recorded extraction failure for a file path, if any."""
+        async with self._open() as conn:
+            conn.row_factory = aiosqlite.Row
+            cursor = await conn.cursor()
+            await cursor.execute(
+                "SELECT * FROM indexer_failures WHERE file_path = ?",
+                (file_path,),
+            )
+            row = await cursor.fetchone()
+            return dict(row) if row else None
+
+    async def record_failure(
+        self, file_path: str, file_size: int, modified_time: int, error: str
+    ) -> int:
+        """Record (or update) a metadata-extraction failure for a file.
+
+        ``attempts`` is incremented only while the file is unchanged
+        (same size + mtime); a changed file resets the counter so a
+        still-uploading file is treated as a fresh attempt each time.
+        Returns the resulting attempt count.
+        """
+        async with self._open() as conn:
+            conn.row_factory = aiosqlite.Row
+            cursor = await conn.cursor()
+            await cursor.execute(
+                "SELECT file_size, modified_time, attempts "
+                "FROM indexer_failures WHERE file_path = ?",
+                (file_path,),
+            )
+            row = await cursor.fetchone()
+            if (
+                row
+                and row["file_size"] == file_size
+                and row["modified_time"] == modified_time
+            ):
+                attempts = row["attempts"] + 1
+            else:
+                attempts = 1
+            await cursor.execute(
+                """
+                INSERT OR REPLACE INTO indexer_failures
+                    (file_path, file_size, modified_time, error, attempts, last_attempt)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (file_path, file_size, modified_time, error, attempts, int(time.time())),
+            )
+            await conn.commit()
+            return attempts
+
+    async def clear_failure(self, file_path: str) -> None:
+        """Remove any recorded extraction failure for a file path."""
+        async with self._open() as conn:
+            cursor = await conn.cursor()
+            await cursor.execute(
+                "DELETE FROM indexer_failures WHERE file_path = ?", (file_path,)
+            )
+            await conn.commit()
+
+    async def get_failure_paths(self) -> List[str]:
+        """Return all file paths currently in the failure cache."""
+        async with self._open() as conn:
+            cursor = await conn.cursor()
+            await cursor.execute("SELECT file_path FROM indexer_failures")
+            rows = await cursor.fetchall()
+            return [row[0] for row in rows]
 
     async def delete_orphaned_albums_and_artists(self) -> Tuple[int, int]:
         """Delete albums and artists that have no tracks referencing them.

--- a/packages/kalinka-plugin-localfiles/tests/test_indexer_failure_cache.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_indexer_failure_cache.py
@@ -142,6 +142,40 @@ async def test_cleanup_prunes_failures_for_deleted_files(indexer, monkeypatch):
     assert await fi.db_manager.get_failure(file_path) is None
 
 
+@pytest.mark.asyncio
+async def test_subsecond_mtime_change_is_retried(indexer, monkeypatch):
+    """A fixed-but-broken file re-written within the same integer second,
+    keeping the same size, must still be retried. The failure-cache key uses
+    nanosecond mtime (stat.st_mtime_ns), not truncated seconds, so it doesn't
+    collide on the second boundary (PR #67 review)."""
+    fi, music_dir = indexer
+    p = music_dir / "samesize.mp3"
+    file_path = _write(p, b"aaaaaaaa")  # 8 bytes
+
+    base_s = 1_700_000_000
+    os.utime(file_path, ns=(base_s * 10**9, base_s * 10**9 + 100_000_000))
+    if os.stat(file_path).st_mtime_ns % 10**9 == 0:
+        pytest.skip("filesystem lacks sub-second mtime resolution")
+
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        fi, "_extract_metadata",
+        lambda _p: (calls.__setitem__("n", calls["n"] + 1), None)[1],
+    )
+
+    # First pass: fails and is recorded with the +0.10s nanosecond mtime.
+    assert await fi.process_file(file_path) is None
+    assert calls["n"] == 1
+
+    # Same byte length, same integer second, different nanoseconds (+0.90s).
+    # Second-resolution keys would treat this as "unchanged" and skip it;
+    # the nanosecond key sees a change and retries.
+    p.write_bytes(b"bbbbbbbb")  # still 8 bytes
+    os.utime(file_path, ns=(base_s * 10**9, base_s * 10**9 + 900_000_000))
+    assert await fi.process_file(file_path) is None
+    assert calls["n"] == 2
+
+
 def test_mp3_without_id3_header_is_supported(monkeypatch):
     """A tagless MP3 must extract (duration only), not raise."""
     fi = FileIndexer.__new__(FileIndexer)  # no DB needed for this unit

--- a/packages/kalinka-plugin-localfiles/tests/test_indexer_failure_cache.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_indexer_failure_cache.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Tests for the indexer's broken-file handling (issue #63):
+
+  1. An MP3 with no ID3 header is a valid file and must still be indexed.
+  2. A file whose metadata can't be extracted is parked in a negative
+     cache and not re-read on every scan...
+  3. ...unless it changes (size/mtime), e.g. a still-uploading file, in
+     which case it is retried.
+  4. A later successful index clears the failure record.
+"""
+
+import os
+
+import pytest
+import pytest_asyncio
+
+from mutagen.id3 import ID3NoHeaderError
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.indexer import indexer as indexer_mod
+from kalinka_plugin_localfiles.indexer.indexer import FileIndexer
+from kalinka_plugin_localfiles.indexer.indexer_db import AsyncIndexerDb
+
+
+@pytest_asyncio.fixture
+async def indexer(tmp_path):
+    """A FileIndexer backed by a real (temporary) sqlite database."""
+    music_dir = tmp_path / "music"
+    music_dir.mkdir()
+    config = LocalFilesConfig(
+        music_folders=[str(music_dir)],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+        quiescence_seconds=0,  # skip the upload-quiescence sleep in tests
+    )
+    await init_db(config.db_path)
+    db = AsyncIndexerDb(config)
+    return FileIndexer(config, db), music_dir
+
+
+def _write(path, data=b"x"):
+    path.write_bytes(data)
+    return str(path)
+
+
+@pytest.mark.asyncio
+async def test_failed_file_is_parked_and_not_reread(indexer, monkeypatch):
+    fi, music_dir = indexer
+    file_path = _write(music_dir / "broken.mp3")
+
+    calls = {"n": 0}
+
+    def fake_extract(_path):
+        calls["n"] += 1
+        return None  # simulate extraction failure
+
+    monkeypatch.setattr(fi, "_extract_metadata", fake_extract)
+
+    # First pass: extraction runs, fails, and is recorded.
+    assert await fi.process_file(file_path) is None
+    assert calls["n"] == 1
+    failure = await fi.db_manager.get_failure(file_path)
+    assert failure is not None
+    assert failure["attempts"] == 1
+
+    # Second pass (file unchanged): served from the negative cache, the
+    # extractor is NOT invoked again — this is the "retry forever" fix.
+    assert await fi.process_file(file_path) is None
+    assert calls["n"] == 1
+    assert (await fi.db_manager.get_failure(file_path))["attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_changed_file_is_retried(indexer, monkeypatch):
+    fi, music_dir = indexer
+    p = music_dir / "uploading.mp3"
+    file_path = _write(p, b"partial")
+
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        fi, "_extract_metadata", lambda _p: (calls.__setitem__("n", calls["n"] + 1), None)[1]
+    )
+
+    assert await fi.process_file(file_path) is None
+    assert calls["n"] == 1
+
+    # File grows (still uploading) -> different size key -> retried, and the
+    # attempt counter resets rather than climbing.
+    _write(p, b"partial-but-bigger-now")
+    assert await fi.process_file(file_path) is None
+    assert calls["n"] == 2
+    assert (await fi.db_manager.get_failure(file_path))["attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_success_clears_failure(indexer, monkeypatch):
+    fi, music_dir = indexer
+    p = music_dir / "fixed.mp3"
+    file_path = _write(p, b"partial")
+
+    state = {"ok": False}
+
+    def fake_extract(_path):
+        if not state["ok"]:
+            return None
+        return {
+            "format": "audio/mpeg",
+            "duration": 123,
+            "title": "Fixed",
+            "artist": "Some Artist",
+            "album": "Some Album",
+        }
+
+    monkeypatch.setattr(fi, "_extract_metadata", fake_extract)
+
+    assert await fi.process_file(file_path) is None
+    assert await fi.db_manager.get_failure(file_path) is not None
+
+    # Upload completes: bump size so the cache key changes, then succeed.
+    state["ok"] = True
+    _write(p, b"complete-file-contents")
+    changes = await fi.process_file(file_path)
+    assert changes is not None and changes["tracks"]
+    assert await fi.db_manager.get_failure(file_path) is None
+    assert await fi.db_manager.get_track_by_path(file_path) is not None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_prunes_failures_for_deleted_files(indexer, monkeypatch):
+    fi, music_dir = indexer
+    p = music_dir / "gone.mp3"
+    file_path = _write(p)
+    monkeypatch.setattr(fi, "_extract_metadata", lambda _p: None)
+
+    await fi.process_file(file_path)
+    assert await fi.db_manager.get_failure(file_path) is not None
+
+    os.remove(file_path)
+    await fi.cleanup_stale_tracks()
+    assert await fi.db_manager.get_failure(file_path) is None
+
+
+def test_mp3_without_id3_header_is_supported(monkeypatch):
+    """A tagless MP3 must extract (duration only), not raise."""
+    fi = FileIndexer.__new__(FileIndexer)  # no DB needed for this unit
+
+    class FakeInfo:
+        length = 200.0
+
+    class FakeMP3:
+        def __init__(self, _path):
+            self.info = FakeInfo()
+
+    def fake_id3(*args):
+        if args:  # ID3(file_path) -> no header on disk
+            raise ID3NoHeaderError("no header")
+        return {}  # ID3() -> empty tag set fallback
+
+    monkeypatch.setattr(indexer_mod, "MP3", FakeMP3)
+    monkeypatch.setattr(indexer_mod, "ID3", fake_id3)
+
+    metadata = fi._extract_mp3_metadata("/music/no-tags.mp3", {"format": "audio/mpeg"})
+    assert metadata["duration"] == 200
+    assert "title" not in metadata
+    assert "artist" not in metadata


### PR DESCRIPTION
Fixes #63.

## Problem
Confirmed in the localfiles indexer. Two related bugs:

1. **Tagless MP3 treated as broken.** `ID3(file_path)` raises `ID3NoHeaderError` when an MP3 has no ID3 header — but such a file is perfectly valid, it just has no tags. Extraction failed for it entirely.
2. **Broken files retried forever.** When metadata extraction failed, `process_file` returned without writing any DB row. The "skip if unchanged" guard only matches files already in `tracks`, so on every scheduled rescan (every `scan_interval_minutes`) and every inotify event the file was re-read and failed again, logging endlessly — exactly the reported symptom.

## Fix
1. `ID3(file_path)` now falls back to an empty tag set on `ID3NoHeaderError`, so a tagless MP3 is indexed with a filename-derived title and Unknown Artist/Album. Genuinely corrupt audio (where `MP3()` itself throws) still goes down the failure path.
2. New `indexer_failures` negative cache, keyed on `file_path` + `(file_size, modified_time)`:
   - A stably broken file is parked and **skipped** on later scans.
   - A **still-uploading / partially written** file changes size or mtime between scans, so it keeps a different cache key and **is retried** until it stabilizes (the case raised in review).
   - The record is cleared on a later successful index, and pruned in `cleanup_stale_tracks` for files that get deleted.

## Tests
`tests/test_indexer_failure_cache.py` (5 tests): tagless-MP3 support, park-and-don't-reread, retry-on-change, clear-on-success, prune-on-delete. Full plugin suite passes except one pre-existing unrelated failure (`test_unified_tags` needs `sqlite_vec`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)