### PR TITLE
search: ASCII-adjacent (diacritic-insensitive) matching for FTS

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
@@ -263,15 +263,18 @@ async def init_db(db_path: str) -> None:
         # FTS5 full-text search
         # ---------------------------------------------------------------
 
-        # Drop legacy contentless fts_tracks table if present
+        # Rebuild fts_tracks when its definition is stale — a legacy
+        # contentless table, or a tokenizer predating remove_diacritics 2.
+        # The index_batch poller repopulates after the index reset.
         row = await cursor.execute(
             "SELECT sql FROM sqlite_master WHERE type='table' AND name='fts_tracks'"
         )
         existing_sql = await row.fetchone()
-        if existing_sql and "content=''" in (existing_sql[0] or ""):
-            logger.warning(
-                "Detected contentless fts_tracks table — dropping and rebuilding"
-            )
+        existing_def = (existing_sql[0] if existing_sql else "") or ""
+        if existing_def and (
+            "content=''" in existing_def or "remove_diacritics 2" not in existing_def
+        ):
+            logger.warning("Detected stale fts_tracks definition — dropping and rebuilding")
             await cursor.execute("DROP TABLE IF EXISTS fts_tracks")
             await cursor.execute("UPDATE tracks SET search_indexed_at = NULL")
 
@@ -283,7 +286,7 @@ async def init_db(db_path: str) -> None:
                 artist_name,
                 album_title,
                 genre_tags,
-                tokenize='porter unicode61'
+                tokenize='porter unicode61 remove_diacritics 2'
             )
             """
         )

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
@@ -20,6 +20,7 @@ import aiosqlite
 from rapidfuzz import fuzz
 
 from ..config_model import LocalFilesConfig
+from ..utils.name_utils import fold_diacritics
 from ..worker_utils import retry_db_locked
 
 logger = logging.getLogger(__name__.split(".")[-1])
@@ -454,7 +455,10 @@ class AsyncSearcherDb:
                 return []
 
         fuzz_target = raw_query.strip() or text_query
-        norm_target = fuzz_target.casefold().strip()
+        # Diacritic-fold both sides so an ASCII query ("noi kabat") isn't
+        # dropped by the re-rank against accented metadata ("Női Kabát").
+        folded_target = fold_diacritics(fuzz_target)
+        norm_target = folded_target.casefold().strip()
         scored: list[dict] = []
         for row in rows:
             # Score against each field separately and keep the best. A
@@ -467,10 +471,11 @@ class AsyncSearcherDb:
             for field in (row["title"], row["artist_name"], row["album_title"]):
                 if not field:
                     continue
-                s = fuzz.WRatio(fuzz_target, field)
+                folded_field = fold_diacritics(field)
+                s = fuzz.WRatio(folded_target, folded_field)
                 if s > best:
                     best = s
-                if field.casefold().strip() == norm_target:
+                if folded_field.casefold().strip() == norm_target:
                     exact = True
             if best >= min_score:
                 scored.append(

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/utils/name_utils.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/utils/name_utils.py
@@ -120,6 +120,20 @@ def path_within_roots(file_path: str, roots: Iterable[str]) -> bool:
     return False
 
 
+def fold_diacritics(name: str) -> str:
+    """Strip diacritics while preserving case, spacing, and punctuation.
+
+    NFKD-decompose and drop combining marks so "Női Kabát" folds to
+    "Noi Kabat". Unlike :func:`normalize_for_id` the surface form is
+    otherwise intact; used by the searcher re-rank to compare an unaccented
+    query against accented metadata.
+    """
+    if not name:
+        return ""
+    n = unicodedata.normalize("NFKD", name)
+    return "".join(c for c in n if not unicodedata.combining(c))
+
+
 def normalize_for_id(name: str) -> str:
     """Aggressive normalization used only for ID hashing.
 

--- a/packages/kalinka-plugin-localfiles/tests/test_search_improvements.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_search_improvements.py
@@ -282,6 +282,26 @@ class TestFtsFuzzyRerank:
         # Title merely *contains* the token — not an exact field match.
         assert by_id["t1"]["exact"] is False
 
+    @pytest.mark.asyncio
+    async def test_ascii_query_matches_accented_artist(self):
+        """An ASCII-folded query ("noi kabat") finds an accented artist
+        ("Női Kabát"). Without diacritic folding in the rapidfuzz re-rank
+        the raw WRatio (~56) falls below the 72 threshold and the candidate
+        is dropped even though FTS matched it. See issue #61."""
+        db_path = os.path.join(tempfile.mkdtemp(), "test.db")
+        db = await _setup_db(db_path)
+
+        await _insert_fts_rows(db_path, [
+            ("t0", "Valami", "Női Kabát", "Best Of"),
+            ("t1", "Yesterday", "Beatles", "Help!"),
+        ])
+
+        results = await db.fts_search("noi kabat", "noi kabat", limit=10)
+        by_id = {r["track_id"]: r for r in results}
+        assert "t0" in by_id
+        # Diacritic-folded equality also sets the exact-artist flag.
+        assert by_id["t0"]["exact"] is True
+
 
 # ---------------------------------------------------------------------------
 # Tests: exact lexical matches float above pure CLAP neighbours


### PR DESCRIPTION
## Problem

Searching `noi kabat` did not find the artist **Női Kabát** (issue #61).

## Root cause

The FTS5 layer was *not* the blocker — on modern SQLite the `unicode61` tokenizer already folds `ő`/`á`, so FTS returned the accented track as a candidate. The candidate was then dropped by the **rapidfuzz re-rank**, which scored the raw query against raw metadata: `WRatio("noi kabat", "Női Kabát")` ≈ **56**, below the `min_score=72` keep threshold. Folded, it scores **~78** and survives.

## Fix

- **`fold_diacritics()`** helper (`name_utils.py`) — NFKD-decompose + strip combining marks, preserving case/spacing/punctuation (lighter than the existing `normalize_for_id`).
- **Searcher re-rank** (`searcher_db.py`) folds both the query and each field before `WRatio` and before the exact-match check. *This is the fix that resolves the issue.*
- **Tokenizer** bumped to `remove_diacritics 2` with a migration guard that rebuilds `fts_tracks` and resets the index (auto-repopulated by the `index_batch` poller). Defensive for Raspberry Pi targets shipping pre-3.27 SQLite, where `remove_diacritics 1` genuinely fails on Hungarian double-acute. Harmless on modern SQLite.

## Tests

New `test_ascii_query_matches_accented_artist` asserting `noi kabat` → Női Kabát. Full suite: 46 passed.

## Known limitation

A few characters fold to nothing under both NFKD and the tokenizer — `ł`, `ø`, `đ`, `æ` — so e.g. `lodz` still won't match `Łódź`. That needs an explicit transliteration map rather than Unicode normalization; out of scope here, easy to layer into `fold_diacritics` later.

@slowriot

🤖 Generated with [Claude Code](https://claude.com/claude-code)