### PR TITLE
ci: install libboost-dev for the native extension build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,8 @@ jobs:
           apt-get install -y --no-install-recommends \
             build-essential make git ca-certificates unzip dpkg-dev \
             python3 python3-dev python3-pip python3-venv \
-            libcurlpp-dev libcurl4-openssl-dev libflac++-dev libasound2-dev \
-            libspdlog-dev libfmt-dev
+            libboost-dev libcurlpp-dev libcurl4-openssl-dev libflac++-dev \
+            libasound2-dev libspdlog-dev libfmt-dev
           # build/setuptools-scm/pybind11 for wheel builds; pydantic is needed
           # by the localfiles plugin's build-time optional_packages export.
           pip install --upgrade build setuptools-scm pybind11 pydantic


### PR DESCRIPTION
The native_player extension includes header-only Boost (`<boost/lexical_cast.hpp>`, `<boost/algorithm/string.hpp>`, `<boost/circular_buffer.hpp>`) via `Config.h`, which the clean Debian/Ubuntu build containers don't ship. The first release run failed at the compile step with `fatal error: boost/lexical_cast.hpp: No such file or directory`. Add `libboost-dev` (header-only is sufficient — no Boost lib is linked) so the extension compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)