### PR TITLE
Embed tracks with missing artist/album metadata (stop dropping them from search)

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder.py
@@ -240,6 +240,12 @@ class EmbeddingWorker:
             if arid:
                 artist_ids.add(arid)
 
+        # The sentinels are not real entities — mean-pooling unrelated tracks
+        # into a single "Unknown Album"/"Unknown Artist" vector would pollute
+        # album/artist search. Track-level embeddings still cover these tracks.
+        album_ids.discard("unknown_album")
+        artist_ids.discard("unknown_artist")
+
         for album_id in album_ids:
             blobs = await self.db.get_track_embeddings_for_album(album_id)
             if not blobs:
@@ -330,6 +336,11 @@ class EmbeddingWorker:
             arid = await self.db.get_artist_id_for_track(tid)
             if arid:
                 artist_ids.add(arid)
+
+        # Skip the sentinels — "Unknown Album"/"Unknown Artist" are placeholder
+        # rows, not searchable entities.
+        album_ids.discard("unknown_album")
+        artist_ids.discard("unknown_artist")
 
         for album_id in album_ids:
             meta = await self.db.get_album_metadata_for_text_embedding(album_id)

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
@@ -398,11 +398,23 @@ class AsyncEmbedderDb:
     # ------------------------------------------------------------------
 
     async def get_track_metadata_for_embedding(self, track_id: str) -> dict | None:
-        """Return title, artist_name, album_title for a track via JOINs."""
+        """Return title, artist_name, album_title for a track via JOINs.
+
+        The ``unknown_artist`` / ``unknown_album`` sentinel rows resolve through
+        the JOIN to the literal display strings ``"Unknown Artist"`` /
+        ``"Unknown Album"``.  Those are returned empty so the placeholder text is
+        never baked into the CLAP text vector as a noise token — a track with an
+        unknown album is still embedded, just as ``"Artist - Title"`` without the
+        ``"(Unknown Album)"`` suffix.
+        """
         async with self._open() as conn:
             cursor = await conn.execute(
                 """
-                SELECT t.title, ar.name AS artist_name, al.title AS album_title
+                SELECT t.title,
+                       CASE WHEN t.artist_id = 'unknown_artist' THEN ''
+                            ELSE ar.name END AS artist_name,
+                       CASE WHEN t.album_id = 'unknown_album' THEN ''
+                            ELSE al.title END AS album_title
                 FROM tracks t
                 LEFT JOIN artists ar ON t.artist_id = ar.id
                 LEFT JOIN albums  al ON t.album_id  = al.id

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
@@ -147,11 +147,12 @@ class AsyncEmbedderDb:
                     (entity_type, entity_id, stage, model_version)
                 SELECT 'track', t.id, 'clap_audio', ?
                 FROM tracks t
+                -- Embed every enriched track regardless of metadata: the audio
+                -- is metadata-independent, so V/A comps, orphan singles and
+                -- artist-less / fully-untagged tracks are all worth indexing
+                -- rather than silently dropped from search. Sentinels are
+                -- handled downstream (blanked in text, skipped in aggregates).
                 WHERE t.enriched IN (1, 2)
-                  -- Embed unknown-album tracks (V/A comps, orphan singles):
-                  -- the audio is metadata-independent and worth indexing.
-                  -- unknown_artist tracks stay excluded.
-                  AND t.artist_id != 'unknown_artist'
                   AND NOT EXISTS (
                     SELECT 1 FROM embedding_jobs j
                     WHERE j.entity_id = t.id
@@ -176,11 +177,11 @@ class AsyncEmbedderDb:
                     (entity_type, entity_id, stage, model_version)
                 SELECT 'track', t.id, 'clap_text', ?
                 FROM tracks t
+                -- Every enriched track gets a text embedding. The sentinel
+                -- artist/album strings are blanked in
+                -- get_track_metadata_for_embedding, so tracks embed as
+                -- "Artist - Title", "Title (Album)" or a bare "Title".
                 WHERE t.enriched IN (1, 2)
-                  -- Unknown-album tracks embed as "Artist - Title"; the
-                  -- "Unknown Album" sentinel is stripped in
-                  -- get_track_metadata_for_embedding. unknown_artist excluded.
-                  AND t.artist_id != 'unknown_artist'
                 """,
                 (clap_version,),
             )
@@ -406,10 +407,10 @@ class AsyncEmbedderDb:
 
         The ``unknown_artist`` / ``unknown_album`` sentinel rows resolve through
         the JOIN to the literal display strings ``"Unknown Artist"`` /
-        ``"Unknown Album"``.  Those are returned empty so the placeholder text is
-        never baked into the CLAP text vector as a noise token — a track with an
-        unknown album is still embedded, just as ``"Artist - Title"`` without the
-        ``"(Unknown Album)"`` suffix.
+        ``"Unknown Album"``.  Both are returned empty so the placeholder text is
+        never baked into the CLAP text vector as a noise token: tracks embed as
+        ``"Artist - Title"``, ``"Title (Album)"`` or a bare ``"Title"`` depending
+        on which metadata is known.
         """
         async with self._open() as conn:
             cursor = await conn.execute(
@@ -624,11 +625,10 @@ class AsyncEmbedderDb:
     async def get_embedding_coverage(self) -> dict:
         """Return job counts and coverage percentages.
 
-        Jobs for tracks parented to the `unknown_artist` placeholder are
-        excluded, since those rows are never scheduled and would otherwise keep
-        coverage below 100% forever. Unknown-album tracks are counted — they are
-        now scheduled and can reach `done`, so this stays consistent with the
-        scheduling filters.
+        Every enriched track is now scheduled — including the unknown-artist /
+        unknown-album sentinels — so all jobs can reach `done` and no sentinel
+        filter is needed. The JOIN to tracks remains so jobs left behind by
+        deleted tracks are not counted.
         """
         async with self._open() as conn:
             cursor = await conn.execute(
@@ -636,7 +636,6 @@ class AsyncEmbedderDb:
                 SELECT j.stage, j.status, COUNT(*) AS cnt
                 FROM embedding_jobs j
                 JOIN tracks t ON t.id = j.entity_id
-                WHERE t.artist_id != 'unknown_artist'
                 GROUP BY j.stage, j.status
                 """
             )

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
@@ -624,9 +624,11 @@ class AsyncEmbedderDb:
     async def get_embedding_coverage(self) -> dict:
         """Return job counts and coverage percentages.
 
-        Jobs for tracks parented to the `unknown_album`/`unknown_artist`
-        placeholders are excluded, since those rows are intentionally never
-        enriched and would otherwise keep coverage below 100% forever.
+        Jobs for tracks parented to the `unknown_artist` placeholder are
+        excluded, since those rows are never scheduled and would otherwise keep
+        coverage below 100% forever. Unknown-album tracks are counted — they are
+        now scheduled and can reach `done`, so this stays consistent with the
+        scheduling filters.
         """
         async with self._open() as conn:
             cursor = await conn.execute(
@@ -634,8 +636,7 @@ class AsyncEmbedderDb:
                 SELECT j.stage, j.status, COUNT(*) AS cnt
                 FROM embedding_jobs j
                 JOIN tracks t ON t.id = j.entity_id
-                WHERE t.album_id != 'unknown_album'
-                  AND t.artist_id != 'unknown_artist'
+                WHERE t.artist_id != 'unknown_artist'
                 GROUP BY j.stage, j.status
                 """
             )

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
@@ -148,7 +148,9 @@ class AsyncEmbedderDb:
                 SELECT 'track', t.id, 'clap_audio', ?
                 FROM tracks t
                 WHERE t.enriched IN (1, 2)
-                  AND t.album_id != 'unknown_album'
+                  -- Embed unknown-album tracks (V/A comps, orphan singles):
+                  -- the audio is metadata-independent and worth indexing.
+                  -- unknown_artist tracks stay excluded.
                   AND t.artist_id != 'unknown_artist'
                   AND NOT EXISTS (
                     SELECT 1 FROM embedding_jobs j
@@ -175,7 +177,9 @@ class AsyncEmbedderDb:
                 SELECT 'track', t.id, 'clap_text', ?
                 FROM tracks t
                 WHERE t.enriched IN (1, 2)
-                  AND t.album_id != 'unknown_album'
+                  -- Unknown-album tracks embed as "Artist - Title"; the
+                  -- "Unknown Album" sentinel is stripped in
+                  -- get_track_metadata_for_embedding. unknown_artist excluded.
                   AND t.artist_id != 'unknown_artist'
                 """,
                 (clap_version,),

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
@@ -173,7 +173,9 @@ class AsyncSearcherDb:
                 SELECT 'track', t.id, 'tags', ?
                 FROM tracks t
                 WHERE t.enriched IN (1, 2)
-                  AND t.album_id != 'unknown_album'
+                  -- Tag unknown-album tracks too (V/A comps, orphan singles);
+                  -- this stage gates clap_audio, which now covers them.
+                  -- unknown_artist tracks stay excluded.
                   AND t.artist_id != 'unknown_artist'
                 """,
                 (tags_version,),

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
@@ -172,11 +172,9 @@ class AsyncSearcherDb:
                     (entity_type, entity_id, stage, model_version)
                 SELECT 'track', t.id, 'tags', ?
                 FROM tracks t
+                -- Tag every enriched track; this stage gates clap_audio, which
+                -- now embeds all enriched tracks (incl. unknown artist/album).
                 WHERE t.enriched IN (1, 2)
-                  -- Tag unknown-album tracks too (V/A comps, orphan singles);
-                  -- this stage gates clap_audio, which now covers them.
-                  -- unknown_artist tracks stay excluded.
-                  AND t.artist_id != 'unknown_artist'
                 """,
                 (tags_version,),
             )

--- a/packages/kalinka-plugin-localfiles/tests/test_embedder_unknown_album.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_embedder_unknown_album.py
@@ -1,10 +1,11 @@
-"""Embedder coverage for tracks anchored to the unknown_album sentinel.
+"""Embedder coverage for tracks anchored to the sentinel rows.
 
 V/A compilations and orphan singles keep a known artist but get parented to the
-``unknown_album`` placeholder. They used to be skipped by the CLAP embedder
-entirely; now they are embedded (audio + ``"Artist - Title"`` text), while
-``unknown_artist`` tracks remain excluded and the ``"Unknown Album"`` placeholder
-string never leaks into the text vector.
+``unknown_album`` placeholder; some files have no resolvable artist either. These
+used to be skipped by the CLAP embedder entirely. Now every enriched track is
+embedded (audio + ``"Artist - Title"`` / ``"Title (Album)"`` / bare ``"Title"``
+text) so nothing silently disappears from search, while the ``"Unknown Album"`` /
+``"Unknown Artist"`` placeholder strings never leak into the text vector.
 """
 
 import os
@@ -30,12 +31,12 @@ async def _seed(db_path: str) -> None:
             "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
             "VALUES ('t1', 'Song One', 'f1', 'mp3', 1, 'ar1', 'al1')"
         )
-        # enriched, known artist + unknown album (V/A / orphan) -> now embedded
+        # enriched, known artist + unknown album (V/A / orphan) -> embedded
         await conn.execute(
             "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
             "VALUES ('t2', 'Song Two', 'f2', 'mp3', 2, 'ar1', 'unknown_album')"
         )
-        # enriched but unknown artist -> still skipped
+        # enriched, unknown artist + known album -> embedded
         await conn.execute(
             "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
             "VALUES ('t3', 'Song Three', 'f3', 'mp3', 1, 'unknown_artist', 'al1')"
@@ -45,19 +46,25 @@ async def _seed(db_path: str) -> None:
             "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
             "VALUES ('t4', 'Song Four', 'f4', 'mp3', 0, 'ar1', 'al1')"
         )
+        # enriched, fully untagged (no artist, no album) -> embedded
+        await conn.execute(
+            "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
+            "VALUES ('t5', 'Song Five', 'f5', 'mp3', 1, 'unknown_artist', 'unknown_album')"
+        )
         await conn.commit()
 
 
 @pytest.mark.asyncio
-async def test_schedule_includes_unknown_album_excludes_unknown_artist():
+async def test_schedule_covers_all_enriched_tracks():
     db_path = os.path.join(tempfile.mkdtemp(), "test.db")
     await _seed(db_path)
 
     db = AsyncEmbedderDb(LocalFilesConfig(db_path=db_path))
     inserted = await db.schedule_new_jobs(clap_version=1)
 
-    # 2 tracks (t1, t2) x 2 stages (clap_audio, clap_text)
-    assert inserted == 4
+    # 4 enriched tracks (t1, t2, t3, t5) x 2 stages (clap_audio, clap_text);
+    # t4 is un-enriched and skipped.
+    assert inserted == 8
 
     async with aiosqlite.connect(db_path) as conn:
         cursor = await conn.execute("SELECT entity_id, stage FROM embedding_jobs")
@@ -65,13 +72,13 @@ async def test_schedule_includes_unknown_album_excludes_unknown_artist():
 
     audio = {eid for eid, stage in rows if stage == "clap_audio"}
     text = {eid for eid, stage in rows if stage == "clap_text"}
-    assert audio == {"t1", "t2"}
-    assert text == {"t1", "t2"}
+    assert audio == {"t1", "t2", "t3", "t5"}
+    assert text == {"t1", "t2", "t3", "t5"}
 
 
 @pytest.mark.asyncio
-async def test_metadata_strips_unknown_album_sentinel():
-    """An unknown-album track yields "Artist - Title" with no placeholder text."""
+async def test_metadata_strips_sentinels():
+    """Sentinel artist/album rows are blanked so no placeholder text is embedded."""
     db_path = os.path.join(tempfile.mkdtemp(), "test.db")
     await _seed(db_path)
 
@@ -84,14 +91,20 @@ async def test_metadata_strips_unknown_album_sentinel():
         "album_title": "Real Album",
     }
 
-    # unknown_album resolves to the "Unknown Album" row via JOIN; must be blanked.
+    # unknown_album resolves to the "Unknown Album" row via JOIN; must be blanked
+    # -> embeds as "Real Artist - Song Two".
     unknown_album = await db.get_track_metadata_for_embedding("t2")
     assert unknown_album["title"] == "Song Two"
     assert unknown_album["artist_name"] == "Real Artist"
     assert unknown_album["album_title"] == ""
 
-    # Defensive: the artist sentinel is blanked too (unknown_artist tracks are
-    # not scheduled, but the metadata helper must never emit "Unknown Artist").
+    # unknown_artist blanked -> embeds as "Song Three (Real Album)".
     unknown_artist = await db.get_track_metadata_for_embedding("t3")
     assert unknown_artist["artist_name"] == ""
     assert unknown_artist["album_title"] == "Real Album"
+
+    # fully untagged -> both blanked, embeds as the bare title "Song Five".
+    fully_unknown = await db.get_track_metadata_for_embedding("t5")
+    assert fully_unknown["title"] == "Song Five"
+    assert fully_unknown["artist_name"] == ""
+    assert fully_unknown["album_title"] == ""

--- a/packages/kalinka-plugin-localfiles/tests/test_embedder_unknown_album.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_embedder_unknown_album.py
@@ -1,0 +1,97 @@
+"""Embedder coverage for tracks anchored to the unknown_album sentinel.
+
+V/A compilations and orphan singles keep a known artist but get parented to the
+``unknown_album`` placeholder. They used to be skipped by the CLAP embedder
+entirely; now they are embedded (audio + ``"Artist - Title"`` text), while
+``unknown_artist`` tracks remain excluded and the ``"Unknown Album"`` placeholder
+string never leaks into the text vector.
+"""
+
+import os
+import tempfile
+
+import aiosqlite
+import pytest
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.embedder.embedder_db import AsyncEmbedderDb
+
+
+async def _seed(db_path: str) -> None:
+    await init_db(db_path)
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute("INSERT INTO artists (id, name) VALUES ('ar1', 'Real Artist')")
+        await conn.execute(
+            "INSERT INTO albums (id, title, artist_id) VALUES ('al1', 'Real Album', 'ar1')"
+        )
+        # enriched, fully known -> embedded
+        await conn.execute(
+            "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
+            "VALUES ('t1', 'Song One', 'f1', 'mp3', 1, 'ar1', 'al1')"
+        )
+        # enriched, known artist + unknown album (V/A / orphan) -> now embedded
+        await conn.execute(
+            "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
+            "VALUES ('t2', 'Song Two', 'f2', 'mp3', 2, 'ar1', 'unknown_album')"
+        )
+        # enriched but unknown artist -> still skipped
+        await conn.execute(
+            "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
+            "VALUES ('t3', 'Song Three', 'f3', 'mp3', 1, 'unknown_artist', 'al1')"
+        )
+        # not enriched -> skipped
+        await conn.execute(
+            "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
+            "VALUES ('t4', 'Song Four', 'f4', 'mp3', 0, 'ar1', 'al1')"
+        )
+        await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_schedule_includes_unknown_album_excludes_unknown_artist():
+    db_path = os.path.join(tempfile.mkdtemp(), "test.db")
+    await _seed(db_path)
+
+    db = AsyncEmbedderDb(LocalFilesConfig(db_path=db_path))
+    inserted = await db.schedule_new_jobs(clap_version=1)
+
+    # 2 tracks (t1, t2) x 2 stages (clap_audio, clap_text)
+    assert inserted == 4
+
+    async with aiosqlite.connect(db_path) as conn:
+        cursor = await conn.execute("SELECT entity_id, stage FROM embedding_jobs")
+        rows = await cursor.fetchall()
+
+    audio = {eid for eid, stage in rows if stage == "clap_audio"}
+    text = {eid for eid, stage in rows if stage == "clap_text"}
+    assert audio == {"t1", "t2"}
+    assert text == {"t1", "t2"}
+
+
+@pytest.mark.asyncio
+async def test_metadata_strips_unknown_album_sentinel():
+    """An unknown-album track yields "Artist - Title" with no placeholder text."""
+    db_path = os.path.join(tempfile.mkdtemp(), "test.db")
+    await _seed(db_path)
+
+    db = AsyncEmbedderDb(LocalFilesConfig(db_path=db_path))
+
+    known = await db.get_track_metadata_for_embedding("t1")
+    assert known == {
+        "title": "Song One",
+        "artist_name": "Real Artist",
+        "album_title": "Real Album",
+    }
+
+    # unknown_album resolves to the "Unknown Album" row via JOIN; must be blanked.
+    unknown_album = await db.get_track_metadata_for_embedding("t2")
+    assert unknown_album["title"] == "Song Two"
+    assert unknown_album["artist_name"] == "Real Artist"
+    assert unknown_album["album_title"] == ""
+
+    # Defensive: the artist sentinel is blanked too (unknown_artist tracks are
+    # not scheduled, but the metadata helper must never emit "Unknown Artist").
+    unknown_artist = await db.get_track_metadata_for_embedding("t3")
+    assert unknown_artist["artist_name"] == ""
+    assert unknown_artist["album_title"] == "Real Album"

--- a/packages/kalinka-plugin-localfiles/tests/test_unified_tags.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_unified_tags.py
@@ -174,7 +174,12 @@ class TestScheduleNewTagJobs:
 
     @pytest.mark.asyncio
     async def test_schedule_uses_unified_stage(self):
-        """Verify the SQL inserts 'tags' not individual stages."""
+        """Verify the SQL inserts 'tags' and applies the right track filter.
+
+        Enriched tracks are queued — including tracks anchored to the
+        ``unknown_album`` sentinel (V/A comps / orphan singles), which used to be
+        skipped — while un-enriched tracks and ``unknown_artist`` tracks stay out.
+        """
         import aiosqlite
         import tempfile
         import os
@@ -186,27 +191,47 @@ class TestScheduleNewTagJobs:
 
         async with aiosqlite.connect(db_path) as conn:
             await conn.execute(
-                "INSERT INTO tracks (id, title, file_path, format, enriched) VALUES ('t1', 't', 'f', 'mp3', 1)"
+                "INSERT INTO artists (id, name) VALUES ('ar1', 'Artist One')"
             )
             await conn.execute(
-                "INSERT INTO tracks (id, title, file_path, format, enriched) VALUES ('t2', 't', 'f', 'mp3', 2)"
+                "INSERT INTO albums (id, title, artist_id) VALUES ('al1', 'Album One', 'ar1')"
+            )
+            # enriched, known artist + album -> scheduled
+            await conn.execute(
+                "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
+                "VALUES ('t1', 't', 'f1', 'mp3', 1, 'ar1', 'al1')"
             )
             await conn.execute(
-                "INSERT INTO tracks (id, title, file_path, format, enriched) VALUES ('t3', 't', 'f', 'mp3', 0)"
+                "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
+                "VALUES ('t2', 't', 'f2', 'mp3', 2, 'ar1', 'al1')"
+            )
+            # not enriched -> skipped
+            await conn.execute(
+                "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
+                "VALUES ('t3', 't', 'f3', 'mp3', 0, 'ar1', 'al1')"
+            )
+            # enriched, known artist but unknown album -> now scheduled (the fix)
+            await conn.execute(
+                "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
+                "VALUES ('t4', 't', 'f4', 'mp3', 1, 'ar1', 'unknown_album')"
+            )
+            # enriched but unknown artist -> still skipped
+            await conn.execute(
+                "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
+                "VALUES ('t5', 't', 'f5', 'mp3', 1, 'unknown_artist', 'al1')"
             )
             await conn.commit()
 
         db = AsyncSearcherDb(config)
 
         inserted = await db.schedule_new_tag_jobs(1)
-        assert inserted == 2  # t1 and t2 (enriched), not t3
+        assert inserted == 3  # t1, t2, t4 — not t3 (unenriched) or t5 (unknown_artist)
 
-        # Verify stage name
+        # Verify stage name and exactly which tracks were queued.
         async with aiosqlite.connect(db_path) as conn:
-            cursor = await conn.execute(
-                "SELECT stage FROM embedding_jobs"
-            )
+            cursor = await conn.execute("SELECT entity_id, stage FROM embedding_jobs")
             rows = await cursor.fetchall()
-            stages = [r[0] for r in rows]
-            assert all(s == "tags" for s in stages)
-            assert len(stages) == 2
+        stages = [r[1] for r in rows]
+        entity_ids = {r[0] for r in rows}
+        assert all(s == "tags" for s in stages)
+        assert entity_ids == {"t1", "t2", "t4"}

--- a/packages/kalinka-plugin-localfiles/tests/test_unified_tags.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_unified_tags.py
@@ -176,9 +176,10 @@ class TestScheduleNewTagJobs:
     async def test_schedule_uses_unified_stage(self):
         """Verify the SQL inserts 'tags' and applies the right track filter.
 
-        Enriched tracks are queued — including tracks anchored to the
-        ``unknown_album`` sentinel (V/A comps / orphan singles), which used to be
-        skipped — while un-enriched tracks and ``unknown_artist`` tracks stay out.
+        Every enriched track is queued — including tracks anchored to the
+        ``unknown_album`` / ``unknown_artist`` sentinels (V/A comps, orphan
+        singles, untagged files), which used to be skipped — while un-enriched
+        tracks stay out.
         """
         import aiosqlite
         import tempfile
@@ -215,7 +216,7 @@ class TestScheduleNewTagJobs:
                 "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
                 "VALUES ('t4', 't', 'f4', 'mp3', 1, 'ar1', 'unknown_album')"
             )
-            # enriched but unknown artist -> still skipped
+            # enriched, unknown artist -> now scheduled (the fix)
             await conn.execute(
                 "INSERT INTO tracks (id, title, file_path, format, enriched, artist_id, album_id) "
                 "VALUES ('t5', 't', 'f5', 'mp3', 1, 'unknown_artist', 'al1')"
@@ -225,7 +226,7 @@ class TestScheduleNewTagJobs:
         db = AsyncSearcherDb(config)
 
         inserted = await db.schedule_new_tag_jobs(1)
-        assert inserted == 3  # t1, t2, t4 — not t3 (unenriched) or t5 (unknown_artist)
+        assert inserted == 4  # t1, t2, t4, t5 — only t3 (unenriched) is skipped
 
         # Verify stage name and exactly which tracks were queued.
         async with aiosqlite.connect(db_path) as conn:
@@ -234,4 +235,4 @@ class TestScheduleNewTagJobs:
         stages = [r[1] for r in rows]
         entity_ids = {r[0] for r in rows}
         assert all(s == "tags" for s in stages)
-        assert entity_ids == {"t1", "t2", "t4"}
+        assert entity_ids == {"t1", "t2", "t4", "t5"}


### PR DESCRIPTION
## Problem

The CLAP embedder skipped any track unless **both** its album and artist were known: `album_id != 'unknown_album' AND artist_id != 'unknown_artist'`. By De Morgan that skips a track if **either** is unknown.

This silently dropped real, searchable music. On a 7991-track library:
- **~2000** tracks have an artist but no album (V/A compilations, orphan singles the indexer deliberately anchors to `unknown_album`)
- **24** have an album but no artist
- **13** have neither

None of these got an audio *or* text embedding — invisible to `ai_search`, with no trace. Their audio is fully meaningful regardless of metadata.

## Change

The track-selection policy for embedding becomes simply **`enriched IN (1, 2)`** — every enriched track is embedded (tags, clap_audio, clap_text), and coverage counts them all.

Two hygiene guards keep this safe instead of degrading search:

1. **Text pollution** — the `LEFT JOIN` resolves the sentinels to the literal strings `"Unknown Artist"` / `"Unknown Album"`, which would otherwise be embedded as noise tokens. `get_track_metadata_for_embedding` blanks them, so tracks embed cleanly as `"Artist - Title"`, `"Title (Album)"`, or a bare `"Title"` depending on what's known.
2. **Aggregate pollution** — album/artist vectors are mean-pooled per id; the aggregation loops skip the two sentinels so `unknown_album`/`unknown_artist` never become bogus aggregate entries in album/artist search. Real artists still absorb their orphan tracks.

Audio is metadata-independent, so this is pure recall gain for track search.

## Commits (incremental, each safe on its own)

1. Strip `Unknown Album`/`Unknown Artist` sentinels from CLAP text input
2. Skip sentinels when aggregating album/artist embeddings
3. Embed tracks with an unknown album (drop album guard)
4. Count unknown-album tracks in embedding coverage
5. Tests for embedder scheduling + sentinel stripping
6. Embed unknown-artist tracks too — drop the remaining artist guard (policy is now "embed every enriched track")

Existing libraries pick the tracks up incrementally on the next schedule pass (`schedule_new_jobs` runs every embedder cycle; `INSERT OR IGNORE` + `NOT EXISTS` dedupe); no migration needed.

## Tests

- `test_embedder_unknown_album.py`: scheduling covers all four metadata combinations (known, unknown-album, unknown-artist, fully-untagged) and skips un-enriched; metadata helper blanks every sentinel.
- Fixed `test_schedule_uses_unified_stage`, which was **failing on `main`** (it inserted tracks with NULL ids; `NULL != 'x'` is NULL, so every row was filtered out). It now sets real ids and asserts the new behavior.
- Full localfiles suite: **208 passed**. The 4 `test_va_coalescing.py` failures are pre-existing on `main` (unrelated: `FakeDb` missing `update_album`) and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)