### PR TITLE
jamendo: inherit album artist for album-nested tracks

### DIFF
--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
@@ -736,9 +736,15 @@ class JamendoInputModule(InputModule):
             or track.get("image")
             or album_meta.get("image")
         )
+        # /albums/tracks nests tracks under the album and does not repeat the
+        # artist on each track (it lives on the album object), so fall back to
+        # album_meta. Without this, album tracks reach the playqueue with an
+        # empty artist even though browse shows the album-level artist.
         performer = Artist(
-            id=artist_id(str(track.get("artist_id", ""))),
-            name=track.get("artist_name", ""),
+            id=artist_id(
+                str(track.get("artist_id") or album_meta.get("artist_id") or "")
+            ),
+            name=track.get("artist_name") or album_meta.get("artist_name") or "",
         )
         return Track(
             id=track_id(str(track["id"])),

--- a/packages/kalinka-plugin-jamendo/tests/test_mapping.py
+++ b/packages/kalinka-plugin-jamendo/tests/test_mapping.py
@@ -140,6 +140,30 @@ async def test_browse_album_paginates_tracks():
 
 
 @pytest.mark.asyncio
+async def test_album_track_inherits_artist_from_album():
+    # Real Jamendo quirk: /albums/tracks nests tracks under the album and the
+    # nested track objects carry NO artist_id/artist_name (the artist lives on
+    # the album). Without the album_meta fallback these tracks reach the
+    # playqueue with an empty artist even though browse shows the album artist.
+    bare_track = {
+        "id": "100",
+        "name": "Sunrise",
+        "duration": "212",
+        "position": "1",
+    }
+    album_with_tracks = {**ALBUM, "tracks": [bare_track]}
+    m = make_module([album_with_tracks])
+    res = await m.browse(jm.album_id("5"), 0, 50)
+    perf = res.items[0].track.performer
+    assert perf.id.id == "10"
+    assert perf.name == "The Band"
+    # And it is cached so a queue-add via get_track_info keeps the artist.
+    infos = await m.get_track_info(["100"])
+    assert infos[0].metadata.performer.id.id == "10"
+    assert infos[0].metadata.performer.name == "The Band"
+
+
+@pytest.mark.asyncio
 async def test_browse_artist_uses_albums_endpoint():
     # Artist browse goes through /albums/?artist_id= so cards get the real
     # trackid-bearing cover; offset/limit are forwarded for native pagination.


### PR DESCRIPTION
## Problem

Jamendo tracks added to the playqueue had an empty artist (`performer.id` and `performer.name` both blank), even though the same tracks showed the artist correctly while browsing.

## Root cause (confirmed against the live Jamendo API)

The browse and playqueue-add paths hit different endpoints with different response shapes:

| Path | Album-level artist | Per-track artist |
|------|--------------------|------------------|
| `/albums/tracks` (album browse → playqueue add) | `artist_id` / `artist_name` present | **absent — keys omitted on each nested track** |
| `/tracks` (search / catalog shelves) | — | `artist_id` / `artist_name` present |

`/albums/tracks` nests tracks under the album and does not repeat the artist on each track (it lives only on the album object). `_track_metadata` read the artist solely from the track fields, so album tracks were cached — and handed to the playqueue — with an empty performer. The album view still looked fine because it renders the album-level header artist.

## Fix

`_track_metadata` now falls back to the album's `artist_id` / `artist_name` (passed in as `album_meta` by `_browse_album`) when the track itself lacks them. Other paths are unaffected: they either pass no `album_meta` or already carry a per-track artist.

## Testing

- Added a regression test reproducing the real `/albums/tracks` shape (nested track with no artist fields) and asserting the artist is inherited from the album, both on browse and via `get_track_info` (the queue-add path).
- Full plugin test suite passes (17 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)