### PR TITLE
Clarify time units in settings labels

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
@@ -336,8 +336,12 @@ class LocalFilesConfig(ModuleConfig):
     )
     scan_interval_minutes: int = Field(
         default=15,
-        title="Scan interval",
-        json_schema_extra={"constraints": {"unit": "min"}, **_SIMPLE},
+        title="Scan interval (minutes)",
+        json_schema_extra={
+            "help": "How often to rescan the library, in minutes",
+            "constraints": {"unit": "min"},
+            **_SIMPLE,
+        },
     )
     file_watch_enabled: bool = Field(
         default=True,

--- a/packages/kalinka-server/src/kalinka_server/config_model.py
+++ b/packages/kalinka-server/src/kalinka_server/config_model.py
@@ -207,7 +207,7 @@ class DeviceAutomationConfig(BaseModel):
     )
     auto_off_timeout_seconds: int = Field(
         default=60,
-        title="Pause timeout",
+        title="Pause timeout (seconds)",
         json_schema_extra={
             "help": "Stop playback if paused for this many seconds (0 = disabled)",
             "constraints": {"unit": "s"},


### PR DESCRIPTION
## Summary
- "Pause timeout" (general settings) and "Scan interval" (localfiles input module settings) didn't indicate their time units in the field title.
- Renamed to **Pause timeout (seconds)** and **Scan interval (minutes)**.
- Added a help description to the scan interval field (it previously had none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)