### PR TITLE
playqueue: resolve stream URLs off the serial lane

### DIFF
--- a/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
+++ b/packages/kalinka-plugin-jamendo/src/kalinka_plugin_jamendo/jamendo.py
@@ -98,8 +98,11 @@ def catalog_id(id: str) -> EntityId:
 
 
 class RetryTransport(httpx.AsyncHTTPTransport):
-    def __init__(self, read_retries=3, **kwargs):
+    def __init__(self, read_retries=2, **kwargs):
         super().__init__(**kwargs)
+        # read_retries is the total number of attempts (1 initial + N-1 retries).
+        # Kept low so a request fails fast when the server has no internet —
+        # otherwise the playqueue's resolution slot stays occupied far too long.
         self.read_retries = read_retries
         self.backoff_factor = 0.5
 
@@ -150,8 +153,11 @@ class JamendoClient:
         self.client_id = client_id
         self.base = BASE_URL
         self.session = httpx.AsyncClient(
-            transport=RetryTransport(read_retries=3, retries=3),
-            timeout=10,
+            # 2 attempts (1 initial + 1 retry), 3s per attempt. RetryTransport
+            # already retries connect failures, so httpx-level retries=0 avoids
+            # multiplying the worst-case wait.
+            transport=RetryTransport(read_retries=2, retries=0),
+            timeout=3,
         )
         self.session.headers.update(
             {

--- a/packages/kalinka-server/src/kalinka_serialized/__init__.py
+++ b/packages/kalinka-server/src/kalinka_serialized/__init__.py
@@ -1,3 +1,4 @@
+from .resolution_slot import ResolutionSlot
 from .serial_executor import (
     DeadlockError,
     SerialExecutor,
@@ -10,6 +11,7 @@ from .serial_executor import (
 __version__ = "0.1.0"
 __all__ = [
     "DeadlockError",
+    "ResolutionSlot",
     "SerialExecutor",
     "StateWatcher",
     "interrupt",

--- a/packages/kalinka-server/src/kalinka_serialized/resolution_slot.py
+++ b/packages/kalinka-server/src/kalinka_serialized/resolution_slot.py
@@ -1,0 +1,79 @@
+"""Single-slot cancellable async operation with a fencing token.
+
+Only one operation runs at a time. Starting a new one — or explicitly
+superseding — cancels the previous task and bumps a generation counter. A
+late-arriving continuation calls :meth:`is_current` with the generation it was
+handed to detect that it was superseded and bail out silently (so it applies no
+side effects). :meth:`cancel_if` lets external state changes abort the in-flight
+operation when a predicate over its target says they invalidate it.
+
+This pairs with :class:`SerialExecutor`: the slot keeps slow I/O *off* the serial
+lane (one cancellable task at a time), while the continuation re-enters the lane
+to apply its result, fenced by the generation so a superseded result is dropped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, Coroutine, Optional
+
+_CoroFactory = Callable[[int], Coroutine[Any, Any, Any]]
+
+
+class ResolutionSlot:
+    """Holds at most one in-flight async operation, with generation fencing."""
+
+    def __init__(self) -> None:
+        self._task: Optional[asyncio.Task] = None
+        self._gen: int = 0
+        # The target (e.g. a track index) the in-flight operation is working on.
+        # Used by cancel_if_affected; None while idle.
+        self.target: Optional[int] = None
+
+    @property
+    def active(self) -> bool:
+        """True while an operation is in flight."""
+        return self._task is not None
+
+    def start(self, make_coro: _CoroFactory, target: int) -> int:
+        """Cancel any in-flight operation and start a new one.
+
+        ``make_coro`` is called with the new generation token; the coroutine must
+        pass it to :meth:`is_current` before applying any side effect, and to
+        :meth:`finish` once applied. Returns the new generation.
+        """
+        self.supersede()
+        self._gen += 1
+        gen = self._gen
+        self.target = target
+        self._task = asyncio.create_task(make_coro(gen))
+        return gen
+
+    def supersede(self) -> None:
+        """Fence any queued continuation and cancel the in-flight task."""
+        self._gen += 1
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+        self.target = None
+
+    def cancel_if(self, predicate: Callable[[int], bool]) -> None:
+        """Supersede the in-flight operation iff one is running and ``predicate``
+        returns True for its target. ``predicate`` is only called when active, so
+        callers never have to guard against an absent target."""
+        if self._task is not None and predicate(self.target):
+            self.supersede()
+
+    def is_current(self, gen: int) -> bool:
+        """True if ``gen`` is still the latest generation (not superseded)."""
+        return gen == self._gen
+
+    def finish(self, gen: int) -> None:
+        """Clear the slot once the current operation has applied its result.
+
+        A no-op if the operation was already superseded, so a stale continuation
+        can never clear a newer operation's task.
+        """
+        if gen == self._gen:
+            self._task = None
+            self.target = None

--- a/packages/kalinka-server/src/kalinka_server/playqueue.py
+++ b/packages/kalinka-server/src/kalinka_server/playqueue.py
@@ -10,7 +10,12 @@ from kalinka_serialized.serial_executor import interrupt
 from .alsa_volume_device import AlsaVolumeControlDevice
 from .config_model import KalinkaConfig
 
-from kalinka_serialized import SerialExecutor, serialised, with_serial_executor
+from kalinka_serialized import (
+    ResolutionSlot,
+    SerialExecutor,
+    serialised,
+    with_serial_executor,
+)
 
 from kalinka_plugin_sdk.datamodel import (
     EntityId,
@@ -72,6 +77,11 @@ logger = logging.getLogger(__name__.split(".")[-1])
 # };
 
 PREFETCH_TIME_MS = 5000
+
+# Upper bound for a single link_retriever() call. Plugins set their own (smaller)
+# HTTP timeouts; this is a backstop so a misbehaving plugin can never pin the
+# resolution slot indefinitely. Generous enough to allow one in-plugin retry.
+LINK_RETRIEVAL_TIMEOUT_S = 8
 
 
 def _remap_index(idx: int, from_index: int, to_index: int) -> int:
@@ -240,6 +250,9 @@ class PlayQueueImpl(PlayQueueController):
         # on real state changes. Kept in sync with track_list across mutations.
         self._unavailable_indices: set[int] = set()
 
+        # Single in-flight URL resolution; see "Off-lane URL resolution" below.
+        self._resolution = ResolutionSlot()
+
         self._state_update_task = None
 
     async def __aenter__(self):
@@ -252,6 +265,7 @@ class PlayQueueImpl(PlayQueueController):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Stop the play queue and cleanup resources."""
+        self._resolution.supersede()
         self._terminate()
         if self._state_update_task:
             self._state_update_task.cancel()
@@ -334,24 +348,38 @@ class PlayQueueImpl(PlayQueueController):
                 return
             self._cancel_prefetch_timer()
         elif new_state.state == AudioGraphNodeState.FINISHED:
-            # Only auto-play next if no streams are already queued.
-            # Non-empty prepared_tracks means a manual switch already appended
-            # a new stream — SOURCE_CHANGED will handle the transition.
-            if self._prefetch_task is None and not self.prepared_tracks:
-                await self._play_unqueued(self.current_track_id + 1)
+            # Only auto-play next if no streams are already queued and no
+            # resolution is already in flight (a manual switch). Non-empty
+            # prepared_tracks means a manual switch already appended a new
+            # stream — SOURCE_CHANGED will handle the transition.
+            if (
+                self._prefetch_task is None
+                and not self.prepared_tracks
+                and not self._resolution.active
+            ):
+                target = self.current_track_id + 1
+                self._begin_resolution(
+                    target,
+                    resolve=lambda: self._resolve_playable(target, 1),
+                    next_step=self._play_resolved,
+                )
         elif new_state.state == AudioGraphNodeState.STOPPED:
             # The prefetch may have completed and appended a stream just as the
             # native player ran out of time and stopped.  If a stream is already
             # queued and the player is still stopped (i.e. play_next hasn't
-            # restarted it yet), do a full _play_unqueued so the remove+append
-            # cycle kicks the player back into motion.
+            # restarted it yet), kick the player back into motion.
             if (
                 self.prepared_tracks
+                and not self._resolution.active
                 and self._track_player.get_state().state == AudioGraphNodeState.STOPPED
             ):
                 next_idx = next(iter(self.prepared_tracks))
-                await self._play_unqueued(next_idx)
-                return  # new playback started; its own state events will follow
+                self._begin_resolution(
+                    next_idx,
+                    resolve=lambda: self._resolve_playable(next_idx, 1),
+                    next_step=self._play_resolved,
+                )
+                return  # resolution started; its own state events will follow
             self._cancel_prefetch_timer()
         elif new_state.state == AudioGraphNodeState.STREAMING:
             self._setup_prefetch_timer(new_state)
@@ -387,35 +415,120 @@ class PlayQueueImpl(PlayQueueController):
         # ±1 boundary stepping done by next()/prev()).
         if index is not None and index not in range(0, len(self.track_list)):
             return
-        await self._play_unqueued(index)
+        if len(self.track_list) == 0:
+            return
+        target = self.current_track_id if index is None else index
+        self._begin_resolution(
+            target,
+            resolve=lambda: self._resolve_playable(target, 1),
+            next_step=self._play_resolved,
+        )
 
     @serialised
     async def play_next(self, index: int) -> None:
-        return await self._play_next_unqueued(index)
-
-    async def _play_unqueued(self, index=None, step=1):
-        self._retry_attempted = False
+        # play_next is index-addressed; an out-of-range or already-queued index
+        # is a no-op. (Prefetch wraps via _play_next_track_async before calling.)
         if len(self.track_list) == 0:
             return
-
-        if index is None:
-            index = self.current_track_id
-
-        resolved_index, track_info = await self._resolve_playable(index, step)
-        if track_info is None:
-            # Nothing playable in this direction: either we ran off the end of
-            # the queue (normal no-op, as before) or every remaining track
-            # failed to yield a URL — in which case _resolve_playable has
-            # already flagged them. Leave any current playback untouched.
+        if index not in range(0, len(self.track_list)) or index in self.prepared_tracks:
             return
-        index = resolved_index
+        logger.info(f"Prefetching next track index={index}")
+        self._begin_resolution(
+            index,
+            resolve=lambda: self._resolve_playable(index, 1),
+            next_step=self._prefetch_resolved,
+            cancel_prefetch=False,  # this *is* the prefetch; don't cancel its timer
+        )
 
-        self._cancel_prefetch_timer()
+    # ------------------------------------------------------------------
+    # Off-lane URL resolution
+    #
+    # link_retriever() is the only slow (network) operation in the playqueue.
+    # Running it inside the serial executor would freeze every other command and
+    # the state-update interrupt lane while a streaming plugin times out. So each
+    # command splits in two: a serialised entry point that kicks off the (slow)
+    # ``resolve`` off the lane, and a serialised ``next_step`` that applies the
+    # result back on the lane once the URL is in hand. Only one resolution runs
+    # at a time; a new one cancels the previous, which then returns silently
+    # (no TrackUnavailableEvent).
+    # ------------------------------------------------------------------
 
-        # Remove any prefetched streams.
+    def _begin_resolution(
+        self,
+        target: int,
+        resolve: Callable[[], Awaitable],
+        next_step: Callable[[int, object], Awaitable[None]],
+        cancel_prefetch: bool = True,
+    ) -> None:
+        """Cancel any in-flight resolution and start a new one. Returns at once.
+
+        ``resolve`` runs the URL fetch off the serial lane; ``next_step`` is a
+        serialised method invoked with ``(gen, result)`` to apply it. Must be
+        called from the serial (or interrupt) lane so the cancel + swap of the
+        single resolution slot is atomic with respect to other commands.
+        """
+        if cancel_prefetch:
+            self._cancel_prefetch_timer()
+        self._resolution.start(
+            lambda gen: self._drive_resolution(gen, resolve, next_step),
+            target=target,
+        )
+
+    async def _drive_resolution(self, gen, resolve, next_step) -> None:
+        """Run ``resolve`` off-lane, then hand its result to ``next_step``.
+
+        Cancellation (a superseding command or an affecting structural mutation)
+        propagates out silently: no events are emitted and nothing is applied.
+        """
+        try:
+            result = await resolve()
+            await next_step(gen, result)
+        except Exception:
+            # CancelledError (a superseding command or affecting mutation) is a
+            # BaseException and propagates silently; only real errors are logged.
+            logger.exception("URL resolution task failed")
+
+    def _accept_scan(self, gen: int, result):
+        """Fence a scan result, flag the failed indices, return the playable
+        ``(index, track_info)`` to apply — or None if superseded / nothing
+        playable. Runs on the lane (called from a serialised next_step)."""
+        if not self._resolution.is_current(gen):
+            return None
+        self._resolution.finish(gen)
+        index, track_info, failed = result
+        # Flag failures only now, on the lane, so the marks (and their dedup
+        # state) stay consistent with mutations that remap _unavailable_indices.
+        for i in failed:
+            self._set_track_unavailable(i, True)
+        if track_info is None or index is None:
+            return None
+        self._set_track_unavailable(index, False)
+        return index, track_info
+
+    @serialised
+    async def _play_resolved(self, gen, result) -> None:
+        playable = self._accept_scan(gen, result)
+        if playable is not None:
+            self._apply_play(*playable)
+
+    @serialised
+    async def _prefetch_resolved(self, gen, result) -> None:
+        playable = self._accept_scan(gen, result)
+        if playable is not None:
+            self._apply_prefetch(*playable)
+
+    def _clear_prepared_streams(self) -> None:
+        """Remove every prefetched native stream and empty the prepared map."""
         for _, (_, stream_id) in list(self.prepared_tracks.items()):
             self._track_player.remove(stream_id)
         self.prepared_tracks.clear()
+
+    def _apply_play(self, index: int, track_info) -> None:
+        """Replace current playback with the already-resolved track."""
+        self._retry_attempted = False
+        self._cancel_prefetch_timer()
+
+        self._clear_prepared_streams()
 
         # Append new stream — auto-starts. prepared_tracks is non-empty so the
         # FINISHED handler (triggered by the removals above) will not auto-play.
@@ -428,39 +541,15 @@ class PlayQueueImpl(PlayQueueController):
             self._track_player.remove(self.current_stream_id)
             self.current_stream_id = None
 
-    async def _play_next_unqueued(self, index):
-        if len(self.track_list) == 0:
-            return
-
-        # play_next is index-addressed; an out-of-range index is a no-op.
-        # (Prefetch already wraps via _play_next_track_async before calling.)
-        if index not in range(0, len(self.track_list)) or index in self.prepared_tracks:
-            return
-
-        logger.info(f"Playing next track index={index}")
-
-        # If the player is already stopped, skip straight to _play_unqueued to
-        # avoid a wasteful append+remove cycle.
-        if self._track_player.get_state().state == AudioGraphNodeState.STOPPED:
-            await self._play_unqueued(index)
-            return
-
-        resolved_index, track_info = await self._resolve_playable(index, step=1)
-        if track_info is None:
-            return
-        index = resolved_index
-
-        # Skipping unavailable tracks may have landed on one that is already
-        # queued — nothing more to do in that case.
+    def _apply_prefetch(self, index: int, track_info) -> None:
+        """Append the already-resolved track as the upcoming stream."""
+        # Resolution may have landed on a now-queued index, or the player may
+        # have stopped while we were fetching — fall back to a full replace.
         if index in self.prepared_tracks:
             return
-
-        # If the player stopped while we were awaiting the URL, fall back to a
-        # full _play_unqueued so the remove+append cycle restarts it.
         if self._track_player.get_state().state == AudioGraphNodeState.STOPPED:
-            await self._play_unqueued(index)
+            self._apply_play(index, track_info)
             return
-
         stream_id = self._track_player.append(
             track_info.url, mime_to_format(track_info.format)
         )
@@ -475,11 +564,25 @@ class PlayQueueImpl(PlayQueueController):
 
     @serialised
     async def next(self):
-        await self._play_unqueued(self.current_track_id + 1)
+        if len(self.track_list) == 0:
+            return
+        target = self.current_track_id + 1
+        self._begin_resolution(
+            target,
+            resolve=lambda: self._resolve_playable(target, 1),
+            next_step=self._play_resolved,
+        )
 
     @serialised
     async def prev(self):
-        await self._play_unqueued(self.current_track_id - 1, step=-1)
+        if len(self.track_list) == 0:
+            return
+        target = self.current_track_id - 1
+        self._begin_resolution(
+            target,
+            resolve=lambda: self._resolve_playable(target, -1),
+            next_step=self._play_resolved,
+        )
 
     @serialised
     async def seek(self, position_ms: int) -> None:
@@ -501,6 +604,10 @@ class PlayQueueImpl(PlayQueueController):
         insert_at = len(self.track_list) if index is None else index
         # Clamp to valid range
         insert_at = max(0, min(insert_at, len(self.track_list)))
+
+        # An insertion at or before the index a resolution is fetching shifts
+        # that target, so the in-flight resolution must be cancelled.
+        self._resolution.cancel_if(lambda target: insert_at <= target)
 
         was_empty = len(self.track_list) == 0
         old_current_track_id = self.current_track_id
@@ -525,21 +632,7 @@ class PlayQueueImpl(PlayQueueController):
             for idx in self._unavailable_indices
         }
 
-        # Validate prefetched next track (same pattern as move())
-        expected_next = self.current_track_id
-        if not self.repeat_single:
-            expected_next += 1
-        if self.repeat_all and expected_next >= len(self.track_list):
-            expected_next = 0
-
-        for idx in list(self.prepared_tracks.keys()):
-            if idx == self.current_track_id:
-                continue
-            if idx != expected_next:
-                _, stream_id = self.prepared_tracks.pop(idx)
-                self._track_player.remove(stream_id)
-                self._cancel_prefetch_timer()
-                self._prefetch_task = asyncio.create_task(self._play_next_track_async())
+        self._revalidate_prefetched_next()
 
         self.event_emitter.dispatch(
             TracksAddedEvent(
@@ -562,6 +655,10 @@ class PlayQueueImpl(PlayQueueController):
     @serialised
     async def remove(self, tracks: list[int]):
         prev_track_id = self.current_track_id
+
+        # Removing the resolution target, or any track before it (which shifts
+        # it down), invalidates the in-flight resolution.
+        self._resolution.cancel_if(lambda target: any(t <= target for t in tracks))
 
         tracks.sort(reverse=True)
         for track in tracks:
@@ -673,6 +770,7 @@ class PlayQueueImpl(PlayQueueController):
         was_already_stopped = (
             self._track_player.get_state().state == AudioGraphNodeState.STOPPED
         )
+        self._resolution.supersede()
         self._track_player.stop()
         self.current_stream_id = None
 
@@ -768,6 +866,11 @@ class PlayQueueImpl(PlayQueueController):
         if to_index not in range(0, len(self.track_list)):
             return
 
+        # A move re-indexes everything between from_index and to_index; if the
+        # resolution target falls in that span its index changes, so cancel it.
+        lo, hi = min(from_index, to_index), max(from_index, to_index)
+        self._resolution.cancel_if(lambda target: lo <= target <= hi)
+
         # Reorder the track list
         track = self.track_list.pop(from_index)
         self.track_list.insert(to_index, track)
@@ -790,22 +893,7 @@ class PlayQueueImpl(PlayQueueController):
             for idx in self._unavailable_indices
         }
 
-        # Verify the prefetched "next" track is still the correct one.
-        # If the wrong track is queued as next, remove it and re-prefetch.
-        expected_next = self.current_track_id
-        if not self.repeat_single:
-            expected_next += 1
-        if self.repeat_all and expected_next >= len(self.track_list):
-            expected_next = 0
-
-        for idx in list(self.prepared_tracks.keys()):
-            if idx == self.current_track_id:
-                continue
-            if idx != expected_next:
-                _, stream_id = self.prepared_tracks.pop(idx)
-                self._track_player.remove(stream_id)
-                self._cancel_prefetch_timer()
-                self._prefetch_task = asyncio.create_task(self._play_next_track_async())
+        self._revalidate_prefetched_next()
 
         self.event_emitter.dispatch(
             TrackMovedEvent(from_index=from_index, to_index=to_index)
@@ -823,6 +911,7 @@ class PlayQueueImpl(PlayQueueController):
         was_already_stopped = (
             self._track_player.get_state().state == AudioGraphNodeState.STOPPED
         )
+        self._resolution.supersede()
         self._cancel_prefetch_timer()
         self._track_player.clear_all()
         self.current_stream_id = None
@@ -858,10 +947,17 @@ class PlayQueueImpl(PlayQueueController):
         return progress
 
     async def _fetch_track_url(self, index):
-        """Fetch the stream URL for a track, returning None if retrieval fails."""
-        track = self.track_list[index]
+        """Fetch the stream URL for a track, returning None if retrieval fails.
+
+        Bounded by LINK_RETRIEVAL_TIMEOUT_S so a plugin that ignores its own
+        HTTP timeout can never pin the resolution slot indefinitely. Runs
+        off-lane, so a slow fetch never blocks the serial executor.
+        """
         try:
-            return await track.link_retriever()
+            track = self.track_list[index]
+            return await asyncio.wait_for(
+                track.link_retriever(), timeout=LINK_RETRIEVAL_TIMEOUT_S
+            )
         except Exception as e:
             logger.warning(
                 "Failed to retrieve track link for index %d: %s", index, repr(e)
@@ -871,17 +967,19 @@ class PlayQueueImpl(PlayQueueController):
     async def _resolve_playable(self, start_index, step=1):
         """Find the first playable track from start_index, moving by ``step``.
 
-        ``step`` must be +1 (forward) or -1 (backward); any other value is
-        normalised to one of those so the scan visits each track at most once
-        and never stalls re-fetching the same index. Tracks whose URL cannot be
-        retrieved are marked unavailable (so clients can flag them) and skipped.
-        Returns ``(index, track_url)`` for the first track that yields a URL, or
-        ``(None, None)`` if none do in that direction. Already-prepared tracks
-        are returned from cache.
+        Pure I/O: runs off the serial lane and performs no state mutation or
+        event dispatch — the caller's commit step records which indices failed
+        (so they can be flagged) and which one succeeded. ``step`` must be +1
+        (forward) or -1 (backward); any other value is normalised so the scan
+        visits each track at most once. Returns ``(index, track_url, failed)``
+        for the first track that yields a URL (``failed`` lists the indices that
+        did not), or ``(None, None, failed)`` if none do in that direction.
+        Already-prepared tracks are returned from cache.
         """
         n = len(self.track_list)
+        failed: list[int] = []
         if n == 0:
-            return None, None
+            return None, None, failed
 
         step = 1 if step >= 0 else -1
 
@@ -891,17 +989,16 @@ class PlayQueueImpl(PlayQueueController):
                 if self.repeat_all:
                     index %= n
                 else:
-                    return None, None
+                    return None, None, failed
             if index in self.prepared_tracks:
                 # Already prepared — its URL is known good.
-                return index, self.prepared_tracks[index][0]
+                return index, self.prepared_tracks[index][0], failed
             track_info = await self._fetch_track_url(index)
             if track_info is not None:
-                self._set_track_unavailable(index, False)
-                return index, track_info
-            self._set_track_unavailable(index, True)
+                return index, track_info, failed
+            failed.append(index)
             index += step
-        return None, None
+        return None, None, failed
 
     def _set_track_unavailable(self, index, unavailable):
         """Notify clients of a track availability change (only on real change)."""
@@ -918,34 +1015,50 @@ class PlayQueueImpl(PlayQueueController):
         )
 
     async def _retry_current_track_async(self, position_ms: int) -> None:
-        """Re-fetch the URL for the current track and resume from position_ms."""
-        track_index = self.current_track_id
-        track = self.track_list[track_index]
+        """Re-fetch the current track's URL off-lane and resume from position_ms.
 
-        try:
-            track_info = await track.link_retriever()
-        except Exception as e:
-            logger.warning("Retry: failed to retrieve track link: %s", repr(e))
+        Called from the state-update interrupt lane on an HTTP stream error. The
+        fetch must not run here (it would block the interrupt lane and stall all
+        state updates), so it is delegated to the off-lane resolver. Unlike
+        play/next, retry targets exactly the current track (single fetch, no
+        skipping) and reports failure as a PlaybackErrorEvent.
+        """
+        index = self.current_track_id
+        self._begin_resolution(
+            index,
+            resolve=lambda: self._fetch_track_url(index),
+            next_step=lambda gen, track_info: self._retry_resolved(
+                gen, index, track_info, position_ms
+            ),
+        )
+
+    @serialised
+    async def _retry_resolved(self, gen, index, track_info, position_ms) -> None:
+        if not self._resolution.is_current(gen):
+            return
+        self._resolution.finish(gen)
+        if track_info is None:
             self.event_emitter.dispatch(
                 PlaybackErrorEvent(message="Failed to retrieve track link on retry")
             )
             return
+        self._apply_retry(index, track_info, position_ms)
 
+    def _apply_retry(self, index: int, track_info, position_ms: int) -> None:
+        """Re-append the already-resolved current track and seek to position_ms."""
         self._cancel_prefetch_timer()
 
         if self.current_stream_id is not None:
             self._track_player.remove(self.current_stream_id)
             self.current_stream_id = None
 
-        for _, (_, stream_id) in list(self.prepared_tracks.items()):
-            self._track_player.remove(stream_id)
-        self.prepared_tracks.clear()
+        self._clear_prepared_streams()
 
         self._retry_pending = True
         stream_id = self._track_player.append(
             track_info.url, mime_to_format(track_info.format)
         )
-        self.prepared_tracks[track_index] = (track_info, stream_id)
+        self.prepared_tracks[index] = (track_info, stream_id)
 
         if position_ms > 0:
             self._track_player.seek(position_ms)
@@ -983,14 +1096,31 @@ class PlayQueueImpl(PlayQueueController):
             logger.debug("Prefetch timer cancelled")
             raise
 
-    async def _play_next_track_async(self):
-        next_track_id = self.current_track_id
+    def _next_index(self) -> int:
+        """The index that should play after the current track, honoring the
+        repeat modes (repeat_single stays put; repeat_all wraps to 0)."""
+        nxt = self.current_track_id
         if not self.repeat_single:
-            next_track_id += 1
-        if self.repeat_all and next_track_id >= len(self.track_list):
-            next_track_id = 0
+            nxt += 1
+        if self.repeat_all and nxt >= len(self.track_list):
+            nxt = 0
+        return nxt
 
-        await self.play_next(next_track_id)
+    def _revalidate_prefetched_next(self) -> None:
+        """After a structural change, drop any prefetched stream that is no
+        longer the correct next track and re-prefetch the right one."""
+        expected_next = self._next_index()
+        for idx in list(self.prepared_tracks.keys()):
+            if idx == self.current_track_id:
+                continue
+            if idx != expected_next:
+                _, stream_id = self.prepared_tracks.pop(idx)
+                self._track_player.remove(stream_id)
+                self._cancel_prefetch_timer()
+                self._prefetch_task = asyncio.create_task(self._play_next_track_async())
+
+    async def _play_next_track_async(self):
+        await self.play_next(self._next_index())
 
     def _cancel_prefetch_timer(self):
         if self._prefetch_task is not None:

--- a/packages/kalinka-server/src/kalinka_server/playqueue.py
+++ b/packages/kalinka-server/src/kalinka_server/playqueue.py
@@ -495,12 +495,19 @@ class PlayQueueImpl(PlayQueueController):
         if not self._resolution.is_current(gen):
             return None
         self._resolution.finish(gen)
-        index, track_info, failed = result
+        index, track_info, track_ref, failed = result
         # Flag failures only now, on the lane, so the marks (and their dedup
         # state) stay consistent with mutations that remap _unavailable_indices.
         for i in failed:
             self._set_track_unavailable(i, True)
         if track_info is None or index is None:
+            return None
+        # A multi-step scan can resolve an index *past* the start target, and a
+        # structural edit in the (target, index] band isn't covered by
+        # cancel_if (its predicate keys on the start target). Re-validate that
+        # the resolved index still points at the track we fetched; if it shifted
+        # under us, bail silently and let the next command re-resolve.
+        if index >= len(self.track_list) or self.track_list[index] is not track_ref:
             return None
         self._set_track_unavailable(index, False)
         return index, track_info
@@ -971,15 +978,17 @@ class PlayQueueImpl(PlayQueueController):
         event dispatch — the caller's commit step records which indices failed
         (so they can be flagged) and which one succeeded. ``step`` must be +1
         (forward) or -1 (backward); any other value is normalised so the scan
-        visits each track at most once. Returns ``(index, track_url, failed)``
-        for the first track that yields a URL (``failed`` lists the indices that
-        did not), or ``(None, None, failed)`` if none do in that direction.
+        visits each track at most once. Returns
+        ``(index, track_url, track_ref, failed)`` for the first track that yields
+        a URL — ``track_ref`` is the TrackInfo whose link produced the URL, so
+        the commit can detect a concurrent reindex — or
+        ``(None, None, None, failed)`` if none do in that direction.
         Already-prepared tracks are returned from cache.
         """
         n = len(self.track_list)
         failed: list[int] = []
         if n == 0:
-            return None, None, failed
+            return None, None, None, failed
 
         step = 1 if step >= 0 else -1
 
@@ -989,16 +998,21 @@ class PlayQueueImpl(PlayQueueController):
                 if self.repeat_all:
                     index %= n
                 else:
-                    return None, None, failed
+                    return None, None, None, failed
             if index in self.prepared_tracks:
                 # Already prepared — its URL is known good.
-                return index, self.prepared_tracks[index][0], failed
+                return index, self.prepared_tracks[index][0], self.track_list[index], failed
+            # Capture the track ref before awaiting: _fetch_track_url reads the
+            # same self.track_list[index] before its own await, so this is the
+            # exact track the resolved URL belongs to even if the list shifts
+            # during the await.
+            track_ref = self.track_list[index]
             track_info = await self._fetch_track_url(index)
             if track_info is not None:
-                return index, track_info, failed
+                return index, track_info, track_ref, failed
             failed.append(index)
             index += step
-        return None, None, failed
+        return None, None, None, failed
 
     def _set_track_unavailable(self, index, unavailable):
         """Notify clients of a track availability change (only on real change)."""

--- a/packages/kalinka-server/tests/test_playqueue.py
+++ b/packages/kalinka-server/tests/test_playqueue.py
@@ -1244,51 +1244,56 @@ def make_tracks_with_failures(n: int, failing: set[int]) -> list[TrackInfo]:
 
 @pytest.mark.asyncio
 async def test_resolve_playable_skips_failed_track(event_emitter, playqueue):
-    """A track whose URL can't be fetched is marked and skipped; the next
-    playable track is returned."""
+    """A track whose URL can't be fetched is collected in ``failed`` and skipped;
+    the next playable track is returned. The pure resolver mutates no state and
+    dispatches no events (the commit step flags failures)."""
     playqueue.track_list = make_tracks_with_failures(3, {0})
     event_emitter.reset_mock()
 
-    index, track_url = await playqueue._resolve_playable(0, step=1)
+    index, track_url, failed = await playqueue._resolve_playable(0, step=1)
 
     assert index == 1
     assert track_url is not None
-    assert playqueue._unavailable_indices == {0}
-    unavailable_events = [
-        e for e in dispatched_events(event_emitter) if isinstance(e, TrackUnavailableEvent)
-    ]
-    assert unavailable_events == [TrackUnavailableEvent(index=0, unavailable=True)]
+    assert failed == [0]
+    # Resolver is pure: no flagging, no events.
+    assert playqueue._unavailable_indices == set()
+    assert not any(
+        isinstance(e, TrackUnavailableEvent) for e in dispatched_events(event_emitter)
+    )
 
 
 @pytest.mark.asyncio
 async def test_resolve_playable_all_failed_returns_none(event_emitter, playqueue):
-    """When every candidate fails, resolve returns (None, None) and marks all."""
+    """When every candidate fails, resolve returns (None, None, all-indices)."""
     playqueue.track_list = make_tracks_with_failures(3, {0, 1, 2})
     event_emitter.reset_mock()
 
-    index, track_url = await playqueue._resolve_playable(0, step=1)
+    index, track_url, failed = await playqueue._resolve_playable(0, step=1)
 
     assert index is None
     assert track_url is None
-    assert playqueue._unavailable_indices == {0, 1, 2}
+    assert failed == [0, 1, 2]
+    # Resolver does not mutate flag state; the commit step would.
+    assert playqueue._unavailable_indices == set()
 
 
 @pytest.mark.asyncio
-async def test_resolve_playable_clears_flag_on_success(event_emitter, playqueue):
-    """A previously-unavailable track that now resolves clears its flag."""
+async def test_resolve_playable_success_reports_no_failures(event_emitter, playqueue):
+    """A track that resolves on the first try yields an empty ``failed`` list and
+    leaves flag state untouched (clearing is the commit's job)."""
     playqueue.track_list = make_tracks(3)
     playqueue._unavailable_indices = {0}
     event_emitter.reset_mock()
 
-    index, track_url = await playqueue._resolve_playable(0, step=1)
+    index, track_url, failed = await playqueue._resolve_playable(0, step=1)
 
     assert index == 0
     assert track_url is not None
-    assert playqueue._unavailable_indices == set()
-    unavailable_events = [
-        e for e in dispatched_events(event_emitter) if isinstance(e, TrackUnavailableEvent)
-    ]
-    assert unavailable_events == [TrackUnavailableEvent(index=0, unavailable=False)]
+    assert failed == []
+    assert playqueue._unavailable_indices == {0}
+    assert not any(
+        isinstance(e, TrackUnavailableEvent) for e in dispatched_events(event_emitter)
+    )
 
 
 @pytest.mark.asyncio
@@ -1401,6 +1406,132 @@ async def test_play_next_out_of_range_index_is_noop(event_emitter, playqueue):
         isinstance(e, TrackUnavailableEvent)
         for e in dispatched_events(event_emitter)
     )
+
+
+# ── Off-lane URL resolution semantics ───────────────────────────────────────────
+#
+# These verify the *wiring* between PlayQueueImpl and its ResolutionSlot. They use
+# a never-resolving link_retriever so resolution stays in flight and nothing ever
+# commits to the native player — keeping the real AudioPlayer untouched. The slot
+# mechanics themselves are unit-tested in test_resolution_slot.py; end-to-end
+# playback (commit → native append) is covered by the streaming tests above.
+
+
+async def _never_resolves():
+    """A link_retriever that blocks until its resolution task is cancelled."""
+    await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_play_does_not_block_on_url_resolution(playqueue):
+    """play() returns at once while the URL is still being fetched, and the
+    serial command lane stays free for other commands."""
+    playqueue.track_list = [
+        TrackInfo(
+            id=to_track_id("1"),
+            metadata=create_track("1"),
+            link_retriever=_never_resolves,
+        )
+    ]
+
+    await playqueue.play(0)
+    assert playqueue._resolution.active  # in flight, not yet committed
+
+    # Lane is free: another serialised call resolves promptly despite the
+    # in-flight (blocked) resolution.
+    state = await asyncio.wait_for(playqueue.get_playback_state(), timeout=1)
+    assert state is not None
+
+
+@pytest.mark.asyncio
+async def test_failed_play_emits_unavailable_event(event_emitter, playqueue):
+    """A play that runs to completion and fails to resolve flags the track."""
+    playqueue.track_list = make_tracks_with_failures(1, {0})
+    event_emitter.reset_mock()
+
+    await playqueue.play(0)
+    await asyncio.sleep(0.05)
+
+    unavailable = [
+        e for e in dispatched_events(event_emitter) if isinstance(e, TrackUnavailableEvent)
+    ]
+    assert unavailable == [TrackUnavailableEvent(index=0, unavailable=True)]
+    assert playqueue._unavailable_indices == {0}
+
+
+@pytest.mark.asyncio
+async def test_superseded_play_suppresses_unavailable_event(event_emitter, playqueue):
+    """A play whose resolution is superseded by a newer play fails silently:
+    no TrackUnavailableEvent for the abandoned track."""
+    playqueue.track_list = [
+        TrackInfo(
+            id=to_track_id("1"),
+            metadata=create_track("1"),
+            link_retriever=_never_resolves,
+        ),
+        TrackInfo(
+            id=to_track_id("2"),
+            metadata=create_track("2"),
+            link_retriever=_never_resolves,
+        ),
+    ]
+    event_emitter.reset_mock()
+
+    await playqueue.play(0)
+    assert playqueue._resolution.target == 0
+    await playqueue.play(1)  # supersedes the index-0 resolution
+    await asyncio.sleep(0.05)
+
+    assert playqueue._resolution.target == 1  # the newer play won
+    assert not any(
+        isinstance(e, TrackUnavailableEvent) and e.index == 0
+        for e in dispatched_events(event_emitter)
+    )
+    assert 0 not in playqueue._unavailable_indices
+
+
+@pytest.mark.asyncio
+async def test_structural_mutation_on_target_cancels_resolution(event_emitter, playqueue):
+    """Removing a track at/before the resolution target cancels it silently."""
+    tracks = make_tracks(4)
+    tracks[2] = TrackInfo(
+        id=to_track_id("slow"),
+        metadata=create_track("slow"),
+        link_retriever=_never_resolves,
+    )
+    playqueue.track_list = tracks
+    event_emitter.reset_mock()
+
+    await playqueue.play(2)
+    assert playqueue._resolution.active
+
+    await playqueue.remove([0])  # index 0 <= target 2 → affected
+    assert not playqueue._resolution.active  # cancelled
+
+    await asyncio.sleep(0.05)
+    assert not any(
+        isinstance(e, TrackUnavailableEvent)
+        for e in dispatched_events(event_emitter)
+    )
+
+
+@pytest.mark.asyncio
+async def test_structural_mutation_after_target_keeps_resolution(playqueue):
+    """A removal entirely after the resolution target leaves it running."""
+    tracks = make_tracks(4)
+    tracks[0] = TrackInfo(
+        id=to_track_id("slow"),
+        metadata=create_track("slow"),
+        link_retriever=_never_resolves,
+    )
+    playqueue.track_list = tracks
+
+    await playqueue.play(0)
+    assert playqueue._resolution.active
+
+    await playqueue.remove([3])  # index 3 > target 0 → unaffected
+    assert playqueue._resolution.active
+    assert playqueue._resolution.target == 0
 
 
 def test_playqueue_state_apply_track_unavailable():

--- a/packages/kalinka-server/tests/test_playqueue.py
+++ b/packages/kalinka-server/tests/test_playqueue.py
@@ -1250,10 +1250,11 @@ async def test_resolve_playable_skips_failed_track(event_emitter, playqueue):
     playqueue.track_list = make_tracks_with_failures(3, {0})
     event_emitter.reset_mock()
 
-    index, track_url, failed = await playqueue._resolve_playable(0, step=1)
+    index, track_url, track_ref, failed = await playqueue._resolve_playable(0, step=1)
 
     assert index == 1
     assert track_url is not None
+    assert track_ref is playqueue.track_list[1]
     assert failed == [0]
     # Resolver is pure: no flagging, no events.
     assert playqueue._unavailable_indices == set()
@@ -1268,10 +1269,11 @@ async def test_resolve_playable_all_failed_returns_none(event_emitter, playqueue
     playqueue.track_list = make_tracks_with_failures(3, {0, 1, 2})
     event_emitter.reset_mock()
 
-    index, track_url, failed = await playqueue._resolve_playable(0, step=1)
+    index, track_url, track_ref, failed = await playqueue._resolve_playable(0, step=1)
 
     assert index is None
     assert track_url is None
+    assert track_ref is None
     assert failed == [0, 1, 2]
     # Resolver does not mutate flag state; the commit step would.
     assert playqueue._unavailable_indices == set()
@@ -1285,10 +1287,11 @@ async def test_resolve_playable_success_reports_no_failures(event_emitter, playq
     playqueue._unavailable_indices = {0}
     event_emitter.reset_mock()
 
-    index, track_url, failed = await playqueue._resolve_playable(0, step=1)
+    index, track_url, track_ref, failed = await playqueue._resolve_playable(0, step=1)
 
     assert index == 0
     assert track_url is not None
+    assert track_ref is playqueue.track_list[0]
     assert failed == []
     assert playqueue._unavailable_indices == {0}
     assert not any(
@@ -1532,6 +1535,41 @@ async def test_structural_mutation_after_target_keeps_resolution(playqueue):
     await playqueue.remove([3])  # index 3 > target 0 → unaffected
     assert playqueue._resolution.active
     assert playqueue._resolution.target == 0
+
+
+@pytest.mark.asyncio
+async def test_accept_scan_rejects_shifted_index(playqueue):
+    """The commit re-validates the resolved index against the track that was
+    actually fetched. A multi-step scan can resolve an index *past* the start
+    target, and a concurrent add/remove/move in the (target, resolved] band
+    slips past cancel_if (whose predicate keys on the start target). _accept_scan
+    must then bail rather than bind the URL to the now-different track."""
+    captured = {}
+
+    async def _record_gen(gen):
+        captured["gen"] = gen
+
+    url = TrackUrl(url="http://x/1.flac", format="FLAC")
+    tracks = make_tracks(3)
+    playqueue.track_list = list(tracks)
+    resolved_ref = tracks[1]  # the track whose link produced `url`
+
+    # Arm a live resolution generation targeting index 1.
+    playqueue._resolution.start(_record_gen, target=1)
+    await asyncio.sleep(0)
+    gen = captured["gen"]
+
+    # Index still holds the fetched track → accepted.
+    assert playqueue._accept_scan(gen, (1, url, resolved_ref, [])) == (1, url)
+
+    # Re-arm (the accept above called finish()).
+    playqueue._resolution.start(_record_gen, target=1)
+    await asyncio.sleep(0)
+    gen = captured["gen"]
+
+    # A different track now sits at index 1 (a concurrent reindex) → must bail.
+    playqueue.track_list[1] = make_tracks(1)[0]
+    assert playqueue._accept_scan(gen, (1, url, resolved_ref, [])) is None
 
 
 def test_playqueue_state_apply_track_unavailable():

--- a/packages/kalinka-server/tests/test_resolution_slot.py
+++ b/packages/kalinka-server/tests/test_resolution_slot.py
@@ -1,0 +1,127 @@
+import asyncio
+
+import pytest
+
+from kalinka_serialized import ResolutionSlot
+
+
+@pytest.mark.asyncio
+async def test_start_runs_and_finishes():
+    """start() runs the coroutine; once it finishes the slot goes idle."""
+    slot = ResolutionSlot()
+    applied = []
+
+    async def op(gen):
+        if slot.is_current(gen):
+            applied.append(gen)
+            slot.finish(gen)
+
+    gen = slot.start(op, target=3)
+    assert slot.active
+    assert slot.target == 3
+
+    await asyncio.sleep(0)  # let the task run
+
+    assert applied == [gen]
+    assert not slot.active
+    assert slot.target is None
+
+
+@pytest.mark.asyncio
+async def test_start_supersedes_and_cancels_previous():
+    """A second start() cancels the first task and invalidates its generation."""
+    slot = ResolutionSlot()
+    cancelled = asyncio.Event()
+
+    async def first(gen):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    g1 = slot.start(first, target=1)
+    await asyncio.sleep(0)  # let `first` park on the wait
+
+    g2 = slot.start(lambda gen: asyncio.sleep(0), target=2)
+
+    assert g2 != g1
+    assert not slot.is_current(g1)
+    assert slot.is_current(g2)
+
+    await asyncio.sleep(0)
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_superseded_continuation_does_not_apply():
+    """A continuation guarded by is_current() applies only for the latest op."""
+    slot = ResolutionSlot()
+    applied = []
+    release = asyncio.Event()
+
+    async def op(gen, tag):
+        await release.wait()
+        if not slot.is_current(gen):
+            return
+        applied.append(tag)
+        slot.finish(gen)
+
+    slot.start(lambda gen: op(gen, "first"), target=1)
+    await asyncio.sleep(0)
+    slot.start(lambda gen: op(gen, "second"), target=2)
+
+    release.set()
+    await asyncio.sleep(0.01)
+
+    assert applied == ["second"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_if():
+    """cancel_if supersedes only when the predicate returns True for the target."""
+    slot = ResolutionSlot()
+
+    async def idle(gen):
+        await asyncio.Event().wait()
+
+    slot.start(idle, target=5)
+    assert slot.active
+
+    slot.cancel_if(lambda target: target == 99)  # predicate sees target=5 → False
+    assert slot.active
+
+    slot.cancel_if(lambda target: target == 5)  # True → supersede
+    assert not slot.active
+    assert slot.target is None
+
+
+def test_cancel_if_when_idle_does_not_call_predicate():
+    slot = ResolutionSlot()
+    # No in-flight op: predicate must not run (there is no target to pass).
+    slot.cancel_if(lambda target: pytest.fail("predicate called while idle"))
+    assert not slot.active
+
+
+def test_supersede_when_idle_is_safe():
+    slot = ResolutionSlot()
+    slot.supersede()  # no in-flight task
+    assert not slot.active
+    assert slot.target is None
+
+
+@pytest.mark.asyncio
+async def test_finish_with_stale_gen_does_not_clear_newer():
+    """A stale continuation calling finish() must not clear a newer op's task."""
+    slot = ResolutionSlot()
+
+    async def idle(gen):
+        await asyncio.Event().wait()
+
+    g1 = slot.start(idle, target=1)
+    slot.start(idle, target=2)  # supersedes g1
+
+    slot.finish(g1)  # stale → no-op
+
+    assert slot.active  # g2's task is still held
+    assert slot.target == 2

--- a/packages/kalinka-server/tests/test_state_restore.py
+++ b/packages/kalinka-server/tests/test_state_restore.py
@@ -14,6 +14,7 @@ from kalinka_plugin_sdk.datamodel import (
 )
 from kalinka_plugin_sdk.events import PlayQueueState
 from kalinka_plugin_sdk.inputmodule import TrackInfo, TrackUrl
+from kalinka_serialized import ResolutionSlot
 from kalinka_server import state_keeper
 from kalinka_server.playqueue import PlayQueueImpl
 
@@ -148,9 +149,10 @@ async def test_restore_prefers_saved_metadata_over_module():
 
     added: list[TrackInfo] = []
     fake_self = SimpleNamespace(
-        track_player=SimpleNamespace(
+        _track_player=SimpleNamespace(
             get_state=lambda: SimpleNamespace(state=None), stop=lambda: None
         ),
+        _resolution=ResolutionSlot(),
         current_stream_id=None,
         track_list=[],
         prepared_tracks={},


### PR DESCRIPTION
## Problem
With a network link but no internet, a streaming plugin (qobuz/jamendo) hangs in `link_retriever()`. Because that call ran **inside the playqueue's single `SerialExecutor` lane**, it blocked every other command (list/state/pause/stop) *and* the state-update interrupt lane — freezing the whole player, including local-file playback.

## Fix
Move URL resolution off the serial lane:

- Each command splits in two: a serialised entry point that kicks off the slow `resolve()` in a single cancellable off-lane task (`ResolutionSlot`), and a serialised `next_step` that applies the result back on the lane — fenced by a generation token so a superseded resolution is dropped silently (no spurious `TrackUnavailableEvent`).
- **All** network calls route through this, including the interrupt-lane stream-error retry and the FINISHED/STOPPED auto-advance, so the interrupt lane is now I/O-free and state updates keep flowing.
- Structural mutations (add/remove/move/clear) cancel the in-flight resolution **only when its target index is affected**; otherwise it proceeds.
- `_fetch_track_url` gains an 8s `wait_for` backstop so a misbehaving plugin can't pin the slot; jamendo HTTP timeouts drop to 3s + 1 retry (qobuz counterpart in its own repo).

## Structure / cleanup
- Extracted `ResolutionSlot` as a reusable primitive in `kalinka_serialized` (single in-flight task + generation fencing + `cancel_if`), unit-tested in isolation.
- DRY helpers in `PlayQueueImpl`: `_next_index`, `_revalidate_prefetched_next`, `_clear_prepared_streams`.
- Fixed a pre-existing `test_state_restore` typo (`track_player` → `_track_player`).

## Tests
`test_playqueue.py` + `test_resolution_slot.py` + `test_state_restore.py`: **52 passed** (incl. real-streaming integration tests).

> Pairs with the qobuz timeout change: https://github.com/madenvel/kalinka-plugin-qobuz/pull/new/perf/fast-fail-http-timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)