### PR TITLE
clap: store search embeddings as int8 (4x smaller index, faster KNN)

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
@@ -99,7 +99,11 @@ class EmbedderClapConfig(BaseModel):
         default=512, frozen=True, title="Embedding dimensions"
     )
     current_version: int = Field(
-        default=3,
+        # v4: float32 -> int8 vectors. Keys embedding_jobs.model_version to
+        # reschedule the embed jobs; independent of (and need not match)
+        # embedding_utils.CLAP_EMBED_FORMAT_VERSION, which handles the on-disk
+        # vec-table format. A stored-format change must bump both.
+        default=4,
         title="Model version",
         json_schema_extra={"help": "Increment to force re-embedding"},
     )

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
@@ -16,6 +16,8 @@ import time
 
 import aiosqlite
 
+from .embedding_utils import CLAP_EMBED_FORMAT_VERSION
+
 logger = logging.getLogger(__name__.split(".")[-1])
 
 _CLAP_DIMS = 512
@@ -317,25 +319,74 @@ async def init_db(db_path: str) -> None:
 
 
 async def _init_vec_tables(db_path: str) -> None:
-    """Try to load sqlite-vec and create CLAP vector tables."""
+    """Load sqlite-vec and create CLAP vector tables, migrating older formats.
+
+    vec0 columns are typed. Legacy builds stored ``float[512]``; we now store
+    ``int8[512]``. On a format mismatch (PRAGMA user_version) we drop the typed
+    vec tables and clear the embedding blobs; the bumped
+    ``embedder.clap.current_version`` reschedules the jobs that recompute them.
+    Until they refill, a typed-mismatch MATCH raises and the search layer reads
+    it as "no vector hits" — KNN search is empty but never crashes.
+    """
     try:
         import sqlite_vec
+    except Exception as e:
+        logger.warning("sqlite-vec not available (%s); KNN search disabled", e)
+        return
 
+    try:
         async with aiosqlite.connect(db_path) as conn:
+            await conn.execute("PRAGMA busy_timeout=5000")
             await conn.enable_load_extension(True)
             await conn.load_extension(sqlite_vec.loadable_path())
             await conn.enable_load_extension(False)
 
             cursor = await conn.cursor()
+            await cursor.execute("PRAGMA user_version")
+            row = await cursor.fetchone()
+            fmt = row[0] if row else 0
+            if fmt != CLAP_EMBED_FORMAT_VERSION:
+                if fmt != 0:
+                    logger.warning(
+                        "CLAP embedding format v%d -> v%d: dropping vector tables "
+                        "and clearing stored embeddings for recompute",
+                        fmt,
+                        CLAP_EMBED_FORMAT_VERSION,
+                    )
+                # Drop the typed vec0 tables (DROP needs the loaded extension)
+                # so they are recreated below with the new dtype.
+                for vec_table, _pk in _VEC_AUDIO_TABLES + _VEC_TEXT_TABLES:
+                    await cursor.execute(f"DROP TABLE IF EXISTS {vec_table}")
+                # Clear stale embedding blobs so the embedder recomputes them and
+                # mean-pooled aggregates never mix old- and new-format vectors.
+                await cursor.execute(
+                    "UPDATE tracks SET embedding_clap_audio = NULL, "
+                    "embedding_clap_text = NULL, embedding_version = 0, "
+                    "embedded_at = NULL"
+                )
+                await cursor.execute(
+                    "UPDATE albums SET embedding_clap = NULL, "
+                    "embedding_clap_text = NULL"
+                )
+                await cursor.execute(
+                    "UPDATE artists SET embedding_clap = NULL, "
+                    "embedding_clap_text = NULL"
+                )
+                # PRAGMA can't be parameterised; the value is a trusted constant.
+                await cursor.execute(
+                    f"PRAGMA user_version = {int(CLAP_EMBED_FORMAT_VERSION)}"
+                )
+                await conn.commit()
+
             for vec_table, pk_col in _VEC_AUDIO_TABLES + _VEC_TEXT_TABLES:
                 await cursor.execute(
                     f"""
                     CREATE VIRTUAL TABLE IF NOT EXISTS {vec_table}
-                    USING vec0({pk_col} TEXT PRIMARY KEY, embedding float[{_CLAP_DIMS}])
+                    USING vec0({pk_col} TEXT PRIMARY KEY, embedding int8[{_CLAP_DIMS}])
                     """
                 )
             await conn.commit()
 
-        logger.info("sqlite-vec extension loaded; CLAP vector tables ready")
+        logger.info("sqlite-vec extension loaded; CLAP int8 vector tables ready")
     except Exception as e:
-        logger.warning("sqlite-vec not available (%s); KNN search disabled", e)
+        logger.warning("sqlite-vec vec table init failed (%s); KNN search disabled", e)

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder.py
@@ -28,7 +28,7 @@ import time
 from typing import Optional
 
 from ..config_model import LocalFilesConfig
-from ..embedding_utils import encode_embedding, normalise
+from ..embedding_utils import decode_embedding, encode_embedding, normalise
 from ..pip_utils import ensure_package
 from ..worker_utils import set_proc_title, sleep_interruptible
 from .embedder_db import AsyncEmbedderDb
@@ -149,7 +149,7 @@ class EmbeddingWorker:
             return None
 
     def _encode_query(self, query: str) -> Optional[bytes]:
-        """Encode a text query with CLAP. Returns float32 bytes or None."""
+        """Encode a text query with CLAP. Returns int8 embedding bytes or None."""
         if not self._clap_available:
             return None
         try:
@@ -251,7 +251,7 @@ class EmbeddingWorker:
             if not blobs:
                 continue
             try:
-                vecs = [np.frombuffer(b, dtype=np.float32) for b in blobs]
+                vecs = [decode_embedding(b) for b in blobs]
                 mean_vec = normalise(np.mean(vecs, axis=0))
                 await self.db.update_album_embedding(
                     album_id, encode_embedding(mean_vec)
@@ -266,7 +266,7 @@ class EmbeddingWorker:
             if not blobs:
                 continue
             try:
-                vecs = [np.frombuffer(b, dtype=np.float32) for b in blobs]
+                vecs = [decode_embedding(b) for b in blobs]
                 mean_vec = normalise(np.mean(vecs, axis=0))
                 await self.db.update_artist_embedding(
                     artist_id, encode_embedding(mean_vec)

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
@@ -602,6 +602,12 @@ class AsyncEmbedderDb:
         unknown-album sentinels — so all jobs can reach `done` and no sentinel
         filter is needed. The JOIN to tracks remains so jobs left behind by
         deleted tracks are not counted.
+
+        Only the latest ``model_version`` per stage is counted. A version bump
+        (e.g. the float32 -> int8 switch) leaves the superseded jobs behind, and
+        summing across versions would double the totals; counting just the
+        current version reports one row per track and shows true progress while
+        a recompute is still draining.
         """
         async with self._open() as conn:
             cursor = await conn.execute(
@@ -609,6 +615,11 @@ class AsyncEmbedderDb:
                 SELECT j.stage, j.status, COUNT(*) AS cnt
                 FROM embedding_jobs j
                 JOIN tracks t ON t.id = j.entity_id
+                WHERE j.model_version = (
+                    SELECT MAX(j2.model_version)
+                    FROM embedding_jobs j2
+                    WHERE j2.stage = j.stage
+                )
                 GROUP BY j.stage, j.status
                 """
             )

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedder/embedder_db.py
@@ -88,23 +88,19 @@ class AsyncEmbedderDb:
         entity_id: str,
         blob: bytes,
     ) -> None:
-        """Upsert into sqlite-vec table using update-first semantics.
+        """Upsert into a sqlite-vec int8 table via delete-then-insert.
 
-        sqlite-vec virtual tables can raise UNIQUE errors with INSERT OR REPLACE,
-        so we do UPDATE first, then INSERT OR IGNORE, then UPDATE again to handle
-        races between concurrent writers.
+        vec0 int8 columns can't be UPDATEd (sqlite-vec only accepts float32 on
+        UPDATE) and INSERT OR REPLACE hits a UNIQUE error on the vec0 PK, so we
+        DELETE then INSERT — safe to do non-atomically as the embedder is the
+        only writer. ``blob`` is int8 bytes; vec0 requires the ``vec_int8()``
+        wrapper (a raw blob is rejected as a type mismatch).
         """
-        update_sql = f"UPDATE {table} SET embedding = ? WHERE {pk_col} = ?"
-        insert_sql = (
-            f"INSERT OR IGNORE INTO {table} ({pk_col}, embedding) VALUES (?, ?)"
+        await conn.execute(f"DELETE FROM {table} WHERE {pk_col} = ?", (entity_id,))
+        await conn.execute(
+            f"INSERT INTO {table} ({pk_col}, embedding) VALUES (?, vec_int8(?))",
+            (entity_id, blob),
         )
-
-        cursor = await conn.execute(update_sql, (blob, entity_id))
-        if cursor.rowcount:
-            return
-
-        await conn.execute(insert_sql, (entity_id, blob))
-        await conn.execute(update_sql, (blob, entity_id))
 
     # ------------------------------------------------------------------
     # Job lifecycle
@@ -579,7 +575,7 @@ class AsyncEmbedderDb:
                 cursor = await conn.cursor()
                 await cursor.execute(
                     f"SELECT {pk_col}, distance FROM {table}"
-                    f" WHERE embedding MATCH ? ORDER BY distance LIMIT ?",
+                    f" WHERE embedding MATCH vec_int8(?) ORDER BY distance LIMIT ?",
                     (blob, limit),
                 )
                 rows = await cursor.fetchall()

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedding_utils.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/embedding_utils.py
@@ -1,12 +1,41 @@
-"""Shared vector utilities for embedder and searcher."""
+"""Shared vector utilities for embedder and searcher.
+
+CLAP embeddings are unit L2-normalised vectors stored as symmetric int8
+(4x smaller than float32, ~no recall loss): q = round(clip(v, -CAP, CAP) * 127/CAP).
+The scale is fixed, not calibrated per corpus: a query is quantized on its own
+and must land on the same integer grid as the stored vectors. sqlite-vec runs
+KNN on int8 directly, so vectors are never dequantized for search.
+"""
 
 from __future__ import annotations
 
+# Per-component clip bound, with headroom over the observed absmax (~0.223);
+# components beyond CAP saturate at ±127. Changing CAP/dtype/dim changes the
+# stored byte format — bump CLAP_EMBED_FORMAT_VERSION when it does.
+CLAP_INT8_CAP = 0.25
+CLAP_INT8_SCALE = 127.0 / CLAP_INT8_CAP
+
+# Stored CLAP vector format, recorded in PRAGMA user_version. On a mismatch the
+# schema layer rebuilds the typed vec0 tables and clears embedding blobs so the
+# embedder recomputes them. 0/unset = legacy float32; 2 = int8 symmetric.
+CLAP_EMBED_FORMAT_VERSION = 2
+
 
 def encode_embedding(vector) -> bytes:
+    """Quantize a (normalised) float embedding to int8 bytes for storage."""
     import numpy as np
 
-    return vector.astype(np.float32).tobytes()
+    v = np.asarray(vector, dtype=np.float32)
+    q = np.clip(np.round(v * CLAP_INT8_SCALE), -127.0, 127.0).astype(np.int8)
+    return q.tobytes()
+
+
+def decode_embedding(blob: bytes):
+    """Dequantize stored int8 bytes to a float32 vector for mean-pooling
+    track vectors into album/artist aggregates."""
+    import numpy as np
+
+    return np.frombuffer(blob, dtype=np.int8).astype(np.float32) / CLAP_INT8_SCALE
 
 
 def normalise(v) -> "object":

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
@@ -96,7 +96,7 @@ class AsyncSearcherDb:
                 await self._load_vec(conn)
                 cursor = await conn.execute(
                     "SELECT track_id, distance FROM vec_tracks_clap_text"
-                    " WHERE embedding MATCH ? ORDER BY distance LIMIT ?",
+                    " WHERE embedding MATCH vec_int8(?) ORDER BY distance LIMIT ?",
                     (query_blob, limit),
                 )
                 rows = await cursor.fetchall()
@@ -117,7 +117,7 @@ class AsyncSearcherDb:
                 await self._load_vec(conn)
                 cursor = await conn.execute(
                     "SELECT track_id, distance FROM vec_tracks_clap"
-                    " WHERE embedding MATCH ? ORDER BY distance LIMIT ?",
+                    " WHERE embedding MATCH vec_int8(?) ORDER BY distance LIMIT ?",
                     (query_blob, limit),
                 )
                 rows = await cursor.fetchall()

--- a/packages/kalinka-plugin-localfiles/tests/test_clap_int8.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_clap_int8.py
@@ -1,0 +1,196 @@
+"""CLAP int8 vector quantization: round-trip, storage format, migration.
+
+The embedder stores CLAP vectors as symmetric int8 (4x smaller than float32)
+instead of raw float32. These tests cover:
+
+  * encode/decode round-trip fidelity and the 512-byte int8 footprint,
+  * the float32 -> int8 schema migration (drop typed vec tables, clear blobs,
+    stamp PRAGMA user_version) on an existing legacy database,
+  * the write + KNN-search path against the int8 vec0 tables,
+  * the backward-compat guarantee that an int8 query against a not-yet-migrated
+    float database returns no results rather than crashing.
+"""
+
+import os
+import tempfile
+
+import aiosqlite
+import numpy as np
+import pytest
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.embedder.embedder_db import AsyncEmbedderDb
+from kalinka_plugin_localfiles.embedding_utils import (
+    CLAP_EMBED_FORMAT_VERSION,
+    CLAP_INT8_CAP,
+    decode_embedding,
+    encode_embedding,
+    normalise,
+)
+from kalinka_plugin_localfiles.searcher.searcher_db import AsyncSearcherDb
+
+sqlite_vec = pytest.importorskip("sqlite_vec")
+
+DIM = 512
+
+
+def _unit_vec(seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return normalise(rng.standard_normal(DIM).astype(np.float32))
+
+
+def _config(db_path: str) -> LocalFilesConfig:
+    return LocalFilesConfig(db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# Pure quantization
+# ---------------------------------------------------------------------------
+
+
+def test_int8_roundtrip_is_512_bytes_and_high_fidelity():
+    v = _unit_vec(1)
+    blob = encode_embedding(v)
+    assert len(blob) == DIM  # one int8 per dimension, 4x smaller than float32
+    back = decode_embedding(blob)
+    cos = float(np.dot(normalise(back), v))
+    assert cos > 0.999  # symmetric int8 preserves direction near-perfectly
+
+
+def test_encode_saturates_out_of_range_components():
+    # Components beyond the cap saturate at +/-127 instead of wrapping.
+    v = np.zeros(DIM, dtype=np.float32)
+    v[0] = 10.0  # far above CAP
+    v[1] = -10.0
+    q = np.frombuffer(encode_embedding(v), dtype=np.int8)
+    assert q[0] == 127 and q[1] == -127
+
+
+def test_cap_covers_observed_range():
+    # Sanity: the cap leaves headroom over a realistic unit-vector component.
+    assert CLAP_INT8_CAP >= 0.23
+
+
+# ---------------------------------------------------------------------------
+# Migration from the legacy float32 format
+# ---------------------------------------------------------------------------
+
+
+async def _make_legacy_float_db(db_path: str) -> None:
+    """Build a database in the pre-int8 (float[512]) on-disk format."""
+    await init_db(db_path)  # creates current (int8) schema...
+    # ...then rewrite the vec tables as float[512] and seed legacy state, so the
+    # next init_db sees a v0/float database to migrate.
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.enable_load_extension(True)
+        await conn.load_extension(sqlite_vec.loadable_path())
+        await conn.enable_load_extension(False)
+        await conn.execute("DROP TABLE IF EXISTS vec_tracks_clap")
+        await conn.execute(
+            f"CREATE VIRTUAL TABLE vec_tracks_clap USING vec0("
+            f"track_id TEXT PRIMARY KEY, embedding float[{DIM}])"
+        )
+        fblob = _unit_vec(7).tobytes()  # 2048-byte float32 blob
+        await conn.execute(
+            "INSERT INTO vec_tracks_clap(track_id, embedding) VALUES('t1', ?)",
+            (fblob,),
+        )
+        await conn.execute(
+            "INSERT INTO tracks (id, title, file_path, format, enriched, "
+            "embedding_clap_audio, embedding_version) "
+            "VALUES ('t1', 'Song', 'f1', 'mp3', 1, ?, 3)",
+            (fblob,),
+        )
+        await conn.execute("PRAGMA user_version = 0")
+        await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_migration_rebuilds_int8_and_clears_blobs():
+    with tempfile.TemporaryDirectory() as d:
+        db = os.path.join(d, "legacy.db")
+        await _make_legacy_float_db(db)
+
+        # Precondition: legacy float format with a stored embedding.
+        async with aiosqlite.connect(db) as conn:
+            cur = await conn.execute("PRAGMA user_version")
+            assert (await cur.fetchone())[0] == 0
+            cur = await conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name='vec_tracks_clap'"
+            )
+            assert "float[512]" in (await cur.fetchone())[0]
+
+        # Restart with the current code.
+        await init_db(db)
+
+        async with aiosqlite.connect(db) as conn:
+            cur = await conn.execute("PRAGMA user_version")
+            assert (await cur.fetchone())[0] == CLAP_EMBED_FORMAT_VERSION
+            cur = await conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name='vec_tracks_clap'"
+            )
+            assert "int8[512]" in (await cur.fetchone())[0]
+            # Stale blobs cleared so the embedder recomputes them in int8 and
+            # aggregates never mix formats.
+            cur = await conn.execute(
+                "SELECT embedding_clap_audio, embedding_version FROM tracks WHERE id='t1'"
+            )
+            row = await cur.fetchone()
+            assert row[0] is None and row[1] == 0
+
+        # Idempotent: a second restart is a no-op.
+        await init_db(db)
+        async with aiosqlite.connect(db) as conn:
+            cur = await conn.execute("PRAGMA user_version")
+            assert (await cur.fetchone())[0] == CLAP_EMBED_FORMAT_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Write + search round-trip on the int8 vec tables
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_then_knn_search_int8():
+    with tempfile.TemporaryDirectory() as d:
+        db = os.path.join(d, "fresh.db")
+        await init_db(db)
+        cfg = _config(db)
+
+        async with aiosqlite.connect(db) as conn:
+            for i in range(5):
+                await conn.execute(
+                    "INSERT INTO tracks (id, title, file_path, format, enriched) "
+                    "VALUES (?, ?, ?, 'mp3', 1)",
+                    (f"t{i}", f"Song {i}", f"f{i}"),
+                )
+            await conn.commit()
+
+        edb = AsyncEmbedderDb(cfg)
+        await edb._check_vec_available()
+        vecs = {f"t{i}": _unit_vec(100 + i) for i in range(5)}
+        for tid, v in vecs.items():
+            # job_id 0 is fine; the embedding_jobs row update is a no-op here.
+            await edb.complete_clap_job(0, tid, encode_embedding(v), version=4)
+
+        sdb = AsyncSearcherDb(cfg)
+        await sdb._check_vec_available()
+        # Self-query: the matching track must come back first at distance 0.
+        res = await sdb.knn_search_audio(encode_embedding(vecs["t2"]), limit=5)
+        assert res, "expected KNN hits from the int8 vec table"
+        assert res[0]["track_id"] == "t2"
+        assert res[0]["distance"] == pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_int8_query_against_float_db_returns_empty():
+    """A not-yet-migrated float database must not crash an int8 query."""
+    with tempfile.TemporaryDirectory() as d:
+        db = os.path.join(d, "legacy.db")
+        await _make_legacy_float_db(db)  # float vec tables, NOT migrated
+
+        sdb = AsyncSearcherDb(_config(db))
+        await sdb._check_vec_available()
+        res = await sdb.knn_search_audio(encode_embedding(_unit_vec(7)), limit=5)
+        assert res == []  # type mismatch is swallowed -> no results, no crash

--- a/packages/kalinka-plugin-localfiles/tests/test_clap_int8.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_clap_int8.py
@@ -194,3 +194,39 @@ async def test_int8_query_against_float_db_returns_empty():
         await sdb._check_vec_available()
         res = await sdb.knn_search_audio(encode_embedding(_unit_vec(7)), limit=5)
         assert res == []  # type mismatch is swallowed -> no results, no crash
+
+
+@pytest.mark.asyncio
+async def test_coverage_counts_only_latest_version():
+    """A version bump leaves superseded jobs behind; coverage must report one
+    row per track (latest model_version), not sum across versions."""
+    with tempfile.TemporaryDirectory() as d:
+        db = os.path.join(d, "cov.db")
+        await init_db(db)
+        async with aiosqlite.connect(db) as conn:
+            for i in range(3):
+                await conn.execute(
+                    "INSERT INTO tracks (id, title, file_path, format, enriched) "
+                    "VALUES (?, ?, ?, 'mp3', 1)",
+                    (f"t{i}", f"Song {i}", f"f{i}"),
+                )
+            # Old (superseded) v3 jobs, all done, plus current v4 jobs mid-recompute.
+            for i in range(3):
+                await conn.execute(
+                    "INSERT INTO embedding_jobs (entity_type, entity_id, stage, "
+                    "status, model_version) VALUES ('track', ?, 'clap_audio', 'done', 3)",
+                    (f"t{i}",),
+                )
+            for i, status in enumerate(["done", "done", "pending"]):
+                await conn.execute(
+                    "INSERT INTO embedding_jobs (entity_type, entity_id, stage, "
+                    "status, model_version) VALUES ('track', ?, 'clap_audio', ?, 4)",
+                    (f"t{i}", status),
+                )
+            await conn.commit()
+
+        cov = await AsyncEmbedderDb(_config(db)).get_embedding_coverage()
+        audio = cov["clap_audio"]
+        assert audio["total"] == 3  # not 6 — only the latest version is counted
+        assert audio["done"] == 2 and audio["pending"] == 1
+        assert audio["coverage_pct"] == pytest.approx(66.7, abs=0.1)


### PR DESCRIPTION
## What

CLAP audio/text search embeddings are stored as **symmetric int8** instead of float32 in the sqlite-vec `vec0` index (and the `embedding_clap*` BLOB columns).

CLAP embeddings are L2-normalised unit vectors whose per-component magnitudes top out around **0.223** across both production libraries I checked, so float32 spends 4× the space for no benefit. Quantization uses a **fixed** scale:

```
q = round(clip(v, -0.25, 0.25) * 127 / 0.25)
```

The scale is fixed (not corpus-calibrated) because a text query is quantized on its own at query time and must land on the same integer grid as the stored vectors. sqlite-vec computes L2 distance directly on int8 — vectors are never dequantized for search.

## Results — measured on real production embeddings

**Real library, 5829 tracks** (all 6 vec tables: tracks/albums/artists × audio/text; same real vectors quantized float→int8; on-disk bytes via `dbstat`, VACUUMed; latency = 400 KNN queries on `vec_tracks_clap`):

| | float32 | int8 | change |
|---|---|---|---|
| vec index (KNN, in-RAM/on-disk) | 34.10 MB | 8.94 MB | **3.82× smaller (−74%)** |
| `embedding_clap*` BLOB columns | 28.57 MB | 7.14 MB | **4.00× smaller** |
| **combined embedding footprint** | **62.7 MB** | **16.1 MB** | **3.9× (−74%)** |
| KNN query latency (median) | 3.15 ms | 1.92 ms | **1.64× faster** |
| KNN query latency (mean) | 3.19 ms | 2.01 ms | 1.59× faster |

**Live confirmation** — recomputed the running dev library (516 tracks) end-to-end through the real embedder pipeline after restart:
- int8 vec index **3.24 MB** (vs ~12.9 MB float-equivalent)
- int8 BLOB columns **0.69 MB** (vs ~2.78 MB float-equivalent)

### Retrieval quality — no regression

Ground-truth metrics (1035 truth-matched tracks) are **within noise** of the float32 baseline:

- audio: P@10 0.290 vs 0.292 · MRR 0.364 vs 0.361 · Hit@10 0.550 = 0.550
- text: P@10 0.262 vs 0.263 · MRR 0.331 vs 0.336 · Hit@10 0.470 = 0.470

Rank fidelity vs float32: top-10 overlap **~0.99**, top-1 preserved 0.96–1.00. The fixed-scale scheme matches the data-calibrated ceiling on fidelity and clearly beats the naive scale=127 scheme.

Range (CAP=0.25) was chosen from the actual distributions in both DBs: combined per-component absmax 0.223, p99.999 0.194; CAP leaves headroom, rare out-of-range components saturate rather than wrap.

## Backward compatibility — no crashes, brief search downtime is fine

- `vec0` columns are typed; a `PRAGMA user_version` stamp records the on-disk format (`CLAP_EMBED_FORMAT_VERSION`). On a mismatch, `init_db` drops the typed vec tables, clears stored embedding blobs, and stamps the new version. The bumped `embedder.clap.current_version` (3→4) reschedules the embed jobs that refill them. (The two counters are intentionally independent — see the comment in `config_model.py`.)
- sqlite-vec rejects a dtype-mismatched `MATCH` with an error, which the search layer already swallows → an **un-migrated (float) DB returns no vector hits rather than crashing**. Search degrades to FTS-only while the embedder recomputes.
- int8 `vec0` columns can't be `UPDATE`d and reject `INSERT OR REPLACE`, so the vec upsert is now **delete-then-insert** (single writer, one transaction).

Verified live: after restart the schema migrated (`int8[512]`, `user_version=2`, blobs cleared), the embedder rescheduled 519 audio + 519 text jobs at v4 and recomputed them (~0.7 s/audio track); 3 undecodable files stayed failed, as on v3.

## Tests

- New `test_clap_int8.py`: round-trip fidelity + 512-byte footprint, float→int8 migration (drop + blob-clear + `user_version` stamp, idempotent), write+KNN path, and the un-migrated-DB safety guarantee.
- Full localfiles suite: 161 passed (`test_match_scoring.py` has a pre-existing, unrelated collection error — `Dict` used without import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)