### PR TITLE
localfiles: purge & refuse files outside the configured folders (#60)

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -26,7 +26,12 @@ except ImportError:
     HAS_INOTIFY = False
 
 from ..config_model import LocalFilesConfig
-from ..utils.name_utils import album_folder_for_path, clean_display_name
+from ..utils.name_utils import (
+    album_folder_for_path,
+    clean_display_name,
+    expand_music_folders,
+    path_within_roots,
+)
 from ..worker_utils import set_proc_title
 from .id_generator import (
     generate_artist_id,
@@ -110,10 +115,10 @@ class FileIndexer:
     def __init__(self, config: LocalFilesConfig, db_manager: AsyncIndexerDb):
         self.config = config
         self.db_manager = db_manager
-        # Expand user (~) and resolve absolute paths for music folders
-        self.music_folders = [
-            str(Path(folder).expanduser().resolve()) for folder in config.music_folders
-        ]
+        # Expand user (~) and resolve absolute paths for music folders. This is
+        # the access boundary: only files under one of these are indexed, and
+        # cleanup_stale_tracks purges anything that falls outside them.
+        self.music_folders = expand_music_folders(config.music_folders)
         self.artwork_path = Path(config.artwork_path).expanduser().resolve()
         self.running = False
         self.lock = asyncio.Lock()
@@ -857,7 +862,16 @@ class FileIndexer:
             )
 
     async def cleanup_stale_tracks(self) -> Dict[str, int]:
-        """Remove entries for files that no longer exist in the file system"""
+        """Remove entries that are no longer valid for the file system.
+
+        A track is dropped when its file either no longer exists, or falls
+        outside the currently configured music folders. The latter handles a
+        changed folder config: when a parent folder is removed from the
+        config, its files are no longer accessible to this module and must be
+        purged so they aren't served or played. Because ``run_scan`` (and thus
+        this method) runs on startup, the cleanup happens immediately after a
+        restart with the new config.
+        """
         logger.debug("Checking for stale files in the database...")
         all_tracks = await self.db_manager.get_all_tracks()
         removed_tracks = 0
@@ -867,14 +881,23 @@ class FileIndexer:
                 logger.info(
                     f"File no longer exists, removing from database: {file_path}"
                 )
-                track_id = track["id"]
-                await self.db_manager.delete_track(track_id)
+                await self.db_manager.delete_track(track["id"])
+                removed_tracks += 1
+            elif not path_within_roots(file_path, self.music_folders):
+                logger.info(
+                    "File is outside the configured music folders, removing "
+                    f"from database: {file_path}"
+                )
+                await self.db_manager.delete_track(track["id"])
                 removed_tracks += 1
 
-        # Drop failure-cache rows for files that have since been deleted,
-        # so the cache doesn't accumulate entries for vanished files.
+        # Drop failure-cache rows for files that have since been deleted or
+        # moved out of the configured folders, so the cache doesn't accumulate
+        # entries for files this module no longer manages.
         for failed_path in await self.db_manager.get_failure_paths():
-            if not os.path.exists(failed_path):
+            if not os.path.exists(failed_path) or not path_within_roots(
+                failed_path, self.music_folders
+            ):
                 await self.db_manager.clear_failure(failed_path)
 
         removed_albums, removed_artists = (
@@ -962,9 +985,7 @@ async def _file_watcher_worker(config: LocalFilesConfig):
         return
 
     try:
-        music_folders = [
-            str(Path(folder).expanduser().resolve()) for folder in config.music_folders
-        ]
+        music_folders = expand_music_folders(config.music_folders)
         logger.info(f"Starting file watcher for folders: {music_folders}")
 
         try:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -281,6 +281,16 @@ class FileIndexer:
 
     async def process_file(self, file_path: str) -> Optional[Dict[str, Optional[str]]]:
         """Process a music file and update the database. Returns changed items IDs."""
+        # Access boundary: never index a file whose canonical path escapes the
+        # configured music folders — e.g. a symlink sitting under a watched
+        # folder that resolves elsewhere. Enforced here, using the same
+        # symlink-resolving check as cleanup_stale_tracks, so the scan and the
+        # cleanup agree on what is in scope; otherwise such a file would be
+        # indexed on every scan and purged again, churning the database.
+        if not path_within_roots(file_path, self.music_folders):
+            logger.debug(f"Skipping file outside configured folders: {file_path}")
+            return None
+
         try:
             stat = os.stat(file_path)
         except FileNotFoundError:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
@@ -85,9 +85,11 @@ class LocalFilesInputModule(InputModule):
         self.db_manager = db_manager
         self.artwork_path = Path(config.artwork_path).expanduser().resolve()
         # Access boundary: only files under a configured music folder may be
-        # served / played. Resolved once here; the module is reconstructed when
-        # the config changes, so a folder dropped from the config stops being
-        # playable even before the indexer purges its rows.
+        # served / played. Captured once here, so it is fixed for the lifetime
+        # of this module instance — a live config edit via PUT /server/config
+        # does not re-run setup(), so the new boundary only takes effect on the
+        # next restart / re-setup (at which point the indexer also purges the
+        # now-out-of-scope rows).
         self._music_folders = expand_music_folders(config.music_folders)
         self._search_request_queue = search_request_queue
         self._search_response_queue = search_response_queue
@@ -606,9 +608,13 @@ class LocalFilesInputModule(InputModule):
                                 f"Track path is outside the configured music "
                                 f"folders: {track_path}"
                             )
-                        if not os.access(track_path, os.R_OK):
+                        if not os.path.exists(track_path):
                             raise FileNotFoundError(
-                                f"Track file is not accessible: {track_path}"
+                                f"Track file no longer exists: {track_path}"
+                            )
+                        if not os.access(track_path, os.R_OK):
+                            raise PermissionError(
+                                f"Track file is not readable: {track_path}"
                             )
                         return TrackUrl(url=f"file://{track_path}", format=track_format)
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
@@ -32,6 +32,7 @@ from kalinka_plugin_sdk.datamodel import (
 )
 from .utils.id_generator import generate_playlist_id
 from .utils.image_utils import create_playlist_cover_collage
+from .utils.name_utils import expand_music_folders, path_within_roots
 from .input_module_db import LocalFilesInputModuleDb
 
 logger = logging.getLogger(__name__.split(".")[-1])
@@ -83,6 +84,11 @@ class LocalFilesInputModule(InputModule):
         self.config = config
         self.db_manager = db_manager
         self.artwork_path = Path(config.artwork_path).expanduser().resolve()
+        # Access boundary: only files under a configured music folder may be
+        # served / played. Resolved once here; the module is reconstructed when
+        # the config changes, so a folder dropped from the config stops being
+        # playable even before the indexer purges its rows.
+        self._music_folders = expand_music_folders(config.music_folders)
         self._search_request_queue = search_request_queue
         self._search_response_queue = search_response_queue
         self._search_lock = asyncio.Lock()
@@ -587,9 +593,23 @@ class LocalFilesInputModule(InputModule):
                 track = track_dict[track_id_str]
                 track_metadata = self._create_track_metadata(track)
 
-                # Create a link retriever function for this track
+                # Create a link retriever function for this track. It validates
+                # access at play time: the file must still be inside a
+                # configured music folder and readable. Otherwise it raises, and
+                # the play queue surfaces the track as unavailable rather than
+                # handing the player a dead/forbidden path. This guards the
+                # window between a folder-config change and the next index scan.
                 def create_link_retriever(track_path, track_format):
                     async def link_retriever():
+                        if not path_within_roots(track_path, self._music_folders):
+                            raise PermissionError(
+                                f"Track path is outside the configured music "
+                                f"folders: {track_path}"
+                            )
+                        if not os.access(track_path, os.R_OK):
+                            raise FileNotFoundError(
+                                f"Track file is not accessible: {track_path}"
+                            )
                         return TrackUrl(url=f"file://{track_path}", format=track_format)
 
                     return link_retriever

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/utils/name_utils.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/utils/name_utils.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 import os
 import re
 import unicodedata
+from collections.abc import Iterable
+from pathlib import Path
 
 _LEADING_TRAILING_PUNCT_RE = re.compile(r"^[\-_.,/ \t]+|[\-_.,/ \t]+$")
 _WHITESPACE_RUN_RE = re.compile(r"\s+")
@@ -70,6 +72,52 @@ def album_folder_for_path(file_path: str) -> str:
     if _DISC_SUBDIR_RE.match(name):
         return os.path.dirname(parent)
     return parent
+
+
+def expand_music_folders(folders: Iterable[str]) -> list[str]:
+    """Expand ``~`` and resolve each configured music folder to a canonical
+    absolute path. The indexer stores file paths derived from these (so they
+    are already canonical); resolving the roots the same way lets
+    :func:`path_within_roots` compare them directly.
+    """
+    resolved: list[str] = []
+    for folder in folders:
+        if not folder:
+            continue
+        try:
+            resolved.append(str(Path(folder).expanduser().resolve()))
+        except (OSError, RuntimeError, ValueError):
+            continue
+    return resolved
+
+
+def path_within_roots(file_path: str, roots: Iterable[str]) -> bool:
+    """Return True if ``file_path`` lives inside one of ``roots``.
+
+    ``roots`` are expected to be canonical absolute paths (see
+    :func:`expand_music_folders`). Membership is tested per path component,
+    so ``/Music`` does not match a sibling ``/Music2``. A path equal to a
+    root is considered inside it.
+
+    This is the access boundary for the local-files module: only files under
+    a configured music folder may be indexed or played. When the folder
+    config changes, entries that fall outside the new roots are no longer
+    accessible and must be purged / refused.
+    """
+    if not file_path:
+        return False
+    try:
+        target = Path(file_path).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+    for root in roots:
+        try:
+            root_path = Path(root)
+        except (OSError, ValueError):
+            continue
+        if target == root_path or root_path in target.parents:
+            return True
+    return False
 
 
 def normalize_for_id(name: str) -> str:

--- a/packages/kalinka-plugin-localfiles/tests/test_folder_config_cleanup.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_folder_config_cleanup.py
@@ -116,6 +116,30 @@ async def test_failure_cache_rows_outside_config_are_dropped(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_symlink_escaping_roots_is_not_indexed(tmp_path):
+    # A symlink physically under a configured folder but resolving outside it
+    # must not be indexed — otherwise scan_folder would add it and
+    # cleanup_stale_tracks (which resolves symlinks) would purge it on every
+    # scan, churning the DB.
+    music = tmp_path / "music"
+    outside = tmp_path / "outside"
+    music.mkdir()
+    outside.mkdir()
+    real = outside / "real.mp3"
+    real.write_bytes(b"x")
+    link = music / "link.mp3"
+    link.symlink_to(real)
+
+    fi, _ = _make_indexer(tmp_path, [music])
+    await init_db(fi.db_manager.db_path)
+    fi._extract_metadata = lambda _p: _meta(artist="A", album="AA", title="a")
+    result = await fi.process_file(str(link))
+
+    assert result is None
+    assert await fi.db_manager.get_all_tracks() == []
+
+
+@pytest.mark.asyncio
 async def test_missing_file_inside_config_still_purged(tmp_path):
     keep = tmp_path / "keep"
     fi, _ = _make_indexer(tmp_path, [keep])

--- a/packages/kalinka-plugin-localfiles/tests/test_folder_config_cleanup.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_folder_config_cleanup.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Tests for issue #60: a changed folder config must purge the database.
+
+The local-files module may only access files under the parent folders named
+in its config. When a folder is dropped from ``music_folders``, the rows for
+its files must be removed on the next startup scan (they exist on disk but are
+no longer in scope), and a play-time URL request for such a track must fail so
+the play queue can flag it unavailable instead of handing the player a path the
+module no longer manages.
+"""
+
+import os
+
+import pytest
+import pytest_asyncio
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.indexer.indexer import FileIndexer
+from kalinka_plugin_localfiles.indexer.indexer_db import AsyncIndexerDb
+from kalinka_plugin_localfiles.utils.name_utils import (
+    expand_music_folders,
+    path_within_roots,
+)
+
+
+def _meta(**over):
+    base = {"format": "audio/mpeg", "duration": 100}
+    base.update(over)
+    return base
+
+
+async def _index_file(fi, path, **meta):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x")
+    fi._extract_metadata = lambda _p, m=meta: _meta(**m)
+    await fi.process_file(str(path))
+
+
+def _make_indexer(tmp_path, folders):
+    config = LocalFilesConfig(
+        music_folders=[str(f) for f in folders],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+        quiescence_seconds=0,
+    )
+    return FileIndexer(config, AsyncIndexerDb(config)), config
+
+
+# --- path_within_roots unit coverage ---------------------------------------
+
+
+def test_path_within_roots_matches_by_component(tmp_path):
+    root = tmp_path / "Music"
+    sibling = tmp_path / "Music2"
+    root.mkdir()
+    sibling.mkdir()
+    roots = expand_music_folders([str(root)])
+
+    assert path_within_roots(str(root / "a" / "song.mp3"), roots)
+    assert path_within_roots(str(root), roots)  # the root itself
+    # A sibling that merely shares a name prefix must NOT match.
+    assert not path_within_roots(str(sibling / "song.mp3"), roots)
+    assert not path_within_roots(str(tmp_path / "elsewhere.mp3"), roots)
+    assert not path_within_roots("", roots)
+
+
+# --- indexer cleanup on a changed folder config ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dropped_folder_tracks_are_purged_on_scan(tmp_path):
+    keep = tmp_path / "keep"
+    drop = tmp_path / "drop"
+
+    # Index two files under two folders with the original config.
+    fi, _ = _make_indexer(tmp_path, [keep, drop])
+    await init_db(fi.db_manager.db_path)
+    await _index_file(fi, keep / "a.mp3", artist="A", album="AA", title="a")
+    await _index_file(fi, drop / "b.mp3", artist="B", album="BB", title="b")
+    assert len(await fi.db_manager.get_all_tracks()) == 2
+
+    # Restart with the "drop" folder removed from config. The file still
+    # exists on disk, but is now out of scope.
+    fi2, _ = _make_indexer(tmp_path, [keep])
+    removed = await fi2.cleanup_stale_tracks()
+
+    assert removed["tracks"] == 1
+    paths = [t["file_path"] for t in await fi2.db_manager.get_all_tracks()]
+    assert paths == [str((keep / "a.mp3"))]
+    # The orphaned album/artist for the dropped track are gone too.
+    assert removed["albums"] >= 1
+    assert removed["artists"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_failure_cache_rows_outside_config_are_dropped(tmp_path):
+    keep = tmp_path / "keep"
+    drop = tmp_path / "drop"
+    keep.mkdir()
+    drop.mkdir()
+    inside = keep / "ok.mp3"
+    outside = drop / "bad.mp3"
+    inside.write_bytes(b"x")
+    outside.write_bytes(b"x")
+
+    fi, _ = _make_indexer(tmp_path, [keep])
+    await init_db(fi.db_manager.db_path)
+    await fi.db_manager.record_failure(str(inside), 1, 1, "boom")
+    await fi.db_manager.record_failure(str(outside), 1, 1, "boom")
+
+    await fi.cleanup_stale_tracks()
+
+    remaining = await fi.db_manager.get_failure_paths()
+    assert remaining == [str(inside)]
+
+
+@pytest.mark.asyncio
+async def test_missing_file_inside_config_still_purged(tmp_path):
+    keep = tmp_path / "keep"
+    fi, _ = _make_indexer(tmp_path, [keep])
+    await init_db(fi.db_manager.db_path)
+    path = keep / "gone.mp3"
+    await _index_file(fi, path, artist="A", album="AA", title="a")
+    os.remove(path)
+
+    removed = await fi.cleanup_stale_tracks()
+    assert removed["tracks"] == 1
+    assert await fi.db_manager.get_all_tracks() == []

--- a/packages/kalinka-plugin-localfiles/tests/test_play_access_validation.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_play_access_validation.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Issue #60 (play side): a track's link_retriever must validate access.
+
+The play queue calls ``link_retriever()`` to get a stream URL and treats any
+exception as "track unavailable". A local-files track whose file has moved out
+of the configured music folders, or is no longer readable, must therefore raise
+rather than return a ``file://`` URL the player can't use.
+"""
+
+import pytest
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.localfiles import LocalFilesInputModule
+
+
+class _FakeDb:
+    def __init__(self, track):
+        self._track = track
+
+    def is_good(self):
+        return True
+
+    def get_tracks_by_ids(self, track_ids):
+        return [self._track] if self._track["id"] in track_ids else []
+
+    def get_album_by_id(self, album_id):
+        # No artwork on disk in these tests; None keeps the cover lookup quiet.
+        return None
+
+
+def _module(tmp_path, music_folders, track):
+    config = LocalFilesConfig(
+        music_folders=[str(f) for f in music_folders],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+    )
+    return LocalFilesInputModule(config, _FakeDb(track))
+
+
+def _track(file_path):
+    return {
+        "id": "track_1",
+        "album_id": "album_1",
+        "artist_id": "artist_1",
+        "album_title": "Album",
+        "artist_name": "Artist",
+        "title": "Song",
+        "duration": 100,
+        "format": "audio/mpeg",
+        "file_path": str(file_path),
+    }
+
+
+@pytest.mark.asyncio
+async def test_link_retriever_returns_url_for_in_config_file(tmp_path):
+    music = tmp_path / "music"
+    music.mkdir()
+    path = music / "song.mp3"
+    path.write_bytes(b"x")
+
+    module = _module(tmp_path, [music], _track(path))
+    [info] = await module.get_track_info(["track_1"])
+    url = await info.link_retriever()
+    assert url.url == f"file://{path}"
+    assert url.format == "audio/mpeg"
+
+
+@pytest.mark.asyncio
+async def test_link_retriever_raises_for_out_of_config_file(tmp_path):
+    music = tmp_path / "music"
+    other = tmp_path / "other"
+    music.mkdir()
+    other.mkdir()
+    path = other / "song.mp3"
+    path.write_bytes(b"x")  # the file exists, but is out of scope
+
+    module = _module(tmp_path, [music], _track(path))
+    [info] = await module.get_track_info(["track_1"])
+    with pytest.raises(PermissionError):
+        await info.link_retriever()
+
+
+@pytest.mark.asyncio
+async def test_link_retriever_raises_for_missing_file(tmp_path):
+    music = tmp_path / "music"
+    music.mkdir()
+    path = music / "song.mp3"  # in config, but never created
+
+    module = _module(tmp_path, [music], _track(path))
+    [info] = await module.get_track_info(["track_1"])
+    with pytest.raises(FileNotFoundError):
+        await info.link_retriever()


### PR DESCRIPTION
Fixes #60.

## Problem
`cleanup_stale_tracks` only removed DB entries whose file no longer existed on disk (`os.path.exists`). When a folder was dropped from `music_folders`, its files still existed, so their rows lingered in the index and stayed playable. The folder config and the database drifted out of sync.

## Changes
- **Startup purge** ([indexer.py](../blob/fix/folder-config-db-cleanup/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py)): `cleanup_stale_tracks` now also drops tracks (and their orphaned albums/artists and failure-cache rows) that fall outside the currently configured music folders. It runs inside `run_scan()`, which fires on startup, so a changed config is reconciled immediately on the next restart scan.
- **Play-time validation** ([localfiles.py](../blob/fix/folder-config-db-cleanup/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py)): the `link_retriever` returned by `get_track_info` now raises `PermissionError` if a track's path is outside the configured folders, or `FileNotFoundError` if it isn't readable, before returning a `file://` URL. The play queue already treats a raising `link_retriever()` as "track unavailable", so this is a clean error signal. It also closes the window between a config change and the next index scan.
- **Shared helpers** ([name_utils.py](../blob/fix/folder-config-db-cleanup/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/utils/name_utils.py)): `expand_music_folders` and `path_within_roots` centralise the expand/resolve and containment logic so the indexer, file watcher, and input module enforce the same access boundary. Containment is tested per path component, so `/Music` doesn't match a sibling `/Music2`.

## Tests
- `test_folder_config_cleanup.py` — dropped-folder purge, failure-cache purge, missing-file purge, and `path_within_roots` (including the `/Music` vs `/Music2` edge).
- `test_play_access_validation.py` — `link_retriever` returns a URL for in-config files and raises for out-of-config / missing files.

All 7 new tests pass. The rest of the suite is green except two failures (`test_va_coalescing.py`, `test_unified_tags.py`) confirmed pre-existing on `main` and unrelated to this change.

## Out of scope
Stale CLAP/FTS rows for purged tracks: out-of-config tracks are removed through the same `delete_track` path as the existing deleted-file cleanup, so this introduces no new inconsistency — any embedding-orphan handling applies equally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)