### PR TITLE
enricher: gate FAILED-row retry on an enrichment fingerprint

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
@@ -243,6 +243,23 @@ async def init_db(db_path: str) -> None:
             )
 
         # ---------------------------------------------------------------
+        # Enricher state (key/value)
+        # ---------------------------------------------------------------
+        # Small grab-bag of enricher-owned scalars. Currently holds the
+        # "enrichment fingerprint" — a signature of the active plugin
+        # set / versions / match-affecting config — used to decide
+        # whether a restart should re-open previously-FAILED rows.
+
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS enricher_state (
+                key   TEXT PRIMARY KEY,
+                value TEXT
+            )
+            """
+        )
+
+        # ---------------------------------------------------------------
         # FTS5 full-text search
         # ---------------------------------------------------------------
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__.split(".")[-1])
 class AcoustIdPlugin(EnricherPlugin):
     """AcoustID audio fingerprinting plugin for track identification"""
 
+    ENRICHER_VERSION = 1
+
     def __init__(self, config: LocalFilesConfig, db_manager):
         self.config = config
         self.db_manager = db_manager
@@ -37,6 +39,14 @@ class AcoustIdPlugin(EnricherPlugin):
 
         # Match confidence thresholds (0-1.0)
         self.min_score_threshold = 0.7  # Minimum score to consider a match valid
+
+    def config_signature(self) -> Dict:
+        # Without a key every lookup short-circuits, so the plugin is
+        # effectively inert; the moment a key is configured it can start
+        # resolving tracks that previously FAILED. Presence is what
+        # changes outcomes — the key value itself isn't recorded (no
+        # secret in the fingerprint).
+        return {"api_key_present": bool(self.api_key)}
 
     def _wait_for_rate_limit(self):
         """Wait to respect rate limits"""

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/deezer_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/deezer_plugin.py
@@ -28,6 +28,8 @@ class DeezerPlugin(EnricherPlugin):
     distributed software without proper licensing from Deezer.
     """
 
+    ENRICHER_VERSION = 1
+
     def __init__(self, config: LocalFilesConfig, db_manager):
         self.config = config
         self.db_manager = db_manager

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
@@ -2,6 +2,7 @@
 import multiprocessing
 import asyncio
 import enum
+import json
 import logging
 import queue
 import signal
@@ -92,6 +93,31 @@ class MetadataEnricher:
         logger.info(
             f"Loaded {len(self.plugins)} enrichment plugins: {[p.__class__.__name__ for p in self.plugins]}"
         )
+
+    def compute_fingerprint(self) -> str:
+        """Stable signature of the *active* enrichment setup.
+
+        Built from ``self.plugins`` in load order — so it captures which
+        plugins are enabled and in what order (first match wins), each
+        one's ``ENRICHER_VERSION`` (bumped when its matching code
+        changes), and its ``config_signature()`` (match-affecting config
+        such as MB thresholds or whether an AcoustID key is set).
+
+        Only enabled plugins contribute, which is the whole point:
+        bumping the version of, or reconfiguring, a plugin the user has
+        *disabled* leaves the fingerprint untouched and so triggers no
+        needless retry sweep. The fingerprint changing is the signal
+        that previously-FAILED rows deserve another attempt.
+        """
+        components = [
+            {
+                "name": p.__class__.__name__,
+                "version": p.ENRICHER_VERSION,
+                "config": p.config_signature(),
+            }
+            for p in self.plugins
+        ]
+        return json.dumps(components, sort_keys=True)
 
     async def start(self):
         """Start the enricher process for general enrichment"""
@@ -387,21 +413,27 @@ async def _enricher_worker(config, db_manager: AsyncEnricherDb):
 
     enricher_instance = MetadataEnricher(config, db_manager)
 
-    # One-time retry of previously-FAILED rows. The enricher subprocess
-    # starts when the main server starts, so a server restart (which is
-    # the natural moment for "we may have new plugin code") flips every
-    # ``enriched=2`` entry back to ``0``. Subsequent enrichment ticks
-    # within the same process lifetime do not reset again — once a row
-    # fails *under the current code*, it stays failed until the next
-    # restart.
+    # One-time, *gated* retry of previously-FAILED rows. A plain restart
+    # no longer re-hammers MusicBrainz/Deezer for rows that will fail
+    # identically: FAILED rows are re-opened only when the enrichment
+    # fingerprint changed since the last run — i.e. a plugin was
+    # enabled/disabled/reordered, a plugin's ENRICHER_VERSION was bumped
+    # (new matcher code), or a match-affecting config field changed (an
+    # AcoustID key added, an MB threshold lowered). The first run after
+    # this ships has no stored fingerprint, so it resets once and then
+    # settles.
     try:
-        retried = await db_manager.reset_failed_to_retry()
-        total = sum(retried.values())
-        if total:
+        fingerprint = enricher_instance.compute_fingerprint()
+        retried = await db_manager.reset_failed_for_fingerprint(fingerprint)
+        if retried is None:
             logger.info(
-                "Reset %d previously-FAILED rows for retry: "
-                "%d artists, %d albums, %d tracks",
-                total,
+                "Enrichment fingerprint unchanged; leaving FAILED rows as-is"
+            )
+        else:
+            logger.info(
+                "Enrichment setup changed; reset %d previously-FAILED rows for "
+                "retry: %d artists, %d albums, %d tracks",
+                sum(retried.values()),
                 retried["artists"],
                 retried["albums"],
                 retried["tracks"],

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
@@ -11,6 +11,9 @@ from ..worker_utils import retry_db_locked
 
 logger = logging.getLogger(__name__.split(".")[-1])
 
+# Key under which the enrichment fingerprint is stored in ``enricher_state``.
+ENRICHMENT_FINGERPRINT_KEY = "enrichment_fingerprint"
+
 
 @retry_db_locked
 class AsyncEnricherDb:
@@ -137,27 +140,81 @@ class AsyncEnricherDb:
             row = await cursor.fetchone()
             return dict(row) if row else None
 
+    @staticmethod
+    async def _reset_failed_rows(cursor) -> Dict[str, int]:
+        """Flip every ``enriched=2`` (FAILED) row back to ``enriched=0``
+        on the given cursor (no commit). Returns per-entity row counts."""
+        counts: Dict[str, int] = {"artists": 0, "albums": 0, "tracks": 0}
+        for table in ("artists", "albums", "tracks"):
+            await cursor.execute(f"UPDATE {table} SET enriched = 0 WHERE enriched = 2")
+            counts[table] = cursor.rowcount or 0
+        return counts
+
     async def reset_failed_to_retry(self) -> Dict[str, int]:
         """Flip every ``enriched=2`` (FAILED) row back to ``enriched=0`` so
-        the next enrichment pass picks it up.
-
-        Called once at enricher-process startup so that, after the user
-        deploys updated plugin code (or a new MB matcher tier), the
-        already-failed rows get one more chance instead of staying
-        stuck. Bounded to once-per-process: if the enricher is hammered
-        with ``enrich`` commands inside the same lifetime the FAILED
-        rows aren't reset again (that's the caller's responsibility).
+        the next enrichment pass picks it up. Unconditional — see
+        :meth:`reset_failed_for_fingerprint` for the gated variant the
+        enricher actually uses at startup.
 
         Returns row counts per entity for logging.
         """
-        counts: Dict[str, int] = {"artists": 0, "albums": 0, "tracks": 0}
         async with self._open() as conn:
             cursor = await conn.cursor()
-            for table in ("artists", "albums", "tracks"):
-                await cursor.execute(
-                    f"UPDATE {table} SET enriched = 0 WHERE enriched = 2"
-                )
-                counts[table] = cursor.rowcount or 0
+            counts = await self._reset_failed_rows(cursor)
+            await conn.commit()
+        return counts
+
+    async def get_enrichment_fingerprint(self) -> Optional[str]:
+        """Return the enrichment fingerprint stored on the previous run,
+        or ``None`` if none has been recorded yet."""
+        async with self._open() as conn:
+            cursor = await conn.cursor()
+            await cursor.execute(
+                "SELECT value FROM enricher_state WHERE key = ?",
+                (ENRICHMENT_FINGERPRINT_KEY,),
+            )
+            row = await cursor.fetchone()
+            return row[0] if row else None
+
+    async def reset_failed_for_fingerprint(
+        self, fingerprint: str
+    ) -> Optional[Dict[str, int]]:
+        """Gated FAILED-row reset, run once at enricher-process startup.
+
+        Reset previously-FAILED rows back to NOT_ENRICHED *only* when
+        ``fingerprint`` differs from the one recorded on the last run
+        (or none is recorded yet — first run after this feature ships,
+        or a fresh DB), then persist ``fingerprint``. The fingerprint
+        encodes the active plugin set, each plugin's
+        ``ENRICHER_VERSION``, and its match-affecting config (see
+        ``MetadataEnricher.compute_fingerprint``), so a reset happens
+        exactly when the enrichment setup changed in a way that could
+        flip a FAILED row to enriched — not on every restart.
+
+        Read, reset and store run in a single transaction so a crash
+        can't leave the fingerprint advanced while the rows stay FAILED.
+
+        Returns the per-entity reset counts when a reset happened, or
+        ``None`` when the fingerprint was unchanged and FAILED rows were
+        left intact.
+        """
+        async with self._open() as conn:
+            cursor = await conn.cursor()
+            await cursor.execute(
+                "SELECT value FROM enricher_state WHERE key = ?",
+                (ENRICHMENT_FINGERPRINT_KEY,),
+            )
+            row = await cursor.fetchone()
+            stored = row[0] if row else None
+            if stored == fingerprint:
+                return None
+
+            counts = await self._reset_failed_rows(cursor)
+            await cursor.execute(
+                "INSERT INTO enricher_state (key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (ENRICHMENT_FINGERPRINT_KEY, fingerprint),
+            )
             await conn.commit()
         return counts
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_plugin.py
@@ -5,6 +5,27 @@ from typing import Dict, Optional
 class EnricherPlugin(abc.ABC):
     """Base class for enricher plugins"""
 
+    # Bump in a subclass whenever its enrichment logic changes in a way
+    # that could turn a previous FAILED into a success (a new matcher
+    # tier, a bug fix, a looser heuristic). It feeds the enrichment
+    # fingerprint (see ``MetadataEnricher.compute_fingerprint``); a bump
+    # re-opens previously-FAILED rows on the next restart. Scoped per
+    # plugin, so bumping a plugin the user has *disabled* changes
+    # nothing — it never enters the fingerprint.
+    ENRICHER_VERSION: int = 1
+
+    def config_signature(self) -> Dict:
+        """Config fields that affect match *outcomes*, folded into the
+        enrichment fingerprint so a change re-opens previously-FAILED
+        rows on restart.
+
+        Return only fields that can change whether an entity enriches
+        successfully (thresholds, an API key becoming available) — not
+        cosmetic ones like debug logging. Default: nothing
+        outcome-affecting.
+        """
+        return {}
+
     @abc.abstractmethod
     def can_enrich_artist(self) -> bool:
         """Whether this plugin can enrich artist metadata"""

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
@@ -41,6 +41,8 @@ class FilesystemFallbackPlugin(EnricherPlugin):
     This plugin does NOT set the "enriched" flag to allow other plugins to re-check the data.
     """
 
+    ENRICHER_VERSION = 1
+
     # Match the indexer's V/A detection criteria
     # (``orphan_va_folder_tracks``). Filesystem fallback skips album
     # reassignment when the track's folder meets these — otherwise it

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
@@ -40,6 +40,8 @@ def _same_release_group(a: Dict, b: Dict) -> bool:
 class MusicBrainzPlugin(EnricherPlugin):
     """MusicBrainz metadata enrichment plugin"""
 
+    ENRICHER_VERSION = 1
+
     def __init__(self, config: LocalFilesConfig, db_manager):
         self.config = config
         self.db_manager = db_manager
@@ -71,6 +73,18 @@ class MusicBrainzPlugin(EnricherPlugin):
             self.user_agent.split("/")[1].split(" ")[0],
             self.user_agent.split(" ", 1)[1].strip("()"),
         )
+
+    def config_signature(self) -> Dict:
+        # Thresholds and the string-similarity floor decide whether a
+        # candidate is accepted, so changing any of them can flip a
+        # FAILED row to enriched. ``debug_matching`` is logging-only and
+        # deliberately excluded.
+        return {
+            "artist_threshold": self.artist_threshold,
+            "album_threshold": self.album_threshold,
+            "track_threshold": self.track_threshold,
+            "string_similarity": self.string_similarity_threshold,
+        }
 
     def _normalize_string(self, text: str) -> str:
         """Normalize string for comparison by removing special characters and lowercasing"""

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/wikidata_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/wikidata_plugin.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__.split(".")[-1])
 class WikidataPlugin(EnricherPlugin):
     """Wikidata enrichment plugin for artist images"""
 
+    ENRICHER_VERSION = 1
+
     def __init__(self, config: LocalFilesConfig, db_manager):
         self.config = config
         self.db_manager = db_manager

--- a/packages/kalinka-plugin-localfiles/tests/test_enricher_fingerprint_retry.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_enricher_fingerprint_retry.py
@@ -1,0 +1,230 @@
+"""Tests for fingerprint-gated FAILED-row retry.
+
+A plain restart used to flip every ``enriched=2`` (FAILED) row back to
+``0``, so the enricher re-hammered MusicBrainz/Deezer for rows that
+would fail identically. Now the reset is gated on an *enrichment
+fingerprint*: the active plugin set (in load order), each plugin's
+``ENRICHER_VERSION``, and its match-affecting ``config_signature()``.
+FAILED rows are re-opened only when that fingerprint changes — a plugin
+enabled/disabled/reordered, a version bumped, or a threshold/API-key
+changed.
+
+Two layers are covered:
+- the DB gate ``reset_failed_for_fingerprint`` (reset iff changed), and
+- ``MetadataEnricher.compute_fingerprint`` (what feeds the gate), in
+  particular that bumping a *disabled* plugin is invisible.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.enricher.acoustid_plugin import AcoustIdPlugin
+from kalinka_plugin_localfiles.enricher.enricher import MetadataEnricher
+from kalinka_plugin_localfiles.enricher.enricher_db import AsyncEnricherDb
+
+
+def _config(tmp_path) -> LocalFilesConfig:
+    return LocalFilesConfig(
+        db_path=str(tmp_path / "test.db"),
+        artwork_path=str(tmp_path / "artwork"),
+    )
+
+
+async def _seed_failed(db_path: str) -> None:
+    """Insert a handful of FAILED rows across the three entity tables."""
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.executemany(
+            "INSERT INTO artists (id, name, enriched) VALUES (?, ?, ?)",
+            [("ar_f1", "F1", 2), ("ar_f2", "F2", 2)],
+        )
+        await conn.executemany(
+            "INSERT INTO albums (id, title, artist_id, enriched) VALUES (?, ?, ?, ?)",
+            [("al_f1", "F1", "ar_f1", 2)],
+        )
+        await conn.executemany(
+            "INSERT INTO tracks (id, title, file_path, format, enriched) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [("t_f1", "T1", "/f1", "mp3", 2), ("t_f2", "T2", "/f2", "mp3", 2)],
+        )
+        await conn.commit()
+
+
+_SEEDED = {
+    "artists": ("ar_f1", "ar_f2"),
+    "albums": ("al_f1",),
+    "tracks": ("t_f1", "t_f2"),
+}
+
+
+async def _mark_seeded_failed(db_path: str) -> None:
+    """Flip the seeded rows back to FAILED — simulates new failures
+    accumulating during normal operation after a reset. Scoped to the
+    seeded ids so init_db's sentinel rows aren't disturbed."""
+    async with aiosqlite.connect(db_path) as conn:
+        for table, ids in _SEEDED.items():
+            placeholders = ", ".join("?" for _ in ids)
+            await conn.execute(
+                f"UPDATE {table} SET enriched = 2 WHERE id IN ({placeholders})", ids
+            )
+        await conn.commit()
+
+
+async def _count_failed(db_path: str) -> int:
+    total = 0
+    async with aiosqlite.connect(db_path) as conn:
+        for table in ("artists", "albums", "tracks"):
+            cur = await conn.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE enriched = 2"
+            )
+            total += (await cur.fetchone())[0]
+    return total
+
+
+# --------------------------------------------------------------------------
+# DB gate: reset_failed_for_fingerprint
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_none_on_fresh_db(tmp_path):
+    cfg = _config(tmp_path)
+    await init_db(cfg.db_path)
+    db = AsyncEnricherDb(cfg)
+    assert await db.get_enrichment_fingerprint() is None
+
+
+@pytest.mark.asyncio
+async def test_first_run_resets_and_stores(tmp_path):
+    """No stored fingerprint (first run after the feature ships) → reset
+    happens and the fingerprint is persisted."""
+    cfg = _config(tmp_path)
+    await init_db(cfg.db_path)
+    await _seed_failed(cfg.db_path)
+    db = AsyncEnricherDb(cfg)
+
+    counts = await db.reset_failed_for_fingerprint("fp-A")
+    assert counts == {"artists": 2, "albums": 1, "tracks": 2}
+    assert await _count_failed(cfg.db_path) == 0
+    assert await db.get_enrichment_fingerprint() == "fp-A"
+
+
+@pytest.mark.asyncio
+async def test_unchanged_fingerprint_is_noop(tmp_path):
+    """Same fingerprint on the next restart → no reset, FAILED rows kept,
+    and the method signals the skip with ``None``."""
+    cfg = _config(tmp_path)
+    await init_db(cfg.db_path)
+    await _seed_failed(cfg.db_path)
+    db = AsyncEnricherDb(cfg)
+
+    await db.reset_failed_for_fingerprint("fp-A")
+    # New FAILED rows accumulate during normal operation after the reset.
+    await _mark_seeded_failed(cfg.db_path)
+    assert await _count_failed(cfg.db_path) == 5
+
+    result = await db.reset_failed_for_fingerprint("fp-A")
+    assert result is None
+    assert await _count_failed(cfg.db_path) == 5  # untouched
+
+
+@pytest.mark.asyncio
+async def test_changed_fingerprint_resets_again(tmp_path):
+    """A different fingerprint (config/code changed) re-opens FAILED rows
+    and stores the new value."""
+    cfg = _config(tmp_path)
+    await init_db(cfg.db_path)
+    await _seed_failed(cfg.db_path)
+    db = AsyncEnricherDb(cfg)
+
+    await db.reset_failed_for_fingerprint("fp-A")
+    await _mark_seeded_failed(cfg.db_path)
+
+    counts = await db.reset_failed_for_fingerprint("fp-B")
+    assert counts == {"artists": 2, "albums": 1, "tracks": 2}
+    assert await _count_failed(cfg.db_path) == 0
+    assert await db.get_enrichment_fingerprint() == "fp-B"
+
+
+# --------------------------------------------------------------------------
+# Fingerprint composition: MetadataEnricher.compute_fingerprint
+# --------------------------------------------------------------------------
+
+
+def _enricher(cfg) -> MetadataEnricher:
+    return MetadataEnricher(cfg, AsyncEnricherDb(cfg))
+
+
+def _minimal_config(tmp_path) -> LocalFilesConfig:
+    """Config with only MusicBrainz active, so fingerprint tests don't
+    spin up the image-fetch plugins' HTTP clients needlessly."""
+    cfg = _config(tmp_path)
+    cfg.enricher.plugins.musicbrainz.enabled = True
+    cfg.enricher.plugins.acoustid.enabled = False
+    cfg.enricher.plugins.wikidata.enabled = False
+    cfg.enricher.plugins.deezer.enabled = False
+    cfg.enricher.plugins.filesystem_fallback_enabled = False
+    return cfg
+
+
+def test_fingerprint_is_stable_for_identical_config(tmp_path):
+    a = _enricher(_minimal_config(tmp_path)).compute_fingerprint()
+    b = _enricher(_minimal_config(tmp_path)).compute_fingerprint()
+    assert a == b
+
+
+def test_enabling_a_plugin_changes_fingerprint(tmp_path):
+    base = _enricher(_minimal_config(tmp_path)).compute_fingerprint()
+
+    cfg = _minimal_config(tmp_path)
+    cfg.enricher.plugins.acoustid.enabled = True
+    with_acoustid = _enricher(cfg).compute_fingerprint()
+
+    assert base != with_acoustid
+
+
+def test_changing_match_threshold_changes_fingerprint(tmp_path):
+    base = _enricher(_minimal_config(tmp_path)).compute_fingerprint()
+
+    cfg = _minimal_config(tmp_path)
+    cfg.enricher.plugins.musicbrainz.track_threshold = 70
+    lowered = _enricher(cfg).compute_fingerprint()
+
+    assert base != lowered
+
+
+def test_acoustid_key_presence_changes_fingerprint(tmp_path):
+    cfg_no_key = _minimal_config(tmp_path)
+    cfg_no_key.enricher.plugins.acoustid.enabled = True
+    no_key = _enricher(cfg_no_key).compute_fingerprint()
+
+    cfg_key = _minimal_config(tmp_path)
+    cfg_key.enricher.plugins.acoustid.enabled = True
+    cfg_key.enricher.plugins.acoustid.api_key = "secret-key"
+    with_key = _enricher(cfg_key).compute_fingerprint()
+
+    assert no_key != with_key
+    # The key value itself is never embedded in the fingerprint.
+    assert "secret-key" not in with_key
+
+
+def test_bumping_a_disabled_plugin_is_invisible(tmp_path, monkeypatch):
+    """The core property: bumping ``ENRICHER_VERSION`` on a plugin the
+    user has *disabled* leaves the fingerprint untouched (no needless
+    retry sweep), while bumping it once *enabled* does change it."""
+    disabled_v1 = _enricher(_minimal_config(tmp_path)).compute_fingerprint()
+
+    monkeypatch.setattr(AcoustIdPlugin, "ENRICHER_VERSION", 999, raising=True)
+    disabled_v999 = _enricher(_minimal_config(tmp_path)).compute_fingerprint()
+    assert disabled_v999 == disabled_v1  # AcoustID disabled → bump invisible
+
+    cfg = _minimal_config(tmp_path)
+    cfg.enricher.plugins.acoustid.enabled = True
+    enabled_v999 = _enricher(cfg).compute_fingerprint()
+
+    monkeypatch.setattr(AcoustIdPlugin, "ENRICHER_VERSION", 1, raising=True)
+    enabled_v1 = _enricher(cfg).compute_fingerprint()
+    assert enabled_v999 != enabled_v1  # AcoustID enabled → bump visible

--- a/packages/kalinka-plugin-localfiles/tests/test_enricher_retry_failed.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_enricher_retry_failed.py
@@ -1,12 +1,17 @@
-"""Tests for the once-per-process FAILED-row retry reset.
+"""Tests for the unconditional FAILED-row retry reset primitive.
 
 Background: a track that gets through the enricher pipeline without
 hitting all of ``TRACK_REQUIRED_FIELDS`` is marked ``enriched=2``
 (FAILED) and the next pass skips it. After plugin code is updated (a
 new matcher tier, a bug fix), those rows would stay stuck forever
 without intervention. ``AsyncEnricherDb.reset_failed_to_retry`` flips
-every FAILED row back to ``0`` and is called once at enricher worker
-startup, so a server restart is the natural trigger.
+every FAILED row back to ``0``.
+
+The enricher worker doesn't call this directly at startup anymore — it
+calls the *gated* ``reset_failed_for_fingerprint`` so an unchanged
+setup doesn't re-hammer the providers (see
+``test_enricher_fingerprint_retry.py``). This primitive is still the
+shared building block and is tested here in isolation.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Problem

Every server restart flipped **all** `enriched=2` (FAILED) rows back to `0`, so the enricher re-attempted MusicBrainz/Deezer/etc. for items that would fail identically — even when nothing about enrichment had changed. We want to retry failed items only when the *thing that produced the failure* changed: new plugin code, or a newly-enabled/reconfigured mechanism (e.g. AcoustID set up).

## Approach

Persist an **enrichment fingerprint** and only reset FAILED rows when it changes. The fingerprint is built over the *active* plugins in load order, each contributing `(name, ENRICHER_VERSION, config_signature())`:

- **`config_signature()`** — match-affecting config, captured automatically. MusicBrainz contributes its thresholds + string-similarity floor; AcoustID contributes whether an API key is present (the key value itself is never embedded — no secret in the fingerprint). So enabling/reconfiguring a mechanism retries failures on its own.
- **`ENRICHER_VERSION`** — a per-plugin constant a developer bumps when that plugin's matching logic changes (a new matcher tier, a bug fix).

Both halves are needed: config-hash covers "user enabled AcoustID" for free; the version int covers "I shipped a better matcher" with no config change.

### Why per-plugin version, scoped to enabled plugins

A single global version would falsely trigger a full retry sweep even when the changed plugin is disabled for that user. Because only enabled plugins enter the fingerprint, **bumping or reconfiguring a disabled plugin changes nothing** — the false-trigger problem is structurally impossible, not something guarded against. Load order is part of the signature too, so reordering plugins (first-match-wins) also retries.

## Implementation

- `enricher_state(key, value)` table (new, in `init_db`) persists the fingerprint.
- `AsyncEnricherDb.reset_failed_for_fingerprint(fp)` reads/resets/stores in a single transaction; returns per-entity counts on reset or `None` when unchanged.
- The worker calls the gated variant at startup. `reset_failed_to_retry()` is kept as the unconditional primitive (shared `_reset_failed_rows` helper + its existing tests).

### Migration

First run after this ships has no stored fingerprint → existing FAILED rows get exactly **one** reset, then it settles. No manual intervention.

## Tests

- `test_enricher_fingerprint_retry.py` (new): the DB gate (first-run reset, unchanged no-op, changed re-reset) and `compute_fingerprint` composition — stable for identical config, changes on enable/threshold/api-key, and the key property that **bumping a disabled plugin is invisible while bumping it once enabled is not**.
- `test_enricher_retry_failed.py`: updated docstring; the primitive's tests still pass.

All 22 enricher/schema/config tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)