### PR TITLE
server: set up plugins concurrently to cut startup latency

### DIFF
--- a/packages/kalinka-server/src/kalinka_server/player_setup.py
+++ b/packages/kalinka-server/src/kalinka_server/player_setup.py
@@ -4,7 +4,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from importlib.metadata import entry_points
-from typing import Any, Dict, Generator, Mapping, MutableMapping
+from typing import Any, Generator, Mapping, MutableMapping
 
 from kalinka_eventbus import EventBus
 from kalinka_plugin_sdk import API_VERSION, DeviceVolume, ModuleHealthState
@@ -439,7 +439,7 @@ class PreparedModuleCollection:
             if isinstance(result, BaseException):
                 logger.error(
                     f"Failed to setup plugin {plugin_name}: {result}",
-                    exc_info=result,
+                    exc_info=(type(result), result, result.__traceback__),
                 )
                 entry["error"] = str(result)
             elif result is not None:

--- a/packages/kalinka-server/src/kalinka_server/player_setup.py
+++ b/packages/kalinka-server/src/kalinka_server/player_setup.py
@@ -1,9 +1,10 @@
+import asyncio
 import enum
 import logging
 import os
 from dataclasses import dataclass, field
 from importlib.metadata import entry_points
-from typing import Any, AsyncGenerator, Dict, Generator, Mapping, MutableMapping
+from typing import Any, Dict, Generator, Mapping, MutableMapping
 
 from kalinka_eventbus import EventBus
 from kalinka_plugin_sdk import API_VERSION, DeviceVolume, ModuleHealthState
@@ -358,21 +359,44 @@ class PreparedModuleCollection:
     async def _scan_and_setup_plugins_from_entry_points(
         self,
         overrides: MutableMapping[str, Any],
-    ) -> AsyncGenerator[tuple[str, PreparedPlugin], None]:
-        """Scan for installed plugins using entry points and setup those matching the specified type."""
+    ) -> list[tuple[str, PreparedPlugin]]:
+        """Scan for installed plugins and set them up, overlapping the slow
+        ``setup()`` calls so startup is gated by the slowest plugin rather than
+        the sum of all of them.
 
+        A plugin's ``setup()`` can block for many seconds (a network login, a
+        web-bundle download, spawning subprocesses). Awaiting them one after
+        another — as this used to — serialised every plugin behind the slowest
+        one and delayed the server from accepting connections. We instead fan
+        the ``setup()`` calls out with ``asyncio.gather``.
+
+        The override-mutating work stays sequential to avoid races on the
+        shared ``overrides`` mapping and its on-disk persistence: per-plugin
+        config building and one-shot consumption run *before* the fan-out, and
+        reconciliation runs *after* it. Plugins are returned in entry-point
+        order regardless of which finished first, so the default-module choice
+        (first enabled) stays deterministic.
+        """
+
+        # Phase 1 (sequential, no awaiting): build each plugin's config and
+        # context and consume any armed one-shot overrides before the plugin
+        # acts on them. Touching ``overrides`` here, single-threaded, keeps the
+        # shared mapping race-free.
+        prepared: list[dict[str, Any]] = []
         for plugin_name, plugin_class in self._scan_entry_points():
-
             logger.info(f"Found plugin: {plugin_name}")
-            prepared_module = None
-            error_message = None
-            config = None
-            plugin_context = None
-
+            entry: dict[str, Any] = {
+                "name": plugin_name,
+                "class": plugin_class,
+                "config": None,
+                "context": None,
+                "error": None,
+            }
             try:
                 config = self._build_module_config(
                     plugin_name, plugin_class, overrides
                 )
+                entry["config"] = config
                 # Reset armed one-shot triggers on disk *before* the plugin
                 # acts, leaving the armed value on ``config`` for this boot.
                 # Only when the module will actually run (setup() is skipped
@@ -382,40 +406,77 @@ class PreparedModuleCollection:
                     self._consume_one_shot_overrides(
                         plugin_name, plugin_class, config, overrides
                     )
-                plugin_context = self._make_plugin_context(
+                entry["context"] = self._make_plugin_context(
                     plugin_name, plugin_class, config
                 )
-                prepared_module = await PreparedPlugin.setup(plugin_class, plugin_context)
-
             except Exception as e:
-                logger.error(f"Failed to setup plugin {plugin_name}: {e}", exc_info=True)
-                error_message = str(e)
+                logger.error(
+                    f"Failed to prepare plugin {plugin_name}: {e}", exc_info=True
+                )
+                entry["error"] = str(e)
+            prepared.append(entry)
 
-                # Create a PreparedPlugin with error state even if setup failed
-                if config is not None and plugin_context is not None:
-                    prepared_module = PreparedPlugin(
-                        plugin_class=plugin_class,
-                        plugin_instance=None,
-                        health_state=ModuleHealthState.ERROR,
-                        plugin_context=plugin_context,
-                        interface=None,
-                        error_message=error_message,
-                    )
+        # Phase 2 (concurrent): run the slow setup() calls in parallel. Entries
+        # that failed to build a context in phase 1 are skipped here and handled
+        # as errors below.
+        async def _do_setup(entry: dict[str, Any]):
+            if entry["context"] is None:
+                return None
+            return await PreparedPlugin.setup(entry["class"], entry["context"])
+
+        results = await asyncio.gather(
+            *(_do_setup(entry) for entry in prepared),
+            return_exceptions=True,
+        )
+
+        # Phase 3 (sequential): fold results back into PreparedPlugins,
+        # reconcile consumed overrides, and emit in entry-point order.
+        out: list[tuple[str, PreparedPlugin]] = []
+        for entry, result in zip(prepared, results):
+            plugin_name = entry["name"]
+            prepared_module: PreparedPlugin | None = None
+
+            if isinstance(result, BaseException):
+                logger.error(
+                    f"Failed to setup plugin {plugin_name}: {result}",
+                    exc_info=result,
+                )
+                entry["error"] = str(result)
+            elif result is not None:
+                prepared_module = result
+
+            # Create a PreparedPlugin with error state even if setup failed,
+            # as long as we got far enough to have a config + context.
+            if (
+                prepared_module is None
+                and entry["config"] is not None
+                and entry["context"] is not None
+            ):
+                prepared_module = PreparedPlugin(
+                    plugin_class=entry["class"],
+                    plugin_instance=None,
+                    health_state=ModuleHealthState.ERROR,
+                    plugin_context=entry["context"],
+                    interface=None,
+                    error_message=entry["error"],
+                )
 
             # Reconcile overrides regardless of READY/ERROR state: a
             # plugin that crashed midway through setup may still have
             # consumed an override before crashing (e.g. localfiles
             # purges the DB before raising) and we don't want that
             # consumption to repeat on every restart.
-            if config is not None:
+            if entry["config"] is not None:
                 changed = self._reconcile_consumed_overrides(
-                    plugin_name, plugin_class, config, overrides
+                    plugin_name, entry["class"], entry["config"], overrides
                 )
                 if changed:
                     self.overrides_dirty = True
 
             if prepared_module is not None:
-                yield plugin_name, prepared_module
+                out.append((plugin_name, prepared_module))
+
+        return out
 
     def _make_plugin_context(
         self,
@@ -537,10 +598,10 @@ class PreparedModuleCollection:
         self.overrides_file = overrides_file
         input_modules = {}
         devices = {}
-        async for (
+        for (
             plugin_name,
             prepared_plugin,
-        ) in self._scan_and_setup_plugins_from_entry_points(overrides):
+        ) in await self._scan_and_setup_plugins_from_entry_points(overrides):
             plugin_type = prepared_plugin.plugin_class.PLUGIN_TYPE
             if plugin_type == PluginType.INPUT_MODULE:
                 input_modules[plugin_name] = prepared_plugin

--- a/packages/kalinka-server/tests/test_plugin_setup_concurrency.py
+++ b/packages/kalinka-server/tests/test_plugin_setup_concurrency.py
@@ -29,9 +29,37 @@ class _Config(ModuleConfig):
     enabled: bool = Field(default=True)
 
 
-def _make_plugin(plugin_id: str, *, delay: float = 0.0, fail: bool = False):
+class _Barrier:
+    """Minimal asyncio barrier (``asyncio.Barrier`` is 3.11+, we target 3.8).
+
+    The event loop is single-threaded, so the unguarded counter bump is safe.
+    Each waiter records its arrival; the last to arrive releases everyone. If
+    plugin setup runs sequentially the first (and only) waiter never sees the
+    others arrive and blocks forever — the test's ``wait_for`` turns that
+    deadlock into a clean, deterministic failure instead of a timing flake.
+    """
+
+    def __init__(self, parties: int):
+        self._parties = parties
+        self._count = 0
+        self._released = asyncio.Event()
+
+    async def wait(self):
+        self._count += 1
+        if self._count >= self._parties:
+            self._released.set()
+        await self._released.wait()
+
+
+def _make_plugin(
+    plugin_id: str,
+    *,
+    delay: float = 0.0,
+    fail: bool = False,
+    barrier: "_Barrier | None" = None,
+):
     """Build a fake input-module plugin class whose setup() optionally sleeps
-    (to expose serialisation) and/or raises."""
+    (to expose serialisation), waits on a shared barrier, and/or raises."""
 
     started: list[float] = []
 
@@ -43,6 +71,8 @@ def _make_plugin(plugin_id: str, *, delay: float = 0.0, fail: bool = False):
 
         async def setup(self, context):
             started.append(time.monotonic())
+            if barrier is not None:
+                await barrier.wait()
             if delay:
                 await asyncio.sleep(delay)
             if fail:
@@ -72,18 +102,24 @@ def _collection(plugins) -> PreparedModuleCollection:
 
 @pytest.mark.asyncio
 async def test_setups_run_concurrently():
-    # Three plugins that each sleep 0.2s. Serialised that is ~0.6s; concurrent
-    # is ~0.2s. Assert well under the serial sum.
-    plugins = [_make_plugin(f"p{i}", delay=0.2) for i in range(3)]
+    # Prove overlap with a barrier rather than a wall-clock threshold: every
+    # plugin must enter setup() before any is allowed to leave. If setup were
+    # serialised the first plugin would block at the barrier forever (the
+    # others never start), and wait_for would trip — no timing heuristic, so
+    # no CI flake.
+    barrier = _Barrier(3)
+    plugins = [_make_plugin(f"p{i}", barrier=barrier) for i in range(3)]
     collection = _collection(plugins)
 
-    start = time.monotonic()
-    result = await collection._scan_and_setup_plugins_from_entry_points({})
-    elapsed = time.monotonic() - start
+    result = await asyncio.wait_for(
+        collection._scan_and_setup_plugins_from_entry_points({}), timeout=5
+    )
 
     assert [name for name, _ in result] == ["p0", "p1", "p2"]
     assert all(p.health_state == ModuleHealthState.READY for _, p in result)
-    assert elapsed < 0.45, f"setup did not overlap (took {elapsed:.2f}s)"
+    # Every plugin reached setup() — the barrier could only release if all
+    # three were in flight at once.
+    assert all(len(p._started) == 1 for p in plugins)
 
 
 @pytest.mark.asyncio

--- a/packages/kalinka-server/tests/test_plugin_setup_concurrency.py
+++ b/packages/kalinka-server/tests/test_plugin_setup_concurrency.py
@@ -1,0 +1,134 @@
+"""Tests for concurrent plugin setup in
+``PreparedModuleCollection._scan_and_setup_plugins_from_entry_points``.
+
+A slow plugin ``setup()`` (network login, web-bundle download, subprocess
+spawn) used to serialise every other plugin behind it, delaying the server
+from accepting connections. Setup now fans out with ``asyncio.gather``. These
+tests pin down that the calls overlap, that results come back in entry-point
+order (so the default-module choice stays deterministic), and that one
+plugin's failure is isolated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+from pydantic import Field
+
+from kalinka_plugin_sdk.module_config import ModuleConfig
+from kalinka_plugin_sdk.plugin import PluginBase, PluginType
+from kalinka_plugin_sdk import ModuleHealthState
+
+from kalinka_server.player_setup import PreparedModuleCollection
+
+
+class _Config(ModuleConfig):
+    enabled: bool = Field(default=True)
+
+
+def _make_plugin(plugin_id: str, *, delay: float = 0.0, fail: bool = False):
+    """Build a fake input-module plugin class whose setup() optionally sleeps
+    (to expose serialisation) and/or raises."""
+
+    started: list[float] = []
+
+    class _Plugin(PluginBase):
+        PLUGIN_ID = plugin_id
+        REQUIRES_SDK = "1.0"
+        PLUGIN_TYPE = PluginType.INPUT_MODULE
+        CONFIG_MODEL = _Config
+
+        async def setup(self, context):
+            started.append(time.monotonic())
+            if delay:
+                await asyncio.sleep(delay)
+            if fail:
+                raise RuntimeError(f"{plugin_id} boom")
+
+        def get_interface(self):
+            return None
+
+    _Plugin._started = started  # type: ignore[attr-defined]
+    return _Plugin
+
+
+def _collection(plugins) -> PreparedModuleCollection:
+    """A collection whose entry-point scan yields the given plugin classes and
+    whose plugin-context builder is stubbed (we only exercise the setup flow)."""
+    collection = PreparedModuleCollection()
+    collection._scan_entry_points = lambda: iter(  # type: ignore[method-assign]
+        [(p.PLUGIN_ID, p) for p in plugins]
+    )
+    # PreparedPlugin.setup reads plugin_context.config.enabled; the rest of the
+    # real context (playqueue/eventbus) is irrelevant to the setup flow here.
+    collection._make_plugin_context = (  # type: ignore[method-assign]
+        lambda name, cls, config: SimpleNamespace(config=config)
+    )
+    return collection
+
+
+@pytest.mark.asyncio
+async def test_setups_run_concurrently():
+    # Three plugins that each sleep 0.2s. Serialised that is ~0.6s; concurrent
+    # is ~0.2s. Assert well under the serial sum.
+    plugins = [_make_plugin(f"p{i}", delay=0.2) for i in range(3)]
+    collection = _collection(plugins)
+
+    start = time.monotonic()
+    result = await collection._scan_and_setup_plugins_from_entry_points({})
+    elapsed = time.monotonic() - start
+
+    assert [name for name, _ in result] == ["p0", "p1", "p2"]
+    assert all(p.health_state == ModuleHealthState.READY for _, p in result)
+    assert elapsed < 0.45, f"setup did not overlap (took {elapsed:.2f}s)"
+
+
+@pytest.mark.asyncio
+async def test_order_preserved_regardless_of_completion():
+    # The last plugin finishes first, the first finishes last — result order
+    # must still follow entry-point order so "first enabled" is deterministic.
+    plugins = [
+        _make_plugin("slow", delay=0.3),
+        _make_plugin("medium", delay=0.15),
+        _make_plugin("fast", delay=0.01),
+    ]
+    collection = _collection(plugins)
+
+    result = await collection._scan_and_setup_plugins_from_entry_points({})
+
+    assert [name for name, _ in result] == ["slow", "medium", "fast"]
+
+
+@pytest.mark.asyncio
+async def test_one_failure_is_isolated():
+    plugins = [
+        _make_plugin("ok1"),
+        _make_plugin("broken", fail=True),
+        _make_plugin("ok2"),
+    ]
+    collection = _collection(plugins)
+
+    result = await collection._scan_and_setup_plugins_from_entry_points({})
+    by_name = dict(result)
+
+    assert [name for name, _ in result] == ["ok1", "broken", "ok2"]
+    assert by_name["ok1"].health_state == ModuleHealthState.READY
+    assert by_name["ok2"].health_state == ModuleHealthState.READY
+    assert by_name["broken"].health_state == ModuleHealthState.ERROR
+    assert "boom" in (by_name["broken"].error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_disabled_plugin_is_not_set_up():
+    plugin = _make_plugin("off")
+    collection = _collection([plugin])
+    overrides = {"input_modules.off.enabled": False}
+
+    result = await collection._scan_and_setup_plugins_from_entry_points(overrides)
+    by_name = dict(result)
+
+    assert by_name["off"].health_state == ModuleHealthState.DISABLED
+    assert plugin._started == []  # setup() never called


### PR DESCRIPTION
## Problem
The server takes a long time to start accepting connections. Plugin setup runs in `create_app()` via `await setup(...)` **before** uvicorn binds the socket, and `_scan_and_setup_plugins_from_entry_points` awaited each plugin's `setup()` **sequentially**. So the server only starts listening once *every* plugin has finished setting up, one after another — a single plugin that blocks for tens of seconds stalls the whole server behind it.

### Diagnosis (from a real startup log)
- `localfiles` setup returned in ~0.3s (it just spawns its subprocesses).
- The next plugin, `qobuz`, took **~34s** before its first log line — its `get_client()` synchronously downloads and regex-parses the Qobuz web bundle on the event loop, on every boot.
- The MusicBrainz/Deezer log lines seen during that window come from the `localfiles` **enricher subprocess** running concurrently; their logs are forwarded into the same console. Because qobuz's stall is network I/O (GIL released), those forwarded logs keep printing during it — which made it *look* like localfiles was the blocker. It isn't.

This PR addresses the amplifier — serialized setup — so one slow plugin no longer gates the others. (The qobuz bundle re-download is a separate, plugin-local issue.)

## Change
`_scan_and_setup_plugins_from_entry_points` now fans the slow `setup()` calls out with `asyncio.gather`, so total startup ≈ the slowest plugin instead of the sum.

Three phases keep it correct:
1. **Sequential, no awaiting** — build each plugin's config + context and consume armed one-shot overrides. Touching the shared `overrides` mapping single-threaded keeps it race-free.
2. **Concurrent** — run the `setup()` calls in parallel (`return_exceptions=True`).
3. **Sequential** — fold results back into `PreparedPlugin`s, reconcile consumed overrides, and emit in **entry-point order** so the default-module choice (first enabled) stays deterministic.

A failing plugin is isolated to an `ERROR` state (with its message) instead of breaking the others, matching the previous per-plugin try/except behavior.

## Tests
New `tests/test_plugin_setup_concurrency.py`:
- setups overlap (3×0.2s sleeps complete in well under the 0.6s serial sum),
- result order follows entry-point order regardless of completion order,
- one plugin's failure is isolated (others still READY),
- a disabled plugin is not set up.

Existing `test_overrides_reconciliation.py` still passes. The rest of the server suite passes except one pre-existing, unrelated `test_state_restore` failure in `PlayQueueImpl.restore_from_state` (a `_track_player` attribute drift; this PR doesn't touch playqueue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)