### PR TITLE
Clean up AI slop in embedder/enricher/indexer; fix two bugs

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/clap_onnx.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/clap_onnx.py
@@ -60,7 +60,7 @@ _MODEL_FILENAMES: dict[str, str] = {
     "clap_tokenizer": "clap_tokenizer.json",
 }
 
-# Audio constants matching laion_clap (non-fusion, HTSAT-tiny)
+# Audio constants matching laion_clap (non-fusion, HTSAT-base)
 _SAMPLE_RATE = 48_000
 _FRAGMENT_SECONDS = 10
 _MAX_SAMPLES = _SAMPLE_RATE * _FRAGMENT_SECONDS  # 480_000 = 10 s at 48 kHz

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder.py
@@ -400,7 +400,6 @@ class EmbeddingWorker:
             try:
                 self._load_clap_model()
                 blob = await loop.run_in_executor(None, self._encode_query, query)
-                self._last_work_time = time.monotonic()
                 response_queue.put({"blob": blob})
             except Exception as e:
                 logger.warning("Text-encode handler error: %s", e)
@@ -469,8 +468,6 @@ class EmbeddingWorker:
         await sleep_interruptible(poll, shutdown_event, nudge_queue, "Embedder")
         logger.info("Embedder waking — starting first work cycle")
 
-        self._last_work_time = time.monotonic()
-
         while not shutdown_event.is_set():
             # Schedule new CLAP jobs for tracks with completed tags
             await self.db.schedule_new_jobs(cfg.clap.current_version)
@@ -488,7 +485,6 @@ class EmbeddingWorker:
                         batch_processed = await self._process_clap_batch()
                         if batch_processed:
                             did_work = True
-                            self._last_work_time = time.monotonic()
                         else:
                             break
                     except Exception:
@@ -505,7 +501,6 @@ class EmbeddingWorker:
                         batch_processed = await self._process_clap_text_batch()
                         if batch_processed:
                             did_work = True
-                            self._last_work_time = time.monotonic()
                         else:
                             break
                     except Exception:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
@@ -37,7 +37,7 @@ _VEC_TEXT_TABLES = {
 @retry_db_locked
 class AsyncEmbedderDb:
     """
-    Database manager for the CLAP + Essentia embedding pipeline.
+    Database manager for the CLAP embedding pipeline.
     All methods are async and open their own short-lived connections.
     """
 
@@ -243,29 +243,6 @@ class AsyncEmbedderDb:
             await conn.commit()
 
         return [dict(r) for r in rows]
-
-    async def complete_tags_job(
-        self, job_id: int, track_id: str, tags_json: str
-    ) -> None:
-        """Mark tags job done and write tags_predicted to the track."""
-        async with self._open() as conn:
-            await conn.execute(
-                """
-                UPDATE tracks
-                SET tags_predicted = json_patch(COALESCE(tags_predicted, '{}'), ?)
-                WHERE id = ?
-                """,
-                (tags_json, track_id),
-            )
-            await conn.execute(
-                """
-                UPDATE embedding_jobs
-                SET status = 'done', error = NULL, updated_at = CURRENT_TIMESTAMP
-                WHERE id = ?
-                """,
-                (job_id,),
-            )
-            await conn.commit()
 
     async def complete_clap_job(
         self, job_id: int, track_id: str, blob: bytes, version: int

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import math
 import time
@@ -607,8 +608,13 @@ class AcoustIdPlugin(EnricherPlugin):
                 f"Fingerprinting track: {track.get('title', 'Unknown')} - {track.get('file_path')}"
             )
 
-            # Generate fingerprint
-            fingerprint, duration = self._generate_fingerprint(track["file_path"])
+            # Generate fingerprint. ``_generate_fingerprint`` (fpcalc
+            # subprocess) and ``_lookup_fingerprint`` (HTTP + rate-limit
+            # sleep) are blocking, so run them off the event loop to avoid
+            # stalling the enricher's other coroutines.
+            fingerprint, duration = await asyncio.to_thread(
+                self._generate_fingerprint, track["file_path"]
+            )
             if not fingerprint or not duration:
                 logger.debug(
                     f"Could not generate fingerprint for {track.get('file_path')}"
@@ -616,7 +622,9 @@ class AcoustIdPlugin(EnricherPlugin):
                 return None
 
             # Look up fingerprint
-            results = self._lookup_fingerprint(fingerprint, duration)
+            results = await asyncio.to_thread(
+                self._lookup_fingerprint, fingerprint, duration
+            )
             if not results:
                 logger.debug(f"No AcoustID matches for {track.get('file_path')}")
                 return None

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
@@ -330,9 +330,6 @@ class MetadataEnricher:
             )
             return
 
-        # Collect any entities that need further enrichment
-        entities_for_enrichment = {"artists": set(), "albums": set(), "tracks": set()}
-
         for plugin in self.plugins:
             if not plugin.can_enrich_track():
                 continue
@@ -362,19 +359,10 @@ class MetadataEnricher:
                     logger.debug(f"Track {track['title']} now fully enriched")
                     updated_track["enriched"] = EnrichmentStatus.ENRICHED
 
-                # # Check if plugin identified entities that need further enrichment
-                # if "changed_items" in result:
-                #     for entity_type in ["artists", "albums", "tracks"]:
-                #         if entity_type in result["changed_items"]:
-                #             entities_for_enrichment[entity_type].update(
-                #                 result["changed_items"][entity_type]
-                # )
-
         # After all plugins, if still not fully enriched, mark as failed
         if (
             not is_fully_enriched
             and updated_track.get("enriched") != EnrichmentStatus.ENRICHED
-            and track["id"] not in entities_for_enrichment["tracks"]
         ):
             logger.info(
                 f"Track {track['id']} failed enrichment - missing required fields"
@@ -387,25 +375,6 @@ class MetadataEnricher:
             await self.db_manager.update_track(track["id"], updated_track)
             if "album_id" in updated_track:
                 await self.db_manager.update_album_stats(updated_track["album_id"])
-
-        # If we have entities that need further enrichment, add them to the enricher queue
-        # if any(entities_for_enrichment.values()):
-        #     changed_items = {
-        #         "artists": list(entities_for_enrichment["artists"]),
-        #         "albums": list(entities_for_enrichment["albums"]),
-        #         "tracks": list(entities_for_enrichment["tracks"]),
-        #     }
-
-        #     logger.info(
-        #         f"Queueing additional enrichment for entities from track {track['id']}: "
-        #         f"Artists={len(changed_items['artists'])}, "
-        #         f"Albums={len(changed_items['albums'])}, "
-        #         f"Tracks={len(changed_items['tracks'])}"
-        #     )
-
-        #     # Add to the enricher queue
-        #     global _enricher_queue
-        #     await _enricher_queue.put({"changed_items": changed_items})
 
 
 async def _enricher_worker(config, db_manager: AsyncEnricherDb):
@@ -440,8 +409,6 @@ async def _enricher_worker(config, db_manager: AsyncEnricherDb):
     except Exception as e:
         logger.warning(f"Failed-row retry reset skipped: {e}")
 
-    enricher_tasks = set()
-
     # Process queue commands
     while True:
         try:
@@ -469,12 +436,9 @@ async def _enricher_worker(config, db_manager: AsyncEnricherDb):
                             pass
 
             except queue.Empty:
-                # No command received in 30 seconds, run periodic enrichment check
-                logger.debug(
-                    "No commands received, checking for new items to enrich..."
-                )
+                # No command in the timeout window; loop and wait again.
+                logger.debug("No enricher commands received; continuing to wait")
                 continue
-                # await enricher_instance.start()
 
             # Small delay to avoid busy waiting
             await asyncio.sleep(0.1)
@@ -484,15 +448,6 @@ async def _enricher_worker(config, db_manager: AsyncEnricherDb):
         except Exception as e:
             logger.exception(f"Error in enricher worker: {str(e)}")
             await asyncio.sleep(5)  # Sleep longer on errors
-
-    running_tasks = list(enricher_tasks)
-    for task in running_tasks:
-        if not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
 
 
 def start_enricher(config, db_manager: AsyncEnricherDb) -> Optional[asyncio.Task]:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
@@ -22,6 +22,7 @@ class AsyncEnricherDb:
     def __init__(self, config: LocalFilesConfig):
         self.db_path = Path(config.db_path).expanduser().resolve()
         self.artwork_path = Path(config.artwork_path).expanduser().resolve()
+        self._columns_cache: Dict[str, set] = {}
 
         # Ensure directories exist
         db_dir = os.path.dirname(self.db_path)
@@ -295,122 +296,49 @@ class AsyncEnricherDb:
             rows = await cursor.fetchall()
             return [dict(row) for row in rows], total
 
-    async def update_artist(self, artist_id: str, data: Dict[str, Any]) -> None:
-        """Update artist information"""
+    async def _table_columns(self, conn, table: str) -> set:
+        """Return the column names for *table*, cached (schema is static)."""
+        cached = self._columns_cache.get(table)
+        if cached is not None:
+            return cached
+        cursor = await conn.execute(f"PRAGMA table_info({table})")
+        columns = {row[1] for row in await cursor.fetchall()}  # name at index 1
+        self._columns_cache[table] = columns
+        return columns
+
+    async def _update(self, table: str, entity_id: str, data: Dict[str, Any]) -> None:
+        """Update a row by id, ignoring keys that aren't real columns."""
         async with self._open() as conn:
-            conn.row_factory = aiosqlite.Row
-            cursor = await conn.cursor()
-
-            # Get artist table column names
-            await cursor.execute("PRAGMA table_info(artists)")
-            rows = await cursor.fetchall()
-            valid_columns = {row["name"] for row in rows}
-
-            # Filter out data keys that don't exist in the artists table
+            valid_columns = await self._table_columns(conn, table)
             filtered_data = {k: v for k, v in data.items() if k in valid_columns}
-
             if not filtered_data:
-                logger.debug(f"No valid columns to update for artist {artist_id}")
+                logger.debug(f"No valid columns to update for {table} {entity_id}")
                 return
 
-            # Build the SET clause with only valid columns
-            fields = []
-            values = []
-            for key, value in filtered_data.items():
-                fields.append(f"{key} = ?")
-                values.append(value)
-
-            # Add artist_id to the values
-            values.append(artist_id)
-
-            query = f"UPDATE artists SET {', '.join(fields)} WHERE id = ?"
-            await cursor.execute(query, values)
+            fields = [f"{key} = ?" for key in filtered_data]
+            values = list(filtered_data.values()) + [entity_id]
+            query = f"UPDATE {table} SET {', '.join(fields)} WHERE id = ?"
+            await conn.execute(query, values)
             await conn.commit()
 
-            # Log if any fields were filtered out
-            filtered_out = set(data.keys()) - valid_columns
+            filtered_out = set(data) - valid_columns
             if filtered_out:
                 logger.debug(
-                    f"Filtered out non-existent columns for artist {artist_id}: {', '.join(filtered_out)}"
+                    f"Filtered out non-existent columns for {table} {entity_id}: "
+                    f"{', '.join(filtered_out)}"
                 )
+
+    async def update_artist(self, artist_id: str, data: Dict[str, Any]) -> None:
+        """Update artist information"""
+        await self._update("artists", artist_id, data)
 
     async def update_album(self, album_id: str, data: Dict[str, Any]) -> None:
         """Update album information"""
-        async with self._open() as conn:
-            conn.row_factory = aiosqlite.Row
-            cursor = await conn.cursor()
-
-            # Get album table column names
-            await cursor.execute("PRAGMA table_info(albums)")
-            rows = await cursor.fetchall()
-            valid_columns = {row["name"] for row in rows}
-
-            # Filter out data keys that don't exist in the albums table
-            filtered_data = {k: v for k, v in data.items() if k in valid_columns}
-
-            if not filtered_data:
-                logger.debug(f"No valid columns to update for album {album_id}")
-                return
-
-            # Build the SET clause with only valid columns
-            fields = []
-            values = []
-            for key, value in filtered_data.items():
-                fields.append(f"{key} = ?")
-                values.append(value)
-
-            # Add album_id to the values
-            values.append(album_id)
-
-            query = f"UPDATE albums SET {', '.join(fields)} WHERE id = ?"
-            await cursor.execute(query, values)
-            await conn.commit()
-
-            # Log if any fields were filtered out
-            filtered_out = set(data.keys()) - valid_columns
-            if filtered_out:
-                logger.debug(
-                    f"Filtered out non-existent columns for album {album_id}: {', '.join(filtered_out)}"
-                )
+        await self._update("albums", album_id, data)
 
     async def update_track(self, track_id: str, data: Dict[str, Any]) -> None:
         """Update track information"""
-        async with self._open() as conn:
-            conn.row_factory = aiosqlite.Row
-            cursor = await conn.cursor()
-
-            # Get track table column names
-            await cursor.execute("PRAGMA table_info(tracks)")
-            rows = await cursor.fetchall()
-            valid_columns = {row["name"] for row in rows}
-
-            # Filter out data keys that don't exist in the tracks table
-            filtered_data = {k: v for k, v in data.items() if k in valid_columns}
-
-            if not filtered_data:
-                logger.debug(f"No valid columns to update for track {track_id}")
-                return
-
-            # Build the SET clause with only valid columns
-            fields = []
-            values = []
-            for key, value in filtered_data.items():
-                fields.append(f"{key} = ?")
-                values.append(value)
-
-            # Add track_id to the values
-            values.append(track_id)
-
-            query = f"UPDATE tracks SET {', '.join(fields)} WHERE id = ?"
-            await cursor.execute(query, values)
-            await conn.commit()
-
-            # Log if any fields were filtered out
-            filtered_out = set(data.keys()) - valid_columns
-            if filtered_out:
-                logger.debug(
-                    f"Filtered out non-existent columns for track {track_id}: {', '.join(filtered_out)}"
-                )
+        await self._update("tracks", track_id, data)
 
     async def update_album_stats(self, album_id: str) -> None:
         """Update album statistics (track count and duration)"""

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import time
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -197,7 +198,7 @@ class FilesystemFallbackPlugin(EnricherPlugin):
                     "id": artist_id,
                     "name": artist_name,
                     "enriched": 0,
-                    "last_updated": int(__import__("time").time()),
+                    "last_updated": int(time.time()),
                 }
             )
             logger.debug(f"Created new artist: {artist_name} (ID: {artist_id})")
@@ -244,7 +245,7 @@ class FilesystemFallbackPlugin(EnricherPlugin):
                 "title": album_title,
                 "artist_id": artist_id,
                 "enriched": 0,
-                "last_updated": int(__import__("time").time()),
+                "last_updated": int(time.time()),
             }
         )
         logger.debug(f"Created new album: {album_title} by {artist_id} (ID: {album_id})")

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -479,131 +479,125 @@ class FileIndexer:
             return None
 
     def _extract_mp3_metadata(self, file_path: str, metadata: Dict) -> Dict:
-        """Extract metadata from an MP3 file"""
+        """Extract metadata from an MP3 file.
+
+        Errors propagate to ``_extract_metadata``, which logs them once.
+        """
+        mp3 = MP3(file_path)
+        # A missing ID3 header is a valid, fully supported case — the
+        # audio plays fine, it just has no tags. Fall back to an empty
+        # tag set so the track still gets indexed (title derived from
+        # the filename, Unknown Artist/Album) instead of failing.
         try:
-            mp3 = MP3(file_path)
-            # A missing ID3 header is a valid, fully supported case — the
-            # audio plays fine, it just has no tags. Fall back to an empty
-            # tag set so the track still gets indexed (title derived from
-            # the filename, Unknown Artist/Album) instead of failing.
+            id3 = ID3(file_path)
+        except ID3NoHeaderError:
+            id3 = ID3()
+        metadata["duration"] = int(mp3.info.length)
+        if "TIT2" in id3:
+            metadata["title"] = str(id3["TIT2"])
+        if "TPE1" in id3:
+            metadata["artist"] = str(id3["TPE1"])
+        if "TALB" in id3:
+            metadata["album"] = str(id3["TALB"])
+        if "TRCK" in id3:
+            track_str = str(id3["TRCK"])
+            if "/" in track_str:
+                track_str = track_str.split("/")[0]
             try:
-                id3 = ID3(file_path)
-            except ID3NoHeaderError:
-                id3 = ID3()
-            metadata["duration"] = int(mp3.info.length)
-            if "TIT2" in id3:
-                metadata["title"] = str(id3["TIT2"])
-            if "TPE1" in id3:
-                metadata["artist"] = str(id3["TPE1"])
-            if "TALB" in id3:
-                metadata["album"] = str(id3["TALB"])
-            if "TRCK" in id3:
-                track_str = str(id3["TRCK"])
-                if "/" in track_str:
-                    track_str = track_str.split("/")[0]
-                try:
-                    metadata["track_number"] = int(track_str)
-                except ValueError:
-                    pass
-            if "TPOS" in id3:
-                disc_str = str(id3["TPOS"])
-                if "/" in disc_str:
-                    disc_str = disc_str.split("/")[0]
-                try:
-                    metadata["disc_number"] = int(disc_str)
-                except ValueError:
-                    pass
-            if "TDRC" in id3:
-                try:
-                    metadata["year"] = int(str(id3["TDRC"]).split("-")[0])
-                except (ValueError, IndexError):
-                    pass
-            if "TCON" in id3:
-                metadata["genre"] = str(id3["TCON"])
-            if "TXXX:replaygain_track_gain" in id3:
-                gain_str = str(id3["TXXX:replaygain_track_gain"])
-                try:
-                    metadata["replaygain_gain"] = float(gain_str.replace(" dB", ""))
-                except ValueError:
-                    pass
-            if "TXXX:replaygain_track_peak" in id3:
-                peak_str = str(id3["TXXX:replaygain_track_peak"])
-                try:
-                    metadata["replaygain_peak"] = float(peak_str)
-                except ValueError:
-                    pass
-            for tag in ["APIC:", "APIC:Cover", "APIC:CoverFront"]:
-                if tag in id3:
-                    apic = id3[tag]
-                    metadata["album_art"] = apic.data
-                    break
-            return metadata
-        except Exception as e:
-            logger.exception(
-                f"Error extracting MP3 metadata from {file_path}: {str(e)}"
-            )
-            raise
+                metadata["track_number"] = int(track_str)
+            except ValueError:
+                pass
+        if "TPOS" in id3:
+            disc_str = str(id3["TPOS"])
+            if "/" in disc_str:
+                disc_str = disc_str.split("/")[0]
+            try:
+                metadata["disc_number"] = int(disc_str)
+            except ValueError:
+                pass
+        if "TDRC" in id3:
+            try:
+                metadata["year"] = int(str(id3["TDRC"]).split("-")[0])
+            except (ValueError, IndexError):
+                pass
+        if "TCON" in id3:
+            metadata["genre"] = str(id3["TCON"])
+        if "TXXX:replaygain_track_gain" in id3:
+            gain_str = str(id3["TXXX:replaygain_track_gain"])
+            try:
+                metadata["replaygain_gain"] = float(gain_str.replace(" dB", ""))
+            except ValueError:
+                pass
+        if "TXXX:replaygain_track_peak" in id3:
+            peak_str = str(id3["TXXX:replaygain_track_peak"])
+            try:
+                metadata["replaygain_peak"] = float(peak_str)
+            except ValueError:
+                pass
+        for tag in ["APIC:", "APIC:Cover", "APIC:CoverFront"]:
+            if tag in id3:
+                apic = id3[tag]
+                metadata["album_art"] = apic.data
+                break
+        return metadata
 
     def _extract_flac_metadata(self, file_path: str, metadata: Dict) -> Dict:
-        """Extract metadata from a FLAC file"""
-        try:
-            flac = FLAC(file_path)
-            metadata["duration"] = int(flac.info.length)
-            if "title" in flac:
-                metadata["title"] = flac["title"][0]
-            if "artist" in flac:
-                metadata["artist"] = flac["artist"][0]
-            if "album" in flac:
-                metadata["album"] = flac["album"][0]
-            if "tracknumber" in flac:
-                track_str = flac["tracknumber"][0]
-                if "/" in track_str:
-                    track_str = track_str.split("/")[0]
-                try:
-                    metadata["track_number"] = int(track_str)
-                except ValueError:
-                    pass
-            if "discnumber" in flac:
-                disc_str = flac["discnumber"][0]
-                if "/" in disc_str:
-                    disc_str = disc_str.split("/")[0]
-                try:
-                    metadata["disc_number"] = int(disc_str)
-                except ValueError:
-                    pass
-            if "date" in flac:
-                try:
-                    metadata["year"] = int(flac["date"][0].split("-")[0])
-                except (ValueError, IndexError):
-                    pass
-            if "genre" in flac:
-                metadata["genre"] = flac["genre"][0]
-            if "replaygain_track_gain" in flac:
-                gain_str = flac["replaygain_track_gain"][0]
-                try:
-                    metadata["replaygain_gain"] = float(gain_str.replace(" dB", ""))
-                except ValueError:
-                    pass
-            if "replaygain_track_peak" in flac:
-                peak_str = flac["replaygain_track_peak"][0]
-                try:
-                    metadata["replaygain_peak"] = float(peak_str)
-                except ValueError:
-                    pass
-            pictures = flac.pictures
-            if pictures:
-                for pic in pictures:
-                    if pic.type == 3:  # Cover (front)
-                        metadata["album_art"] = pic.data
-                        break
-                else:
-                    metadata["album_art"] = pictures[0].data
-            return metadata
-        except Exception as e:
-            logger.exception(
-                f"Error extracting FLAC metadata from {file_path}: {str(e)}"
-            )
-            raise
+        """Extract metadata from a FLAC file.
+
+        Errors propagate to ``_extract_metadata``, which logs them once.
+        """
+        flac = FLAC(file_path)
+        metadata["duration"] = int(flac.info.length)
+        if "title" in flac:
+            metadata["title"] = flac["title"][0]
+        if "artist" in flac:
+            metadata["artist"] = flac["artist"][0]
+        if "album" in flac:
+            metadata["album"] = flac["album"][0]
+        if "tracknumber" in flac:
+            track_str = flac["tracknumber"][0]
+            if "/" in track_str:
+                track_str = track_str.split("/")[0]
+            try:
+                metadata["track_number"] = int(track_str)
+            except ValueError:
+                pass
+        if "discnumber" in flac:
+            disc_str = flac["discnumber"][0]
+            if "/" in disc_str:
+                disc_str = disc_str.split("/")[0]
+            try:
+                metadata["disc_number"] = int(disc_str)
+            except ValueError:
+                pass
+        if "date" in flac:
+            try:
+                metadata["year"] = int(flac["date"][0].split("-")[0])
+            except (ValueError, IndexError):
+                pass
+        if "genre" in flac:
+            metadata["genre"] = flac["genre"][0]
+        if "replaygain_track_gain" in flac:
+            gain_str = flac["replaygain_track_gain"][0]
+            try:
+                metadata["replaygain_gain"] = float(gain_str.replace(" dB", ""))
+            except ValueError:
+                pass
+        if "replaygain_track_peak" in flac:
+            peak_str = flac["replaygain_track_peak"][0]
+            try:
+                metadata["replaygain_peak"] = float(peak_str)
+            except ValueError:
+                pass
+        pictures = flac.pictures
+        if pictures:
+            for pic in pictures:
+                if pic.type == 3:  # Cover (front)
+                    metadata["album_art"] = pic.data
+                    break
+            else:
+                metadata["album_art"] = pictures[0].data
+        return metadata
 
     def _save_images(self, image_data: bytes, entity_id: str, entity_type: str):
         """Save artwork images in different sizes"""
@@ -716,6 +710,7 @@ class FileIndexer:
             #     doesn't masquerade as a Various-Artists compilation)
             #   * otherwise           -> a Various-Artists compilation album
             comp_title = self._compilation_title(folder)
+            album_reanchored = False
             if comp_title is None:
                 target_id = "unknown_album"
                 dest = "unknown_album"
@@ -740,7 +735,9 @@ class FileIndexer:
                 # generate_album_id (folder, normalized_title) invariant and
                 # stays stable across re-scans.
                 target_id = generate_album_id(display_title, folder)
-                await self._ensure_compilation_album(target_id, display_title, owner_id)
+                album_reanchored = await self._ensure_compilation_album(
+                    target_id, display_title, owner_id
+                )
 
             folder_repointed = 0
             for t in ts:
@@ -750,13 +747,27 @@ class FileIndexer:
                     await self.db_manager.update_track(t["id"], {"album_id": target_id})
                     folder_repointed += 1
 
-            if folder_repointed:
+            # A folder counts as coalesced when tracks moved OR an existing
+            # shared-tag album was re-anchored to Various Artists in place
+            # (no re-point needed, but still real work worth reporting).
+            if folder_repointed or album_reanchored:
                 coalesced_folders += 1
                 repointed_tracks += folder_repointed
-                logger.info(
-                    f"V/A folder '{folder}' ({n_tracks} tracks, "
-                    f"{n_artists} artists): {folder_repointed} track(s) -> {dest}"
-                )
+                # The tracks now belong to target_id; recompute its
+                # track_count/duration (the compilation album was created
+                # without them, and any source albums are about to be deleted).
+                if target_id != "unknown_album":
+                    await self.db_manager.update_album_stats(target_id)
+                if folder_repointed:
+                    logger.info(
+                        f"V/A folder '{folder}' ({n_tracks} tracks, "
+                        f"{n_artists} artists): {folder_repointed} track(s) -> {dest}"
+                    )
+                else:
+                    logger.info(
+                        f"V/A folder '{folder}' ({n_tracks} tracks, "
+                        f"{n_artists} artists): re-anchored album -> {dest}"
+                    )
             else:
                 # Already coalesced on a prior scan; idempotent no-op.
                 logger.debug(
@@ -846,10 +857,14 @@ class FileIndexer:
 
     async def _ensure_compilation_album(
         self, album_id: str, title: str, artist_id: str
-    ) -> None:
+    ) -> bool:
         """Create the compilation album, or re-anchor an existing same-id album
         (process_file may have created it under the first track's artist with a
-        different title)."""
+        different title).
+
+        Returns True if the album was created or re-anchored this call, False if
+        it already matched (so a re-scan can tell real work from a no-op).
+        """
         existing = await self.db_manager.get_album_by_id(album_id)
         if not existing:
             await self.db_manager.insert_album(
@@ -861,7 +876,8 @@ class FileIndexer:
                     "last_updated": int(time.time()),
                 }
             )
-        elif existing.get("artist_id") != artist_id or existing.get("title") != title:
+            return True
+        if existing.get("artist_id") != artist_id or existing.get("title") != title:
             await self.db_manager.update_album(
                 album_id,
                 {
@@ -870,6 +886,8 @@ class FileIndexer:
                     "last_updated": int(time.time()),
                 },
             )
+            return True
+        return False
 
     async def cleanup_stale_tracks(self) -> Dict[str, int]:
         """Remove entries that are no longer valid for the file system.
@@ -1209,7 +1227,7 @@ async def stop_file_watcher() -> bool:
 def start_file_watcher(config: LocalFilesConfig) -> Optional[asyncio.Task]:
     """Start the file watcher process in a background task if enabled"""
     global _file_watcher_task, _file_watcher_stop_event
-    if config.file_watch_enabled == False:
+    if not config.file_watch_enabled:
         logger.info("File watcher is disabled in config.")
         return None
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -22,6 +22,7 @@ class AsyncIndexerDb:
     def __init__(self, config: LocalFilesConfig):
         self.db_path = os.path.expanduser(config.db_path)
         self.artwork_path = os.path.expanduser(config.artwork_path)
+        self._columns_cache: Dict[str, set] = {}
 
         # Ensure directories exist
         db_dir = os.path.dirname(self.db_path)
@@ -100,59 +101,45 @@ class AsyncIndexerDb:
             row = await cursor.fetchone()
             return dict(row) if row else None
 
-    async def update_track(self, track_id: str, data: Dict[str, Any]) -> None:
-        """Update track information"""
+    async def _table_columns(self, conn, table: str) -> set:
+        """Return the column names for *table*, cached (schema is static)."""
+        cached = self._columns_cache.get(table)
+        if cached is not None:
+            return cached
+        cursor = await conn.execute(f"PRAGMA table_info({table})")
+        columns = {row[1] for row in await cursor.fetchall()}  # name at index 1
+        self._columns_cache[table] = columns
+        return columns
+
+    async def _update(self, table: str, entity_id: str, data: Dict[str, Any]) -> None:
+        """Update a row by id, ignoring keys that aren't real columns."""
         async with self._open() as conn:
-            cursor = await conn.cursor()
-
-            # Get track table column names
-            await cursor.execute("PRAGMA table_info(tracks)")
-            rows = await cursor.fetchall()
-            valid_columns = {row[1] for row in rows}  # Column name is at index 1
-
-            # Filter out data keys that don't exist in the tracks table
+            valid_columns = await self._table_columns(conn, table)
             filtered_data = {k: v for k, v in data.items() if k in valid_columns}
-
             if not filtered_data:
-                logger.debug(f"No valid columns to update for track {track_id}")
+                logger.debug(f"No valid columns to update for {table} {entity_id}")
                 return
 
-            # Build the SET clause with only valid columns
-            fields = []
-            values = []
-            for key, value in filtered_data.items():
-                fields.append(f"{key} = ?")
-                values.append(value)
-
-            # Add track_id to the values
-            values.append(track_id)
-
-            query = f"UPDATE tracks SET {', '.join(fields)} WHERE id = ?"
-            await cursor.execute(query, values)
+            fields = [f"{key} = ?" for key in filtered_data]
+            values = list(filtered_data.values()) + [entity_id]
+            query = f"UPDATE {table} SET {', '.join(fields)} WHERE id = ?"
+            await conn.execute(query, values)
             await conn.commit()
 
-            # Log if any fields were filtered out
-            filtered_out = set(data.keys()) - valid_columns
+            filtered_out = set(data) - valid_columns
             if filtered_out:
                 logger.debug(
-                    f"Filtered out non-existent columns for track {track_id}: {', '.join(filtered_out)}"
+                    f"Filtered out non-existent columns for {table} {entity_id}: "
+                    f"{', '.join(filtered_out)}"
                 )
+
+    async def update_track(self, track_id: str, data: Dict[str, Any]) -> None:
+        """Update track information"""
+        await self._update("tracks", track_id, data)
 
     async def update_album(self, album_id: str, data: Dict[str, Any]) -> None:
         """Update album information (only columns that exist in the table)."""
-        async with self._open() as conn:
-            cursor = await conn.cursor()
-            await cursor.execute("PRAGMA table_info(albums)")
-            valid_columns = {row[1] for row in await cursor.fetchall()}
-            filtered_data = {k: v for k, v in data.items() if k in valid_columns}
-            if not filtered_data:
-                logger.debug(f"No valid columns to update for album {album_id}")
-                return
-            fields = [f"{k} = ?" for k in filtered_data]
-            values = list(filtered_data.values()) + [album_id]
-            query = f"UPDATE albums SET {', '.join(fields)} WHERE id = ?"
-            await cursor.execute(query, values)
-            await conn.commit()
+        await self._update("albums", album_id, data)
 
     async def insert_track(self, data: Dict[str, Any]) -> None:
         """Insert a new track"""

--- a/packages/kalinka-plugin-localfiles/tests/test_va_coalescing.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_va_coalescing.py
@@ -1,18 +1,20 @@
-"""Tests for the V/A folder *detach* pass (formerly "coalescing").
+"""Tests for the V/A folder *coalesce* pass (``orphan_va_folder_tracks``).
 
-After the folder-bounded album-ID change, a folder of compilation
-tracks where each track carries its own per-album tag (e.g. a Jamendo
-playlist) still fragments into one album per track. The detach pass
-re-points every such track to the ``unknown_album`` sentinel so:
+A folder of compilation tracks where each track carries its own per-album
+tag (e.g. a Jamendo playlist) fragments into one album per track. The
+coalesce pass collapses a qualifying folder into a single album:
 
-  * the per-track single-track albums get cleaned up as orphans
-  * each track surfaces as a single under its real artist via the
-    orphan-tracks fallback in the browse view
+  * a real compilation -> a Various-Artists album titled after the folder
+    (``VA -`` prefix stripped); the per-track albums are cleaned up as orphans
+  * a folder under a real artist (remixer-credited tracks) -> that artist's album
+  * a generic dump (``music/``, ``90s Mixes``) -> tracks left loose under
+    ``unknown_album``, no fabricated album
 
-The earlier "coalesce into a Various-Artists umbrella" behaviour was
-rejected because it broke artist navigation: a track's artist_id
-correctly pointed at the real artist, but the album was anchored to
-``various_artists``, so the artist page found no albums for them.
+Each track keeps its real ``artist_id`` and still surfaces under that artist
+via ``get_artist_orphan_tracks`` (album.artist_id != track.artist_id), so the
+artist-navigation regression that sank the *earlier* umbrella-album attempt no
+longer applies. An earlier iteration instead detached such tracks to
+``unknown_album``; that behaviour was superseded by the coalesce pass.
 """
 
 from __future__ import annotations
@@ -25,6 +27,7 @@ import pytest
 from kalinka_plugin_localfiles.indexer.indexer import (
     FileIndexer,
     VA_MIN_DISTINCT_ARTISTS,
+    VARIOUS_ARTISTS_ID,
 )
 from kalinka_plugin_localfiles.utils.id_generator import (
     generate_album_id,
@@ -68,6 +71,10 @@ class FakeDb:
     async def update_track(self, track_id: str, data: Dict) -> None:
         if track_id in self.tracks:
             self.tracks[track_id].update(data)
+
+    async def update_album(self, album_id: str, data: Dict) -> None:
+        if album_id in self.albums:
+            self.albums[album_id].update(data)
 
     async def update_album_stats(self, album_id: str) -> None:
         if album_id not in self.albums:
@@ -150,21 +157,22 @@ def _seed_track(
 
 
 @pytest.mark.asyncio
-async def test_jamendo_playlist_tracks_become_singles_under_real_artists():
+async def test_jamendo_playlist_tracks_coalesce_into_one_va_album():
     """Motivating case: one folder, many single-track albums each
-    anchored to a different real artist. After detach, every track
-    points at ``unknown_album``, every per-track album is gone, and
-    no Various-Artists row is created — artist navigation now works
-    via the orphan-tracks fallback."""
+    anchored to a different real artist. After coalescing, every track
+    points at one Various-Artists album titled after the folder, the
+    per-track albums are gone, and the VA sentinel artist is created.
+    Each track keeps its real artist_id so it still browses under that
+    artist via the orphan-tracks fallback."""
     db = FakeDb()
     indexer = _make_indexer(db)
 
-    folder = "/Music/Playlist - Compilation"
+    base = "/Music/Playlist - Compilation"
     real_artist_ids = []
     for i in range(6):
         _, ar_id, _ = _seed_track(
             db,
-            f"{folder}/{i:02d} - track.mp3",
+            f"{base}/{i:02d} - track.mp3",
             artist_name=f"Artist {i}",
             album_title=f"Album {i}",
         )
@@ -173,18 +181,27 @@ async def test_jamendo_playlist_tracks_become_singles_under_real_artists():
     # Pre-state: 6 per-track albums, 6 distinct artists.
     assert len(db.albums) == 1 + 6  # unknown_album + 6 per-track albums
 
+    folder = album_folder_for_path(f"{base}/00 - track.mp3")
+    va_album_id = generate_album_id("Playlist - Compilation", folder)
+
     result = await indexer.orphan_va_folder_tracks()
 
     assert result["folders"] == 1
     assert result["tracks"] == 6
     assert result["orphans"] == 6
-    # All tracks now point to unknown_album.
+    # All tracks now point to the single VA compilation album.
     for t in db.tracks.values():
-        assert t["album_id"] == "unknown_album"
-    # The per-track albums are gone; only unknown_album survives.
-    assert set(db.albums) == {"unknown_album"}
-    # No Various-Artists row was created.
-    assert "various_artists" not in db.artists
+        assert t["album_id"] == va_album_id
+    # The per-track albums are gone; only unknown_album + the VA album survive.
+    assert set(db.albums) == {"unknown_album", va_album_id}
+    # The VA album is anchored to Various Artists, titled after the folder,
+    # and its stats reflect the coalesced tracks.
+    va_album = db.albums[va_album_id]
+    assert va_album["artist_id"] == VARIOUS_ARTISTS_ID
+    assert va_album["title"] == "Playlist - Compilation"
+    assert va_album["track_count"] == 6
+    # The Various-Artists sentinel artist was created.
+    assert VARIOUS_ARTISTS_ID in db.artists
     # The real artists are still present so their tracks can be browsed
     # under them via the orphan-tracks fallback.
     for ar_id in real_artist_ids:
@@ -192,22 +209,25 @@ async def test_jamendo_playlist_tracks_become_singles_under_real_artists():
 
 
 @pytest.mark.asyncio
-async def test_rerun_on_already_detached_folder_is_a_noop():
-    """The detach pass runs on every scan (~every 15 min). Once a V/A
-    folder's tracks are detached, a second run must report no work:
+async def test_rerun_on_already_coalesced_folder_is_a_noop():
+    """The coalesce pass runs on every scan (~every 15 min). Once a V/A
+    folder is coalesced, a second run must report no work:
     ``folders``/``tracks``/``orphans`` all zero. This is what keeps the
-    indexer from re-announcing the same detach in the logs forever."""
+    indexer from re-announcing the same coalesce in the logs forever."""
     db = FakeDb()
     indexer = _make_indexer(db)
 
-    folder = "/Music/Playlist - Compilation"
+    base = "/Music/Playlist - Compilation"
     for i in range(6):
         _seed_track(
             db,
-            f"{folder}/{i:02d} - track.mp3",
+            f"{base}/{i:02d} - track.mp3",
             artist_name=f"Artist {i}",
             album_title=f"Album {i}",
         )
+
+    folder = album_folder_for_path(f"{base}/00 - track.mp3")
+    va_album_id = generate_album_id("Playlist - Compilation", folder)
 
     first = await indexer.orphan_va_folder_tracks()
     assert first == {"folders": 1, "tracks": 6, "orphans": 6}
@@ -216,7 +236,7 @@ async def test_rerun_on_already_detached_folder_is_a_noop():
     assert second == {"folders": 0, "tracks": 0, "orphans": 0}
     # State is unchanged by the no-op second run.
     for t in db.tracks.values():
-        assert t["album_id"] == "unknown_album"
+        assert t["album_id"] == va_album_id
 
 
 @pytest.mark.asyncio
@@ -264,13 +284,14 @@ async def test_mistagged_album_is_not_detached():
 
 
 @pytest.mark.asyncio
-async def test_real_compilation_album_with_shared_tag_also_detaches():
+async def test_real_compilation_album_with_shared_tag_is_reanchored_in_place():
     """The other V/A pattern: same folder, same album tag, many
     artists (e.g., 'Now That's What I Call X'). After the folder-
     bounded change these already share one album row anchored to the
-    first track's artist. Detach still kicks in — the tracks lose
-    their album linkage and surface as singles under each real
-    artist. The umbrella album disappears from the album list."""
+    first track's artist. No track needs re-pointing, but the shared
+    album is re-anchored in place to Various Artists — counted as one
+    coalesced folder, with the album kept (not deleted) and its tracks
+    intact."""
     db = FakeDb()
     indexer = _make_indexer(db)
     folder = "/Music/Now Thats What I Call 2024"
@@ -288,11 +309,20 @@ async def test_real_compilation_album_with_shared_tag_also_detaches():
     assert original_album_id in db.albums
 
     result = await indexer.orphan_va_folder_tracks()
-    assert result["folders"] == 1
-    # Tracks all moved to unknown_album, the umbrella album was orphaned and deleted.
+    # No re-point (tracks already on the target album), but the in-place
+    # re-anchor counts as one coalesced folder.
+    assert result == {"folders": 1, "tracks": 0, "orphans": 0}
+    # The shared album survives, re-anchored to Various Artists, tracks intact.
+    assert original_album_id in db.albums
+    assert db.albums[original_album_id]["artist_id"] == VARIOUS_ARTISTS_ID
+    assert db.albums[original_album_id]["track_count"] == 5
     for t in db.tracks.values():
-        assert t["album_id"] == "unknown_album"
-    assert original_album_id not in db.albums
+        assert t["album_id"] == original_album_id
+    assert VARIOUS_ARTISTS_ID in db.artists
+
+    # Re-running is an idempotent no-op (album already correctly anchored).
+    second = await indexer.orphan_va_folder_tracks()
+    assert second == {"folders": 0, "tracks": 0, "orphans": 0}
 
 
 @pytest.mark.asyncio
@@ -330,10 +360,15 @@ async def test_disc_subdirs_count_under_the_parent_folder():
             artist_name=f"Artist {i+10}",
             album_title=f"B{i}",
         )
+    folder = album_folder_for_path(f"{parent}/Disc 1/00.flac")
+    va_album_id = generate_album_id("Massive Compilation", folder)
+
     result = await indexer.orphan_va_folder_tracks()
     assert result["folders"] == 1
+    # Both discs collapse into one VA album under the parent folder.
     for t in db.tracks.values():
-        assert t["album_id"] == "unknown_album"
+        assert t["album_id"] == va_album_id
+    assert db.albums[va_album_id]["artist_id"] == VARIOUS_ARTISTS_ID
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reviewed the AI-heavy **embedder**, **enricher**, and **indexer** implementations for AI slop and fixed the real issues found. Every HIGH-severity finding was verified against the code (two suspected bugs turned out to be false positives and were left untouched).

## Bugs fixed
- **Indexer — V/A compilation track counts**: `orphan_va_folder_tracks` re-points tracks to a compilation album but never recomputed its stats, so coalesced compilations showed `track_count`/`duration` of 0. Now calls `update_album_stats`.
- **Enricher — AcoustID blocked the event loop**: `async def enrich_track` ran the blocking `fpcalc` subprocess, `requests.get`, and rate-limit `time.sleep` directly on the loop, stalling every other enricher coroutine (deezer/wikidata correctly use `httpx`). Offloaded both blocking helpers to `asyncio.to_thread`.

## V/A coalescing reporting + stale tests
- An already-shared-tag compilation is now **re-anchored to Various Artists in place and counted as one coalesced folder** (previously reported as a no-op). `_ensure_compilation_album` returns whether it changed the album.
- `test_va_coalescing.py` still asserted the **superseded "detach to `unknown_album`"** behavior — left stale when coalescing was re-introduced in `9e9e1f2`. Rewritten to match current behavior; added the missing `FakeDb.update_album` (the cause of an `AttributeError`).

## Slop cleanup
- **embedder**: removed dead `_last_work_time` writes; dropped unused `complete_tags_job` (the searcher owns tags); fixed stale "Essentia" / "HTSAT-tiny" comments.
- **enricher**: removed dead `entities_for_enrichment`, the always-empty `enricher_tasks` set + cleanup loop, and commented-out re-queue blocks; fixed a misleading `queue.Empty` comment; `__import__("time")` → `import time`.
- **indexer**: `== False` → `not`; removed double-logging in the metadata extractors.
- **db layers**: collapsed the byte-identical `update_artist`/`update_album`/`update_track` methods into one `_update` helper and cached column sets (drops a per-update `PRAGMA table_info` query) in both `enricher_db` and `indexer_db`.

## Deliberately skipped
- Per-connection `PRAGMA journal_mode=WAL` + connection-churn — consistent across all 5 DB files and WAL is already persisted at schema creation; the real fix is a cross-cutting refactor with concurrency risk for negligible gain.
- `gc.collect()` per audio fragment — intentional for Pi memory pressure.

## Testing
All **212** plugin tests pass (`test_va_coalescing` previously had 4 stale failures, now green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)