### PR TITLE
BEST MATCH: literal/navigational search section (FTS + rapidfuzz)

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
@@ -193,6 +193,30 @@ class SearcherConfig(BaseModel):
     max_results: int = Field(
         default=20, title="Max results per entity type",
     )
+    # --- BEST MATCH (literal/navigational FTS block shown above AI search) ---
+    # Expert-only: these surface as the top "BEST MATCH" section, so the
+    # defaults err on the strict side. A weak match shown as the "best"
+    # result is worse than showing nothing.
+    best_match_min_fuzz_score: int = Field(
+        default=70, ge=0, le=100,
+        title="BEST MATCH minimum rapidfuzz score (0–100)",
+        json_schema_extra={
+            "help": (
+                "Inclusion threshold for the top BEST MATCH block. Higher = "
+                "fewer, more confident literal matches. Mirrors RAPIDFUZZ_CUTOFF."
+            ),
+        },
+    )
+    best_match_max_results: int = Field(
+        default=6, ge=1, le=50,
+        title="BEST MATCH max results",
+        json_schema_extra={
+            "help": (
+                "Maximum entities in the BEST MATCH block (before "
+                "album/artist redundancy removal). Mirrors MAX_RESULTS."
+            ),
+        },
+    )
 
 
 class EmbedderConfig(BaseModel):

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
@@ -165,9 +165,6 @@ class SearcherConfig(BaseModel):
         title="Model directory",
         json_schema_extra={"widget": "path"},
     )
-    weight_fts: float = Field(
-        default=0.35, ge=0.0, le=1.0, title="FTS rank weight",
-    )
     weight_knn: float = Field(
         default=0.45, ge=0.0, le=1.0, title="CLAP KNN similarity weight",
     )
@@ -182,10 +179,6 @@ class SearcherConfig(BaseModel):
     )
     fts_candidate_limit: int = Field(
         default=100, title="Max FTS candidates before re-ranking",
-    )
-    fts_min_fuzz_score: int = Field(
-        default=72, ge=0, le=100,
-        title="Minimum rapidfuzz WRatio for FTS hits (0–100)",
     )
     knn_candidate_limit: int = Field(
         default=50, title="Max KNN candidates before re-ranking",

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
@@ -130,13 +130,21 @@ class LocalFilesInputModule(InputModule):
                 logger.warning("ai_search: timed out waiting for searcher response")
                 return EmptyList(offset, limit)
         logger.info(
-            "ai_search: response — %d tracks, %d albums, %d artists",
+            "ai_search: response — %d best-match, %d tracks, %d albums, %d artists",
+            len(ids.get("best_match", [])),
             len(ids.get("tracks", [])),
             len(ids.get("albums", [])),
             len(ids.get("artists", [])),
         )
 
         sections: List[BrowseItem] = []
+
+        # BEST MATCH (literal/navigational FTS hits) renders first, as a single
+        # flat list ordered by score — above the semantic AI suggestions.
+        best_match_section = self._build_best_match_section(ids.get("best_match", []))
+        if best_match_section is not None:
+            sections.append(best_match_section)
+
         for entity_type, fetch_fn, create_fn, name, preview_content in [
             (
                 "tracks",
@@ -193,6 +201,71 @@ class LocalFilesInputModule(InputModule):
             limit=limit,
             total=len(sections),
             items=sections[offset : offset + limit],
+        )
+
+    def _build_best_match_section(
+        self, entities: List[Dict]
+    ) -> Optional[BrowseItem]:
+        """Build the BEST MATCH section: a single flat list of mixed entity
+        types (track / album / artist) in the order the searcher returned
+        them (rapidfuzz score, highest first).
+
+        ``entities`` is the searcher's ``best_match`` payload — ``{"id",
+        "type"}`` dicts. Returns None when empty so the UI renders no header.
+        """
+        if not entities:
+            return None
+
+        # Batch-fetch per type, then reassemble in the original score order.
+        builders = {
+            ("track", row["id"]): self._create_track_browse_item(row)
+            for row in self.db_manager.get_tracks_by_ids(
+                [e["id"] for e in entities if e["type"] == "track"]
+            )
+        }
+        builders.update(
+            {
+                ("album", row["id"]): self._create_album_browse_item(row)
+                for row in self.db_manager.get_albums_by_ids(
+                    [e["id"] for e in entities if e["type"] == "album"]
+                )
+            }
+        )
+        builders.update(
+            {
+                ("artist", row["id"]): self._create_artist_browse_item(row)
+                for row in self.db_manager.get_artists_by_ids(
+                    [e["id"] for e in entities if e["type"] == "artist"]
+                )
+            }
+        )
+
+        rows = [
+            builders[(e["type"], e["id"])]
+            for e in entities
+            if (e["type"], e["id"]) in builders
+        ]
+        if not rows:
+            return None
+
+        cat = catalog_id("best_match")
+        return BrowseItem(
+            id=cat,
+            name="BEST MATCH",
+            can_browse=False,
+            can_add=False,
+            catalog=Catalog(
+                id=cat,
+                title="BEST MATCH",
+                # Mixed entity types in one ranked list: a neutral CATALOG
+                # content hint, TILE so each row shows its own icon + subname.
+                preview_config=Preview(
+                    type=PreviewType.TILE,
+                    content_type=PreviewContentType.CATALOG,
+                    items_count=len(rows),
+                ),
+            ),
+            sections=rows,
         )
 
     async def search(

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
@@ -145,27 +145,49 @@ class LocalFilesInputModule(InputModule):
         if best_match_section is not None:
             sections.append(best_match_section)
 
-        for entity_type, fetch_fn, create_fn, name, preview_content in [
+        # Presentation (header label, subtitle, icon, layout) is owned by the
+        # backend so the UI renders sections verbatim instead of re-interpreting
+        # content. The curated track set is a CARD; the derived album/artist
+        # sets are plain TILE sections shown below it.
+        for (
+            entity_type,
+            fetch_fn,
+            create_fn,
+            name,
+            subname,
+            icon,
+            content_type,
+            preview_type,
+        ) in [
             (
                 "tracks",
                 self.db_manager.get_tracks_by_ids,
                 self._create_track_browse_item,
-                "Tracks",
+                "AI SUGGESTIONS",
+                "Curated for your search",
+                "ai_suggestions",
                 PreviewContentType.TRACK,
+                PreviewType.CARD,
             ),
             (
                 "albums",
                 self.db_manager.get_albums_by_ids,
                 self._create_album_browse_item,
-                "Albums",
+                "Related Albums",
+                None,
+                "album",
                 PreviewContentType.ALBUM,
+                PreviewType.TILE,
             ),
             (
                 "artists",
                 self.db_manager.get_artists_by_ids,
                 self._create_artist_browse_item,
-                "Artists",
+                "Related Artists",
+                None,
+                "artist",
                 PreviewContentType.ARTIST,
+                PreviewType.TILE,
             ),
         ]:
             entity_ids = ids.get(entity_type, [])
@@ -179,14 +201,16 @@ class LocalFilesInputModule(InputModule):
                 BrowseItem(
                     id=cat,
                     name=name,
+                    subname=subname,
                     can_browse=False,
                     can_add=False,
                     catalog=Catalog(
                         id=cat,
                         title=name,
                         preview_config=Preview(
-                            type=PreviewType.IMAGE_TEXT,
-                            content_type=preview_content,
+                            type=preview_type,
+                            content_type=content_type,
+                            icon=icon,
                             items_count=len(entities),
                         ),
                     ),
@@ -242,16 +266,19 @@ class LocalFilesInputModule(InputModule):
         return BrowseItem(
             id=cat,
             name="BEST MATCH",
+            subname="Top results for your search",
             can_browse=False,
             can_add=False,
             catalog=Catalog(
                 id=cat,
                 title="BEST MATCH",
-                # Mixed entity types in one ranked list: a neutral CATALOG
-                # content hint, TILE so each row shows its own icon + subname.
+                # Plain TILE section (not a card). Mixed entity types in one
+                # ranked list -> neutral CATALOG content hint; the star icon
+                # marks it as the navigational best match.
                 preview_config=Preview(
                     type=PreviewType.TILE,
                     content_type=PreviewContentType.CATALOG,
+                    icon="best_match",
                     items_count=len(rows),
                 ),
             ),

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
@@ -217,28 +217,18 @@ class LocalFilesInputModule(InputModule):
             return None
 
         # Batch-fetch per type, then reassemble in the original score order.
-        builders = {
-            ("track", row["id"]): self._create_track_browse_item(row)
-            for row in self.db_manager.get_tracks_by_ids(
-                [e["id"] for e in entities if e["type"] == "track"]
-            )
-        }
-        builders.update(
-            {
-                ("album", row["id"]): self._create_album_browse_item(row)
-                for row in self.db_manager.get_albums_by_ids(
-                    [e["id"] for e in entities if e["type"] == "album"]
-                )
-            }
-        )
-        builders.update(
-            {
-                ("artist", row["id"]): self._create_artist_browse_item(row)
-                for row in self.db_manager.get_artists_by_ids(
-                    [e["id"] for e in entities if e["type"] == "artist"]
-                )
-            }
-        )
+        builders: Dict[tuple, BrowseItem] = {}
+        for entity_type, fetch_fn, create_fn in (
+            ("track", self.db_manager.get_tracks_by_ids,
+             self._create_track_browse_item),
+            ("album", self.db_manager.get_albums_by_ids,
+             self._create_album_browse_item),
+            ("artist", self.db_manager.get_artists_by_ids,
+             self._create_artist_browse_item),
+        ):
+            ids = [e["id"] for e in entities if e["type"] == entity_type]
+            for row in fetch_fn(ids):
+                builders[(entity_type, row["id"])] = create_fn(row)
 
         rows = [
             builders[(e["type"], e["id"])]

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/best_match.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/best_match.py
@@ -1,0 +1,121 @@
+"""
+"BEST MATCH" assembly for Kalinka full-text search.
+
+Takes a flat list of scored library entities (artists, albums, tracks) and
+produces a small, high-confidence ordered set answering *navigational* intent
+("I know what this is called, take me to it").  The result renders as a single
+flat "BEST MATCH" block at the very top of search results, above the AI /
+semantic suggestions.  This module is purely about the FTS/literal side; the
+semantic sections are assembled elsewhere and are unaffected.
+
+Algorithm (executed in this exact order — see assemble_best_match):
+    1. Score every candidate against the query; discard score < RAPIDFUZZ_CUTOFF.
+    2. Sort surviving entities (all types mixed) by score descending; keep top
+       MAX_RESULTS.
+    3. Remove redundancy on the truncated list, strictly-greater comparisons:
+         a. album dominates its tracks (album.score > track.score)
+         b. artist dominates its tracks/albums (artist.score > entity.score)
+    4. Return the remaining entities, still score-descending (0..MAX_RESULTS).
+
+The truncate-before-dedup ordering (step 2 before step 3) is deliberate: a
+strong-but-redundant entity can crowd out a weaker survivor, leaving fewer than
+MAX_RESULTS items.  That is intended; we do not backfill.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from rapidfuzz import fuzz
+
+# ---------------------------------------------------------------------------
+# Tunable constants
+# ---------------------------------------------------------------------------
+
+# Inclusion threshold (rapidfuzz score, 0-100).  These surface as "BEST MATCH"
+# at the very top, so err higher rather than lower: a weak match shown as the
+# best result is worse than showing nothing.  Start ~70 and tune.
+RAPIDFUZZ_CUTOFF: float = 70.0
+
+# Maximum number of entities in the BEST MATCH block.
+MAX_RESULTS: int = 6
+
+# Scorer applied to (query, entity.name).  WRatio is robust to word-order and
+# partial matches ("piano guys" vs "The Piano Guys").  Swap for
+# fuzz.token_set_ratio / fuzz.partial_ratio if a different behaviour is wanted.
+SCORER = fuzz.WRatio
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Entity:
+    """A library entity (artist / album / track) considered for BEST MATCH.
+
+    `score` is populated by assemble_best_match; callers may leave it at the
+    default.  Redundancy checks operate on IDs (album_id / artist_id), never on
+    name strings.
+    """
+
+    id: str
+    type: str  # "artist" | "album" | "track"
+    name: str
+    score: float = 0.0
+    album_id: Optional[str] = None  # tracks only
+    artist_id: Optional[str] = None  # tracks and albums
+
+
+# ---------------------------------------------------------------------------
+# Assembly
+# ---------------------------------------------------------------------------
+
+
+def assemble_best_match(candidates: list[Entity], query: str) -> list[Entity]:
+    """Score, cut off, sort, truncate to MAX_RESULTS, then remove album/artist-
+    dominated redundancies.
+
+    Returns 0..MAX_RESULTS entities, score-descending, exactly as produced (no
+    re-sort or regroup by type).  An empty list means the UI renders no BEST
+    MATCH section.
+    """
+    # Step 1 — score every candidate; discard below the cutoff.
+    survivors: list[Entity] = []
+    for entity in candidates:
+        entity.score = SCORER(query, entity.name)
+        if entity.score >= RAPIDFUZZ_CUTOFF:
+            survivors.append(entity)
+
+    # Step 2 — sort by score descending, keep the top MAX_RESULTS.  This is
+    # "the list" the redundancy rules operate on.
+    survivors.sort(key=lambda e: e.score, reverse=True)
+    the_list = survivors[:MAX_RESULTS]
+
+    # Step 3 — remove redundancy.  Index by id+type so lookups are exact and a
+    # track and its same-named album/artist never collide.
+    albums_by_id = {e.id: e for e in the_list if e.type == "album"}
+    artists_by_id = {e.id: e for e in the_list if e.type == "artist"}
+
+    # Rule 1: album dominates its tracks (strictly greater).
+    after_rule1: list[Entity] = []
+    for e in the_list:
+        if e.type == "track" and e.album_id is not None:
+            album = albums_by_id.get(e.album_id)
+            if album is not None and album.score > e.score:
+                continue  # dominated by its album
+        after_rule1.append(e)
+
+    # Rule 2: artist dominates its tracks/albums (strictly greater).
+    final: list[Entity] = []
+    for e in after_rule1:
+        if e.type in ("track", "album") and e.artist_id is not None:
+            artist = artists_by_id.get(e.artist_id)
+            if artist is not None and artist.score > e.score:
+                continue  # dominated by its artist
+        final.append(e)
+
+    # Step 4 — already in score-descending order; return as-is.
+    return final

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/best_match.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/best_match.py
@@ -29,16 +29,21 @@ from typing import Optional
 
 from rapidfuzz import fuzz
 
+from ..utils.name_utils import fold_diacritics
+
 # ---------------------------------------------------------------------------
 # Tunable constants
 # ---------------------------------------------------------------------------
 
 # Inclusion threshold (rapidfuzz score, 0-100).  These surface as "BEST MATCH"
 # at the very top, so err higher rather than lower: a weak match shown as the
-# best result is worse than showing nothing.  Start ~70 and tune.
+# best result is worse than showing nothing.  Start ~70 and tune.  The runtime
+# pipeline overrides this from config (searcher.best_match_min_fuzz_score);
+# this is the in-code default and the value the unit tests pin to.
 RAPIDFUZZ_CUTOFF: float = 70.0
 
-# Maximum number of entities in the BEST MATCH block.
+# Maximum number of entities in the BEST MATCH block.  Overridden at runtime by
+# config (searcher.best_match_max_results).
 MAX_RESULTS: int = 6
 
 # Scorer applied to (query, entity.name).  WRatio is robust to word-order and
@@ -74,25 +79,35 @@ class Entity:
 # ---------------------------------------------------------------------------
 
 
-def assemble_best_match(candidates: list[Entity], query: str) -> list[Entity]:
-    """Score, cut off, sort, truncate to MAX_RESULTS, then remove album/artist-
-    dominated redundancies.
+def assemble_best_match(
+    candidates: list[Entity],
+    query: str,
+    *,
+    cutoff: float = RAPIDFUZZ_CUTOFF,
+    max_results: int = MAX_RESULTS,
+) -> list[Entity]:
+    """Score, cut off, sort, truncate to ``max_results``, then remove album/
+    artist-dominated redundancies.
 
-    Returns 0..MAX_RESULTS entities, score-descending, exactly as produced (no
-    re-sort or regroup by type).  An empty list means the UI renders no BEST
-    MATCH section.
+    Returns 0..``max_results`` entities, score-descending, exactly as produced
+    (no re-sort or regroup by type).  An empty list means the UI renders no
+    BEST MATCH section.  ``cutoff`` / ``max_results`` default to the module
+    constants and are overridden from config by the search pipeline.
     """
-    # Step 1 — score every candidate; discard below the cutoff.
+    # Step 1 — score every candidate; discard below the cutoff.  Both sides are
+    # diacritic-folded so an ASCII query ("noi kabat") still matches accented
+    # names ("Női Kabát") — consistent with the FTS re-rank elsewhere.
+    folded_query = fold_diacritics(query)
     survivors: list[Entity] = []
     for entity in candidates:
-        entity.score = SCORER(query, entity.name)
-        if entity.score >= RAPIDFUZZ_CUTOFF:
+        entity.score = SCORER(folded_query, fold_diacritics(entity.name))
+        if entity.score >= cutoff:
             survivors.append(entity)
 
-    # Step 2 — sort by score descending, keep the top MAX_RESULTS.  This is
+    # Step 2 — sort by score descending, keep the top ``max_results``.  This is
     # "the list" the redundancy rules operate on.
     survivors.sort(key=lambda e: e.score, reverse=True)
-    the_list = survivors[:MAX_RESULTS]
+    the_list = survivors[:max_results]
 
     # Step 3 — remove redundancy.  Index by id+type so lookups are exact and a
     # track and its same-named album/artist never collide.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher.py
@@ -475,18 +475,18 @@ class SearchWorker:
     def _score_track(
         self,
         parsed: ParsedQuery,
-        fts_rank_norm: float,
         knn_norm: float,
         track_tags: dict | None,
-        has_fts_hits: bool = True,
         has_knn_hits: bool = True,
     ) -> float:
         """
-        Compute a combined relevance score for a single track.
+        Compute a combined relevance score for a single track from the
+        semantic (CLAP KNN) leg and the predicted-tag components.
 
-        Weights are dynamically normalised based on which search legs
-        actually contributed results, so scores always use the full 0–1
-        range regardless of CLAP availability.
+        Weights are dynamically normalised based on which inputs actually
+        contributed, so scores always use the full 0–1 range regardless of
+        CLAP availability. Literal/text matching is handled separately by
+        the BEST MATCH path and never enters this blend.
 
         ``cfg.tags.enabled`` gates the entire tag pipeline — both
         prediction (handled elsewhere) and search-time scoring. When
@@ -507,8 +507,6 @@ class SearchWorker:
 
         # Build weighted sum only from active components
         components: list[tuple[float, float]] = []
-        if has_fts_hits:
-            components.append((cfg.weight_fts, fts_rank_norm))
         if has_knn_hits:
             components.append((cfg.weight_knn, knn_norm))
         if tags_active:
@@ -720,10 +718,8 @@ class SearchWorker:
             track_tags = tags_map.get(tid)
             score = self._score_track(
                 parsed,
-                0.0,
                 knn_norm,
                 track_tags,
-                has_fts_hits=False,
                 has_knn_hits=has_knn,
             )
             scored.append((score, tid))
@@ -913,10 +909,8 @@ class SearchWorker:
             knn_norm = knn_map.get(tid, 0.0)
             score = self._score_track(
                 synth,
-                0.0,
                 knn_norm,
                 track_tags,
-                has_fts_hits=False,
                 has_knn_hits=bool(knn_map),
             )
             scored.append((score, tid))

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher.py
@@ -641,7 +641,6 @@ class SearchWorker:
         FTS is no longer blended into the semantic ranking; the AI sections
         are purely semantic.
         """
-        empty: dict = {"tracks": [], "albums": [], "artists": [], "best_match": []}
         cfg = self.config.searcher
         self._track_meta_cache: dict[str, dict] = {}
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher.py
@@ -40,6 +40,7 @@ from typing import Optional
 from ..config_model import LocalFilesConfig
 from ..pip_utils import ensure_package
 from ..worker_utils import set_proc_title, sleep_interruptible
+from .best_match import Entity, assemble_best_match
 from .genre_labels import label_for_index
 from .query_parser import ParsedQuery, parse_query
 from .searcher_db import AsyncSearcherDb
@@ -627,8 +628,20 @@ class SearchWorker:
     # ------------------------------------------------------------------
 
     async def _do_search(self, query: str, limit: int) -> dict:
-        """Handle one search request end-to-end (FTS + KNN in parallel)."""
-        empty: dict = {"tracks": [], "albums": [], "artists": []}
+        """Handle one search request end-to-end.
+
+        Two independent legs run in parallel and are returned side by side,
+        not merged:
+
+          * BEST MATCH — literal/navigational FTS over artist/album/track
+            names (``assemble_best_match``). Surfaced as its own top section.
+          * Semantic — CLAP KNN audio neighbours, tag re-ranked. Drives the
+            AI suggestion sections (tracks/albums/artists).
+
+        FTS is no longer blended into the semantic ranking; the AI sections
+        are purely semantic.
+        """
+        empty: dict = {"tracks": [], "albums": [], "artists": [], "best_match": []}
         cfg = self.config.searcher
         self._track_meta_cache: dict[str, dict] = {}
 
@@ -645,57 +658,49 @@ class SearchWorker:
         if parsed.is_similar_query and parsed.similar_to_track_id:
             return await self._do_similar_search(parsed, limit)
 
-        # --- Run FTS and KNN in parallel ---
-        fts_coro = self._fts_leg(parsed, cfg.fts_candidate_limit)
+        # --- Run the BEST MATCH (FTS) and semantic (KNN) legs in parallel ---
+        best_match_coro = self._best_match_leg(parsed)
         knn_coro = self._knn_leg(query, cfg.knn_candidate_limit)
-        fts_hits, knn_hits = await asyncio.gather(fts_coro, knn_coro)
+        best_match, knn_hits = await asyncio.gather(best_match_coro, knn_coro)
 
         logger.info(
-            "_do_search: FTS=%d hits, KNN=%d hits",
-            len(fts_hits),
+            "_do_search: BEST MATCH=%d, KNN=%d hits",
+            len(best_match),
             len(knn_hits),
         )
 
-        # Tag fallback — only when both FTS and KNN returned nothing
-        # AND the tag pipeline is active. With tags disabled we leave the
-        # result empty rather than reaching into stale tag predictions.
+        # Semantic tag fallback — only when the KNN leg returned nothing AND
+        # the tag pipeline is active. Ranks purely by genre-tag overlap. (FTS
+        # no longer participates; literal matches surface via BEST MATCH.)
         tag_fallback_used = False
-        if not fts_hits and not knn_hits:
-            if (
-                cfg.tags.enabled
-                and parsed.has_tag_constraints
-                and parsed.genres
-            ):
-                tag_track_ids = await self.db.get_similar_tracks_by_tags(
-                    parsed.genres, cfg.fts_candidate_limit
-                )
-                logger.info(
-                    "_do_search: tag fallback returned %d tracks", len(tag_track_ids)
-                )
-                fts_hits = [{"track_id": tid, "rank": -1.0} for tid in tag_track_ids]
-                tag_fallback_used = bool(tag_track_ids)
+        has_knn = bool(knn_hits)
+        if (
+            not has_knn
+            and cfg.tags.enabled
+            and parsed.has_tag_constraints
+            and parsed.genres
+        ):
+            tag_track_ids = await self.db.get_similar_tracks_by_tags(
+                parsed.genres, cfg.fts_candidate_limit
+            )
+            logger.info(
+                "_do_search: tag fallback returned %d tracks", len(tag_track_ids)
+            )
+            knn_hits = [{"track_id": tid, "distance": 0.0} for tid in tag_track_ids]
+            tag_fallback_used = bool(tag_track_ids)
 
-        if not fts_hits and not knn_hits:
-            logger.info("_do_search: no hits — returning empty")
+        if not knn_hits:
+            # No semantic results; BEST MATCH may still be non-empty.
+            logger.info("_do_search: no semantic hits")
             self._log_tag_contribution_summary(
                 "_do_search", parsed, [], {}, tag_fallback_used=False
             )
-            return empty
+            return {"tracks": [], "albums": [], "artists": [], "best_match": best_match}
 
-        # --- Merge candidate sets ---
-        # Build FTS score map (normalised 0-1, higher is better)
-        fts_map: dict[str, float] = {}
-        if fts_hits:
-            ranks = [h["rank"] for h in fts_hits]
-            min_rank = min(ranks)
-            max_rank = max(ranks)
-            rank_range = max_rank - min_rank if max_rank != min_rank else 1.0
-            for h in fts_hits:
-                fts_map[h["track_id"]] = 1.0 - (h["rank"] - min_rank) / rank_range
-
-        # Build KNN score map (normalised 0-1, higher is better)
+        # KNN score map (normalised 0-1, higher is better). Skipped on the
+        # tag-fallback path, where distances are synthetic and uniform.
         knn_map: dict[str, float] = {}
-        if knn_hits:
+        if has_knn:
             dists = [h["distance"] for h in knn_hits]
             min_dist = min(dists)
             max_dist = max(dists)
@@ -703,12 +708,7 @@ class SearchWorker:
             for h in knn_hits:
                 knn_map[h["track_id"]] = 1.0 - (h["distance"] - min_dist) / dist_range
 
-        # Union of all candidate track IDs
-        all_track_ids = list(
-            dict.fromkeys(
-                [h["track_id"] for h in fts_hits] + [h["track_id"] for h in knn_hits]
-            )
-        )
+        all_track_ids = list(dict.fromkeys(h["track_id"] for h in knn_hits))
 
         tags_map = await self.db.get_tracks_tags_bulk(all_track_ids)
         self._track_meta_cache = await self.db.get_tracks_album_artist_bulk(
@@ -717,27 +717,19 @@ class SearchWorker:
 
         scored: list[tuple[float, str]] = []
         for tid in all_track_ids:
-            fts_norm = fts_map.get(tid, 0.0)
             knn_norm = knn_map.get(tid, 0.0)
             track_tags = tags_map.get(tid)
             score = self._score_track(
                 parsed,
-                fts_norm,
+                0.0,
                 knn_norm,
                 track_tags,
-                has_fts_hits=bool(fts_hits),
-                has_knn_hits=bool(knn_hits),
+                has_fts_hits=False,
+                has_knn_hits=has_knn,
             )
             scored.append((score, tid))
 
-        # Exact lexical matches (query == a track's title / artist /
-        # album) float to the top, ordered among themselves by the
-        # blended score. Without this, the CLAP leg's weight (which
-        # exceeds the FTS weight) lets an unrelated audio neighbour
-        # outrank a track that literally is by the artist you searched
-        # for — e.g. "vangelis" surfacing Michael Jackson above Vangelis.
-        exact_ids = {h["track_id"] for h in fts_hits if h.get("exact")}
-        scored.sort(key=lambda st: (st[1] not in exact_ids, -st[0]))
+        scored.sort(key=lambda st: -st[0])
         top_tracks = scored[:limit]
         track_result = [tid for _, tid in top_tracks]
 
@@ -755,18 +747,46 @@ class SearchWorker:
             "tracks": track_result,
             "albums": album_ids,
             "artists": artist_ids,
+            "best_match": best_match,
         }
 
-    async def _fts_leg(self, parsed: ParsedQuery, candidate_limit: int) -> list[dict]:
-        """FTS5 search leg — returns [{track_id, rank}]."""
+    async def _best_match_leg(self, parsed: ParsedQuery) -> list[dict]:
+        """BEST MATCH leg — literal/navigational FTS over entity names.
+
+        Builds artist/album/track candidates from FTS recall and runs the
+        pure ``assemble_best_match`` algorithm (score, cut off, truncate,
+        collapse album/artist redundancies). Returns an ordered list of
+        ``{"id", "type"}`` dicts, highest rapidfuzz score first.
+
+        Scored against the raw query, not the genre/mood-stripped text
+        query: BEST MATCH answers "take me to the thing I named", which is
+        a property of the whole typed string.
+        """
         if not parsed.text_query:
             return []
-        return await self.db.fts_search(
-            parsed.text_query,
-            parsed.raw,
-            candidate_limit,
-            min_score=self.config.searcher.fts_min_fuzz_score,
+        cfg = self.config.searcher
+        rows = await self.db.search_entity_candidates(
+            parsed.text_query, cfg.fts_candidate_limit
         )
+        if not rows:
+            return []
+        candidates = [
+            Entity(
+                id=r["id"],
+                type=r["type"],
+                name=r["name"],
+                album_id=r.get("album_id"),
+                artist_id=r.get("artist_id"),
+            )
+            for r in rows
+        ]
+        best = assemble_best_match(
+            candidates,
+            parsed.raw,
+            cutoff=cfg.best_match_min_fuzz_score,
+            max_results=cfg.best_match_max_results,
+        )
+        return [{"id": e.id, "type": e.type} for e in best]
 
     async def _knn_leg(self, query: str, candidate_limit: int) -> list[dict]:
         """CLAP KNN search leg — returns [{track_id, distance}].
@@ -810,8 +830,11 @@ class SearchWorker:
         When tags are off the function returns empty rather than
         falling through to a CLAP-only similar path — keeping the
         toggle as a single switch for the whole tag pipeline.
+
+        "Songs like this" has no text query, so there is no BEST MATCH
+        block — the result always carries an empty ``best_match``.
         """
-        empty: dict = {"tracks": [], "albums": [], "artists": []}
+        empty: dict = {"tracks": [], "albums": [], "artists": [], "best_match": []}
 
         if not self.config.searcher.tags.enabled:
             logger.info(
@@ -931,6 +954,7 @@ class SearchWorker:
             "tracks": track_result,
             "albums": album_ids,
             "artists": artist_ids,
+            "best_match": [],
         }
 
     # ------------------------------------------------------------------
@@ -960,8 +984,10 @@ class SearchWorker:
                 t0 = time.monotonic()
                 result = await self._do_search(req["query"], req.get("limit", 20))
                 logger.info(
-                    "Search '%s': %d tracks, %d albums, %d artists in %.3fs",
+                    "Search '%s': %d best-match, %d tracks, %d albums, "
+                    "%d artists in %.3fs",
                     req["query"],
+                    len(result.get("best_match", [])),
                     len(result.get("tracks", [])),
                     len(result.get("albums", [])),
                     len(result.get("artists", [])),
@@ -969,7 +995,7 @@ class SearchWorker:
                 )
             except Exception as e:
                 logger.error("Search handler error: %s", e, exc_info=True)
-                result = {"tracks": [], "albums": [], "artists": []}
+                result = {"tracks": [], "albums": [], "artists": [], "best_match": []}
 
             search_response_queue.put(result)
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
@@ -495,6 +495,101 @@ class AsyncSearcherDb:
         )
         return scored[:limit]
 
+    async def search_entity_candidates(
+        self, text_query: str, limit: int = 100
+    ) -> list[dict]:
+        """Gather artist / album / track candidates for the BEST MATCH block.
+
+        FTS5 OR-recall over the track index, expanded into typed entities:
+        each matched track row yields a track candidate plus (de-duplicated)
+        its album and artist. This is *broad recall only* — rapidfuzz scoring,
+        the cutoff, and album/artist redundancy removal all happen in
+        :func:`assemble_best_match`, so no score is computed here.
+
+        Returns entity dicts ``{id, type, name, album_id, artist_id}`` where
+        ``type`` is one of ``"track" | "album" | "artist"``.
+        """
+        if not text_query.strip():
+            return []
+
+        fts_query = _build_fts_query(text_query, join="OR")
+        if not fts_query:
+            return []
+
+        async with self._open() as conn:
+            conn.row_factory = aiosqlite.Row
+            try:
+                cursor = await conn.execute(
+                    """
+                    SELECT t.id AS track_id, t.title AS track_title,
+                           t.album_id, t.artist_id,
+                           al.title AS album_title, ar.name AS artist_name
+                    FROM fts_tracks f
+                    JOIN tracks t ON t.id = f.track_id
+                    LEFT JOIN albums  al ON t.album_id  = al.id
+                    LEFT JOIN artists ar ON t.artist_id = ar.id
+                    WHERE fts_tracks MATCH ?
+                    LIMIT ?
+                    """,
+                    (fts_query, limit),
+                )
+                rows = await cursor.fetchall()
+            except Exception as e:
+                logger.warning(
+                    "best-match candidate fetch failed for %r: %s", fts_query, e
+                )
+                return []
+
+        candidates: list[dict] = []
+        seen_albums: set[str] = set()
+        seen_artists: set[str] = set()
+        for row in rows:
+            # One track candidate per matched row (track_ids are unique).
+            if row["track_title"]:
+                candidates.append(
+                    {
+                        "id": row["track_id"],
+                        "type": "track",
+                        "name": row["track_title"],
+                        "album_id": row["album_id"],
+                        "artist_id": row["artist_id"],
+                    }
+                )
+            aid = row["album_id"]
+            if aid and aid not in seen_albums and row["album_title"]:
+                seen_albums.add(aid)
+                candidates.append(
+                    {
+                        "id": aid,
+                        "type": "album",
+                        "name": row["album_title"],
+                        "album_id": None,
+                        "artist_id": row["artist_id"],
+                    }
+                )
+            arid = row["artist_id"]
+            if arid and arid not in seen_artists and row["artist_name"]:
+                seen_artists.add(arid)
+                candidates.append(
+                    {
+                        "id": arid,
+                        "type": "artist",
+                        "name": row["artist_name"],
+                        "album_id": None,
+                        "artist_id": None,
+                    }
+                )
+
+        logger.info(
+            "search_entity_candidates: %d rows -> %d candidates "
+            "(%d albums, %d artists)",
+            len(rows),
+            len(candidates),
+            len(seen_albums),
+            len(seen_artists),
+        )
+        return candidates
+
     # ------------------------------------------------------------------
     # Tag lookups (for re-ranking and "songs like this")
     # ------------------------------------------------------------------

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/searcher/searcher_db.py
@@ -17,10 +17,8 @@ from contextlib import asynccontextmanager
 from typing import Optional
 
 import aiosqlite
-from rapidfuzz import fuzz
 
 from ..config_model import LocalFilesConfig
-from ..utils.name_utils import fold_diacritics
 from ..worker_utils import retry_db_locked
 
 logger = logging.getLogger(__name__.split(".")[-1])
@@ -395,105 +393,6 @@ class AsyncSearcherDb:
     # ------------------------------------------------------------------
     # FTS5 search
     # ------------------------------------------------------------------
-
-    async def fts_search(
-        self,
-        text_query: str,
-        raw_query: str,
-        limit: int = 100,
-        min_score: int = 72,
-        overfetch: int = 5,
-    ) -> list[dict]:
-        """
-        Full-text search on the FTS5 table, with rapidfuzz re-ranking.
-
-        Returns [{"track_id": str, "rank": float, "exact": bool}] sorted
-        by relevance, ``rank`` negated so lower is better (matches the
-        convention of the rest of the pipeline). ``exact`` is True when
-        the query equals one of the track's fields (title / artist /
-        album) case-insensitively — the caller floats those above pure
-        semantic neighbours so an exact artist/album hit always wins.
-
-        FTS5 is used purely as a fast candidate fetcher (OR-mode, broad
-        recall). Each candidate is then scored with
-        ``rapidfuzz.fuzz.WRatio`` against ``title``, ``artist_name``,
-        and ``album_title`` *separately* — the best per-field score
-        wins — and dropped if it falls below ``min_score`` (0–100).
-        Per-field rather than concatenated because WRatio is
-        length-sensitive: a short query ("yesterday") against a long
-        concatenated haystack scores lower than against the title
-        alone. This kills single-token coincidental hits ("tonight"
-        matching "Make Tonight All Mine" for the query "something
-        melancholic for tonight") and is naturally typo-tolerant on
-        the metadata side.
-        """
-        if not text_query.strip():
-            return []
-
-        fts_query = _build_fts_query(text_query, join="OR")
-        logger.info("fts_search: raw=%r built=%r", text_query, fts_query)
-        if not fts_query:
-            logger.info("fts_search: query built to empty string — no results")
-            return []
-
-        candidate_limit = limit * overfetch
-        async with self._open() as conn:
-            conn.row_factory = aiosqlite.Row
-            try:
-                cursor = await conn.execute(
-                    """
-                    SELECT track_id, title, artist_name, album_title
-                    FROM fts_tracks
-                    WHERE fts_tracks MATCH ?
-                    LIMIT ?
-                    """,
-                    (fts_query, candidate_limit),
-                )
-                rows = await cursor.fetchall()
-            except Exception as e:
-                logger.warning("FTS search failed for query %r: %s", fts_query, e)
-                return []
-
-        fuzz_target = raw_query.strip() or text_query
-        # Diacritic-fold both sides so an ASCII query ("noi kabat") isn't
-        # dropped by the re-rank against accented metadata ("Női Kabát").
-        folded_target = fold_diacritics(fuzz_target)
-        norm_target = folded_target.casefold().strip()
-        scored: list[dict] = []
-        for row in rows:
-            # Score against each field separately and keep the best. A
-            # single concatenated haystack penalises short queries
-            # because WRatio is length-sensitive: e.g. "yesterday" vs
-            # the full "Yesterday | Beatles | Help!" string drags lower
-            # than "yesterday" vs the title field on its own.
-            best = 0
-            exact = False
-            for field in (row["title"], row["artist_name"], row["album_title"]):
-                if not field:
-                    continue
-                folded_field = fold_diacritics(field)
-                s = fuzz.WRatio(folded_target, folded_field)
-                if s > best:
-                    best = s
-                if folded_field.casefold().strip() == norm_target:
-                    exact = True
-            if best >= min_score:
-                scored.append(
-                    {
-                        "track_id": row["track_id"],
-                        "rank": -float(best),
-                        "exact": exact,
-                    }
-                )
-
-        scored.sort(key=lambda r: r["rank"])
-        logger.info(
-            "fts_search: %d candidates, %d kept after WRatio>=%d",
-            len(rows),
-            len(scored),
-            min_score,
-        )
-        return scored[:limit]
 
     async def search_entity_candidates(
         self, text_query: str, limit: int = 100

--- a/packages/kalinka-plugin-localfiles/tests/test_best_match.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_best_match.py
@@ -1,0 +1,161 @@
+"""Tests for the FTS "BEST MATCH" assembly (searcher.best_match)."""
+
+import pytest
+
+from kalinka_plugin_localfiles.searcher import best_match
+from kalinka_plugin_localfiles.searcher.best_match import (
+    Entity,
+    assemble_best_match,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fixed_scorer(scores):
+    """A SCORER stub that returns predetermined scores in candidate order.
+
+    assemble_best_match calls SCORER once per candidate, iterating the input
+    list in order, so a positional iterator gives each candidate an exact,
+    controlled score regardless of its name.
+    """
+    it = iter(scores)
+
+    def scorer(query, name):
+        return next(it)
+
+    return scorer
+
+
+def _ids(entities):
+    return [(e.id, e.type, e.score) for e in entities]
+
+
+# ---------------------------------------------------------------------------
+# Worked example (query: "piano")
+# ---------------------------------------------------------------------------
+
+
+class TestWorkedExample:
+    def test_collapses_to_track_and_artist(self, monkeypatch):
+        # Order here defines the score alignment for the stub scorer.
+        candidates = [
+            Entity(id="t-sonata", type="track", name="Piano Sonata",
+                   album_id="X", artist_id="Y"),
+            Entity(id="PG-artist", type="artist", name="The Piano Guys"),
+            Entity(id="PG-album", type="album", name="The Piano Guys",
+                   artist_id="PG-artist"),
+            Entity(id="t-thousand", type="track", name="A Thousand Years",
+                   album_id="PG-album", artist_id="PG-artist"),
+        ]
+        monkeypatch.setattr(best_match, "SCORER", _fixed_scorer([95, 90, 88, 70]))
+
+        result = assemble_best_match(candidates, "piano")
+
+        assert _ids(result) == [
+            ("t-sonata", "track", 95),
+            ("PG-artist", "artist", 90),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_when_nothing_clears_cutoff(self, monkeypatch):
+        candidates = [
+            Entity(id="a", type="track", name="foo"),
+            Entity(id="b", type="album", name="bar"),
+        ]
+        # Both below RAPIDFUZZ_CUTOFF (70).
+        monkeypatch.setattr(best_match, "SCORER", _fixed_scorer([69, 10]))
+
+        assert assemble_best_match(candidates, "q") == []
+
+    def test_fewer_than_six_no_backfill(self, monkeypatch):
+        # Seven candidates clear the cutoff; truncation to MAX_RESULTS happens
+        # BEFORE redundancy removal, so the dropped redundant entities are not
+        # backfilled from the cut-off tail.
+        candidates = [
+            Entity(id="ar", type="artist", name="Band"),               # 99
+            Entity(id="al", type="album", name="Band Album",
+                   artist_id="ar"),                                     # 98 -> dominated by artist
+            Entity(id="t1", type="track", name="Song 1",
+                   album_id="al", artist_id="ar"),                      # 97 -> dominated
+            Entity(id="t2", type="track", name="Song 2",
+                   album_id="al", artist_id="ar"),                      # 96 -> dominated
+            Entity(id="t3", type="track", name="Song 3",
+                   album_id="al", artist_id="ar"),                      # 95 -> dominated
+            Entity(id="t4", type="track", name="Song 4",
+                   album_id="al", artist_id="ar"),                      # 94 -> dominated (6th, in list)
+            Entity(id="lonely", type="track", name="Song 5",
+                   album_id="other", artist_id="other"),               # 80 -> cut off (7th, truncated)
+        ]
+        monkeypatch.setattr(
+            best_match, "SCORER", _fixed_scorer([99, 98, 97, 96, 95, 94, 80])
+        )
+
+        result = assemble_best_match(candidates, "q")
+
+        # Only the artist survives; the truncated "lonely" track is NOT pulled
+        # in to fill the gap.
+        assert _ids(result) == [("ar", "artist", 99)]
+
+    def test_tie_keeps_both(self, monkeypatch):
+        # Album and its track have equal scores; strictly-greater comparison
+        # means the track is not removed.
+        candidates = [
+            Entity(id="al", type="album", name="Same", artist_id="ar"),
+            Entity(id="t", type="track", name="Same", album_id="al",
+                   artist_id="ar"),
+        ]
+        monkeypatch.setattr(best_match, "SCORER", _fixed_scorer([88, 88]))
+
+        result = assemble_best_match(candidates, "q")
+
+        assert {e.id for e in result} == {"al", "t"}
+
+    def test_track_with_absent_relations_not_removed(self, monkeypatch):
+        # A high-scoring album/artist is present but unrelated to the track,
+        # and the track's own album/artist are not in the list.
+        candidates = [
+            Entity(id="ar", type="artist", name="Unrelated"),
+            Entity(id="t", type="track", name="Orphan",
+                   album_id="missing-al", artist_id="missing-ar"),
+            Entity(id="t-no-rel", type="track", name="No Relations",
+                   album_id=None, artist_id=None),
+        ]
+        monkeypatch.setattr(best_match, "SCORER", _fixed_scorer([95, 80, 75]))
+
+        result = assemble_best_match(candidates, "q")
+
+        # All three survive: the artist dominates nothing it isn't related to.
+        assert {e.id for e in result} == {"ar", "t", "t-no-rel"}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with the real scorer
+# ---------------------------------------------------------------------------
+
+
+class TestRealScorer:
+    def test_ranks_and_cuts_with_wratio(self):
+        candidates = [
+            Entity(id="ar1", type="artist", name="Miles Davis"),
+            Entity(id="al1", type="album", name="Kind of Blue", artist_id="ar1"),
+            Entity(id="t1", type="track", name="So What", album_id="al1",
+                   artist_id="ar1"),
+        ]
+
+        result = assemble_best_match(candidates, "miles davis")
+
+        # The artist match is the clear winner; unrelated track "So What"
+        # should fall below the cutoff and be dropped.
+        assert result, "expected a non-empty best-match block"
+        assert result[0].id == "ar1"
+        assert all(e.score >= best_match.RAPIDFUZZ_CUTOFF for e in result)
+        assert "t1" not in {e.id for e in result}

--- a/packages/kalinka-plugin-localfiles/tests/test_best_match.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_best_match.py
@@ -159,3 +159,30 @@ class TestRealScorer:
         assert result[0].id == "ar1"
         assert all(e.score >= best_match.RAPIDFUZZ_CUTOFF for e in result)
         assert "t1" not in {e.id for e in result}
+
+    def test_ascii_query_matches_accented_name(self):
+        # Diacritic folding: an ASCII query finds an accented artist name.
+        candidates = [
+            Entity(id="ar1", type="artist", name="Női Kabát"),
+            Entity(id="ar2", type="artist", name="The Beatles"),
+        ]
+
+        result = assemble_best_match(candidates, "noi kabat")
+
+        assert [e.id for e in result] == ["ar1"]
+
+    def test_custom_cutoff_and_max_results(self):
+        candidates = [
+            Entity(id="a", type="artist", name="Exact Name"),
+            Entity(id="b", type="album", name="Exact Name Deluxe", artist_id="a"),
+            Entity(id="c", type="track", name="Totally Different", album_id="b",
+                   artist_id="a"),
+        ]
+
+        # A near-impossible cutoff keeps only the exact-ish hit; max_results=1
+        # truncates before redundancy removal.
+        result = assemble_best_match(
+            candidates, "Exact Name", cutoff=99, max_results=1
+        )
+
+        assert [e.id for e in result] == ["a"]

--- a/packages/kalinka-plugin-localfiles/tests/test_best_match.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_best_match.py
@@ -171,6 +171,22 @@ class TestRealScorer:
 
         assert [e.id for e in result] == ["ar1"]
 
+    def test_drops_coincidental_single_token_hit(self):
+        # An NL query that incidentally shares one common word ("tonight")
+        # with a title must not clear the cutoff. (Ported from the old FTS
+        # re-rank suite — the behaviour now lives in WRatio + the cutoff.)
+        candidates = [
+            Entity(id="t", type="track", name="Make Tonight All Mine"),
+        ]
+        result = assemble_best_match(candidates, "something melancholic for tonight")
+        assert result == []
+
+    def test_keeps_typo_match(self):
+        # A single-character typo still clears the cutoff via WRatio.
+        candidates = [Entity(id="t", type="track", name="Bohemian Rhapsody")]
+        result = assemble_best_match(candidates, "bohemain rhapsody")
+        assert [e.id for e in result] == ["t"]
+
     def test_custom_cutoff_and_max_results(self):
         candidates = [
             Entity(id="a", type="artist", name="Exact Name"),

--- a/packages/kalinka-plugin-localfiles/tests/test_best_match_section.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_best_match_section.py
@@ -1,0 +1,90 @@
+"""Tests for the BEST MATCH section rendering in LocalFilesInputModule.
+
+The searcher returns ``best_match`` as an ordered list of ``{"id", "type"}``
+dicts (rapidfuzz score, highest first). ``_build_best_match_section`` must
+render them as a single flat list in that exact order — no grouping or
+sub-sorting by entity type.
+"""
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.localfiles import LocalFilesInputModule
+
+
+class _FakeDb:
+    """Returns rows by id, preserving the requested order (like the real db)."""
+
+    def __init__(self):
+        self._tracks = {
+            "t1": {
+                "id": "t1", "album_id": "al1", "artist_id": "ar1",
+                "album_title": "Album One", "artist_name": "The Piano Guys",
+                "title": "A Thousand Years", "duration": 100,
+            },
+        }
+        self._albums = {
+            "al1": {
+                "id": "al1", "title": "Album One", "artist_id": "ar1",
+                "artist_name": "The Piano Guys", "duration": 100, "track_count": 10,
+            },
+        }
+        self._artists = {"ar1": {"id": "ar1", "name": "The Piano Guys"}}
+
+    def get_tracks_by_ids(self, ids):
+        return [self._tracks[i] for i in ids if i in self._tracks]
+
+    def get_albums_by_ids(self, ids):
+        return [self._albums[i] for i in ids if i in self._albums]
+
+    def get_artists_by_ids(self, ids):
+        return [self._artists[i] for i in ids if i in self._artists]
+
+    # Cover-art lookups: no artwork on disk in these tests.
+    def get_album_by_id(self, album_id):
+        return None
+
+    def get_artist_by_id(self, artist_id):
+        return None
+
+
+def _module(tmp_path):
+    config = LocalFilesConfig(
+        music_folders=[str(tmp_path)],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+    )
+    return LocalFilesInputModule(config, _FakeDb())
+
+
+def test_flat_list_preserves_score_order_across_types(tmp_path):
+    module = _module(tmp_path)
+
+    # Deliberately interleaved types — artist, then track, then album.
+    section = module._build_best_match_section([
+        {"id": "ar1", "type": "artist"},
+        {"id": "t1", "type": "track"},
+        {"id": "al1", "type": "album"},
+    ])
+
+    assert section is not None
+    assert section.name == "BEST MATCH"
+    assert section.catalog.title == "BEST MATCH"
+
+    rows = section.sections
+    assert len(rows) == 3
+    # Order matches the input exactly — no regrouping by type.
+    assert rows[0].artist is not None and rows[0].artist.name == "The Piano Guys"
+    assert rows[1].track is not None and rows[1].name == "A Thousand Years"
+    assert rows[2].album is not None and rows[2].album.title == "Album One"
+
+
+def test_empty_returns_none(tmp_path):
+    module = _module(tmp_path)
+    assert module._build_best_match_section([]) is None
+
+
+def test_missing_rows_drop_out_and_collapse_to_none(tmp_path):
+    module = _module(tmp_path)
+    # An id the db can't resolve is skipped; if nothing resolves -> None.
+    assert module._build_best_match_section(
+        [{"id": "ghost", "type": "track"}]
+    ) is None

--- a/packages/kalinka-plugin-localfiles/tests/test_best_match_section.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_best_match_section.py
@@ -8,6 +8,7 @@ sub-sorting by entity type.
 
 from kalinka_plugin_localfiles.config_model import LocalFilesConfig
 from kalinka_plugin_localfiles.localfiles import LocalFilesInputModule
+from kalinka_plugin_sdk.datamodel import PreviewType
 
 
 class _FakeDb:
@@ -68,6 +69,10 @@ def test_flat_list_preserves_score_order_across_types(tmp_path):
     assert section is not None
     assert section.name == "BEST MATCH"
     assert section.catalog.title == "BEST MATCH"
+    # Backend-owned presentation: plain TILE section, star icon, subtitle.
+    assert section.subname == "Top results for your search"
+    assert section.catalog.preview_config.type == PreviewType.TILE
+    assert section.catalog.preview_config.icon == "best_match"
 
     rows = section.sections
     assert len(rows) == 3

--- a/packages/kalinka-plugin-localfiles/tests/test_search_improvements.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_search_improvements.py
@@ -367,17 +367,17 @@ class TestBestMatchCandidates:
 
 
 # ---------------------------------------------------------------------------
-# Tests: exact lexical matches float above pure CLAP neighbours
+# Tests: BEST MATCH is separate from the semantic (CLAP) sections
 # ---------------------------------------------------------------------------
 
 
-class TestExactMatchFloating:
+class TestBestMatchSeparation:
     @pytest.mark.asyncio
-    async def test_exact_artist_track_outranks_clap_neighbour(self):
-        """Reproduces the 'vangelis' bug: a track whose artist exactly
-        matches the query must rank above an unrelated track that the
-        CLAP leg considers a close audio neighbour, even though the
-        higher KNN weight would otherwise win the blend."""
+    async def test_exact_match_goes_to_best_match_not_ai_tracks(self):
+        """The 'vangelis' case: the exact artist match surfaces in the
+        BEST MATCH block (literal/navigational), while the AI ``tracks``
+        section is purely semantic — the CLAP neighbour "Ben". FTS is no
+        longer blended into the semantic ranking, so the two never mix."""
         db_path = os.path.join(tempfile.mkdtemp(), "test.db")
         config = _make_config(db_path=db_path)
         await init_db(db_path)
@@ -413,14 +413,17 @@ class TestExactMatchFloating:
         db = AsyncSearcherDb(config)
         worker = SearchWorker(config, db)
 
-        # Force the CLAP leg to return "Ben" as the nearest neighbour —
-        # the exact situation that put Michael Jackson above Vangelis.
+        # Force the CLAP leg to return "Ben" as the nearest neighbour.
         async def fake_knn(query, candidate_limit):
             return [{"track_id": "tMJ", "distance": 0.0}]
 
         worker._knn_leg = fake_knn
 
         result = await worker._do_search("vangelis", limit=10)
-        # The exact artist match comes first despite the heavier KNN weight.
-        assert result["tracks"][0] == "tV"
-        assert "tMJ" in result["tracks"]
+
+        # BEST MATCH leads with the exact artist hit; the album collapses
+        # into it (artist dominates) and the unrelated track is cut off.
+        assert result["best_match"][0] == {"id": "arV", "type": "artist"}
+        # The semantic section is CLAP-only — no FTS bleed-through.
+        assert result["tracks"] == ["tMJ"]
+        assert "tV" not in result["tracks"]

--- a/packages/kalinka-plugin-localfiles/tests/test_search_improvements.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_search_improvements.py
@@ -304,6 +304,69 @@ class TestFtsFuzzyRerank:
 
 
 # ---------------------------------------------------------------------------
+# Tests: BEST MATCH entity-candidate recall
+# ---------------------------------------------------------------------------
+
+
+class TestBestMatchCandidates:
+    @pytest.mark.asyncio
+    async def test_expands_tracks_into_typed_entities(self):
+        """FTS recall yields a track candidate per row plus the de-duplicated
+        album and artist, each carrying its own name and relationships."""
+        db_path = os.path.join(tempfile.mkdtemp(), "test.db")
+        config = _make_config(db_path=db_path)
+        await init_db(db_path)
+
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "INSERT INTO artists (id, name) VALUES ('arP', 'The Piano Guys')"
+            )
+            await conn.execute(
+                "INSERT INTO albums (id, title, artist_id) VALUES "
+                "('alP', 'The Piano Guys', 'arP')"
+            )
+            await conn.execute(
+                "INSERT INTO tracks (id, title, file_path, format, enriched, "
+                "album_id, artist_id) VALUES "
+                "('t1', 'A Thousand Years', 'f1', 'mp3', 1, 'alP', 'arP'), "
+                "('t2', 'Beethoven Symphony', 'f2', 'mp3', 1, 'alP', 'arP')"
+            )
+            await conn.commit()
+
+        await _insert_fts_rows(db_path, [
+            ("t1", "A Thousand Years", "The Piano Guys", "The Piano Guys"),
+            ("t2", "Beethoven Symphony", "The Piano Guys", "The Piano Guys"),
+        ])
+
+        db = AsyncSearcherDb(config)
+        candidates = await db.search_entity_candidates("piano", limit=50)
+
+        by_type: dict[str, list[dict]] = {"track": [], "album": [], "artist": []}
+        for c in candidates:
+            by_type[c["type"]].append(c)
+
+        # Two tracks, one deduped album, one deduped artist.
+        assert {c["id"] for c in by_type["track"]} == {"t1", "t2"}
+        assert [c["id"] for c in by_type["album"]] == ["alP"]
+        assert [c["id"] for c in by_type["artist"]] == ["arP"]
+
+        # Relationships carried for the redundancy rules; no scoring done here.
+        track = next(c for c in by_type["track"] if c["id"] == "t1")
+        assert track["album_id"] == "alP" and track["artist_id"] == "arP"
+        assert by_type["album"][0]["artist_id"] == "arP"
+        assert all("score" not in c for c in candidates)
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_empty(self):
+        db_path = os.path.join(tempfile.mkdtemp(), "test.db")
+        config = _make_config(db_path=db_path)
+        await init_db(db_path)
+        db = AsyncSearcherDb(config)
+        assert await db.search_entity_candidates("nonexistent", limit=50) == []
+        assert await db.search_entity_candidates("", limit=50) == []
+
+
+# ---------------------------------------------------------------------------
 # Tests: exact lexical matches float above pure CLAP neighbours
 # ---------------------------------------------------------------------------
 

--- a/packages/kalinka-plugin-localfiles/tests/test_search_improvements.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_search_improvements.py
@@ -124,33 +124,20 @@ class TestDynamicWeightNormalization:
         db._vec_available = False
         return SearchWorker(config, db)
 
-    def test_fts_only_uses_full_range(self):
-        """With only FTS hits, score should be in 0-1 range."""
+    def test_knn_only_uses_full_range(self):
+        """With only KNN hits and no tags, a perfect neighbour scores 1.0 —
+        the single active weight normalises to the full 0-1 range."""
         worker = self._make_worker()
         parsed = parse_query("beatles")  # no tag constraints
 
-        # Perfect FTS match, no KNN
         score = worker._score_track(
-            parsed, fts_rank_norm=1.0, knn_norm=0.0, track_tags=None,
-            has_fts_hits=True, has_knn_hits=False,
+            parsed, knn_norm=1.0, track_tags=None, has_knn_hits=True,
         )
-        # Should be 1.0 (not 0.35 which was the old broken behavior)
         assert score == pytest.approx(1.0, abs=0.01)
 
-    def test_both_legs_active(self):
-        """With both FTS and KNN active, weights are split normally."""
-        worker = self._make_worker()
-        parsed = parse_query("beatles")
-
-        score = worker._score_track(
-            parsed, fts_rank_norm=1.0, knn_norm=1.0, track_tags=None,
-            has_fts_hits=True, has_knn_hits=True,
-        )
-        # Both active, no tags: (0.35*1 + 0.30*1) / (0.35+0.30) = 1.0
-        assert score == pytest.approx(1.0, abs=0.01)
-
-    def test_with_tag_constraints(self):
-        """Tag components contribute when present."""
+    def test_knn_and_tags_normalise_together(self):
+        """Tag components blend with KNN; both perfect -> 1.0 after the
+        dynamic weight normalisation."""
         worker = self._make_worker()
         parsed = parse_query("jazz piano")  # has genre constraint
 
@@ -159,26 +146,24 @@ class TestDynamicWeightNormalization:
         }
 
         score = worker._score_track(
-            parsed, fts_rank_norm=1.0, knn_norm=0.0, track_tags=track_tags,
-            has_fts_hits=True, has_knn_hits=False,
+            parsed, knn_norm=1.0, track_tags=track_tags, has_knn_hits=True,
         )
-        # FTS=1.0 + genre match for "jazz" in "jazz---cool jazz" = 1.0
-        assert score > 0.5
+        # (weight_knn*1 + weight_genre*1) / (weight_knn + weight_genre) = 1.0
+        assert score == pytest.approx(1.0, abs=0.01)
 
-    def test_no_active_legs_returns_zero(self):
-        """Edge case: no search legs active."""
+    def test_no_active_inputs_returns_zero(self):
+        """Edge case: no KNN hits and no tag constraints."""
         worker = self._make_worker()
         parsed = parse_query("something")
 
         score = worker._score_track(
-            parsed, fts_rank_norm=0.0, knn_norm=0.0, track_tags=None,
-            has_fts_hits=False, has_knn_hits=False,
+            parsed, knn_norm=0.0, track_tags=None, has_knn_hits=False,
         )
         assert score == 0.0
 
 
 # ---------------------------------------------------------------------------
-# Tests: FTS + rapidfuzz re-ranking
+# Helper: seed the FTS index directly (shared by the best-match tests)
 # ---------------------------------------------------------------------------
 
 
@@ -192,115 +177,6 @@ async def _insert_fts_rows(db_path: str, rows: list[tuple[str, str, str, str]]) 
                 (tid, title, artist, album, ""),
             )
         await conn.commit()
-
-
-class TestFtsFuzzyRerank:
-    @pytest.mark.asyncio
-    async def test_returns_match(self):
-        """Exact-title query finds the matching track."""
-        db_path = os.path.join(tempfile.mkdtemp(), "test.db")
-        db = await _setup_db(db_path)
-
-        await _insert_fts_rows(db_path, [
-            ("t0", "Yesterday", "Beatles", "Help!"),
-            ("t1", "Tomorrow Never Knows", "Beatles", "Revolver"),
-        ])
-
-        results = await db.fts_search("yesterday", "yesterday", limit=10)
-        assert [r["track_id"] for r in results] == ["t0"]
-
-    @pytest.mark.asyncio
-    async def test_drops_coincidental_single_token_hit(self):
-        """The original AI-search bug: an NL query that incidentally shares
-        one common word ("tonight") with a track title must NOT make the
-        track pass the fuzzy filter."""
-        db_path = os.path.join(tempfile.mkdtemp(), "test.db")
-        db = await _setup_db(db_path)
-
-        await _insert_fts_rows(db_path, [
-            ("t0", "Make Tonight All Mine", "Michael Jackson",
-             "The Best Of Michael Jackson (Disk 2)"),
-            ("t1", "Yesterday", "Beatles", "Help!"),
-        ])
-
-        # "tonight" appears in both query and title but the overall
-        # fuzzy similarity is well below the 72 threshold.
-        results = await db.fts_search(
-            "tonight", "something melancholic for tonight", limit=10,
-        )
-        assert results == []
-
-    @pytest.mark.asyncio
-    async def test_keeps_typo_match(self):
-        """Single-character typo in a title query still matches via rapidfuzz."""
-        db_path = os.path.join(tempfile.mkdtemp(), "test.db")
-        db = await _setup_db(db_path)
-
-        await _insert_fts_rows(db_path, [
-            ("t0", "Bohemian Rhapsody", "Queen", "A Night At The Opera"),
-        ])
-
-        # FTS5 OR-mode finds it on the correctly-spelled "rhapsody"
-        # token; rapidfuzz then approves the score despite "bohemain".
-        results = await db.fts_search(
-            "rhapsody", "bohemain rhapsody", limit=10,
-        )
-        assert [r["track_id"] for r in results] == ["t0"]
-
-    @pytest.mark.asyncio
-    async def test_min_score_threshold_respected(self):
-        """A high threshold drops borderline matches."""
-        db_path = os.path.join(tempfile.mkdtemp(), "test.db")
-        db = await _setup_db(db_path)
-
-        await _insert_fts_rows(db_path, [
-            ("t0", "Yesterday", "Beatles", "Help!"),
-        ])
-
-        # Threshold above any plausible score: even an exact hit drops.
-        results = await db.fts_search(
-            "yesterday", "yesterday", limit=10, min_score=99,
-        )
-        assert results == []
-
-    @pytest.mark.asyncio
-    async def test_exact_artist_match_is_flagged(self):
-        """A query equal to the artist name (case-insensitive) sets the
-        ``exact`` flag; a mere title/album substring match does not."""
-        db_path = os.path.join(tempfile.mkdtemp(), "test.db")
-        db = await _setup_db(db_path)
-
-        await _insert_fts_rows(db_path, [
-            ("t0", "Chariots of Fire", "Vangelis", "The Best of Vangelis CD II"),
-            ("t1", "Vangelis Tribute", "Some Cover Band", "Tributes"),
-        ])
-
-        results = await db.fts_search("vangelis", "vangelis", limit=10)
-        by_id = {r["track_id"]: r for r in results}
-        # Exact artist hit flagged regardless of letter case.
-        assert by_id["t0"]["exact"] is True
-        # Title merely *contains* the token — not an exact field match.
-        assert by_id["t1"]["exact"] is False
-
-    @pytest.mark.asyncio
-    async def test_ascii_query_matches_accented_artist(self):
-        """An ASCII-folded query ("noi kabat") finds an accented artist
-        ("Női Kabát"). Without diacritic folding in the rapidfuzz re-rank
-        the raw WRatio (~56) falls below the 72 threshold and the candidate
-        is dropped even though FTS matched it. See issue #61."""
-        db_path = os.path.join(tempfile.mkdtemp(), "test.db")
-        db = await _setup_db(db_path)
-
-        await _insert_fts_rows(db_path, [
-            ("t0", "Valami", "Női Kabát", "Best Of"),
-            ("t1", "Yesterday", "Beatles", "Help!"),
-        ])
-
-        results = await db.fts_search("noi kabat", "noi kabat", limit=10)
-        by_id = {r["track_id"]: r for r in results}
-        assert "t0" in by_id
-        # Diacritic-folded equality also sets the exact-artist flag.
-        assert by_id["t0"]["exact"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/datamodel.py
+++ b/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/datamodel.py
@@ -172,6 +172,10 @@ class PreviewType(str, Enum):
     TILE = "tile"
     # Numbered tile layout: order number, title, and subtitle on the right
     TILE_NUMBERED = "tile_numbered"
+    # Self-contained card wrapping a vertical list of items (e.g. the AI
+    # suggestions track list): the section renders its own bordered surface
+    # with a header. Plain (non-card) sections render header + rows inline.
+    CARD = "card"
     # No preview items (section displays only an image or text)
     NONE = "none"
 
@@ -379,6 +383,9 @@ class Preview(BaseModel):
         items_count (Optional[int]): Maximum number of items to show in preview
         type (PreviewType): Layout type for the preview section
         content_type (Optional[PreviewContentType]): Hint about content type for UI styling
+        icon (Optional[str]): Semantic icon id for the section header (e.g.
+            "best_match", "ai_suggestions", "album", "artist"). The UI maps
+            this to a concrete icon; presentation is owned by the backend.
         rows_count (Optional[int]): Number of rows to display
         aspect_ratio (Optional[float]): Preferred aspect ratio for items
         card_size (Optional[CardSize]): Size preference for cards/items
@@ -389,6 +396,7 @@ class Preview(BaseModel):
     items_count: Optional[int] = None
     type: PreviewType
     content_type: Optional[PreviewContentType] = None
+    icon: Optional[str] = None
     rows_count: Optional[int] = None
     aspect_ratio: Optional[float] = None
     card_size: Optional[CardSize] = None


### PR DESCRIPTION
Splits literal/navigational name matching into its own **BEST MATCH** section, separate from the CLAP semantic AI suggestions — so "take me to the thing I named" (artist / album / track) is answered by exact-ish name matching, while discovery stays with the embedding search.

## What's in it
- **`assemble_best_match`** FTS algorithm + tests: score candidates with rapidfuzz, cut off below a threshold, sort, truncate, and remove album/artist-dominated redundancies.
- **`search_entity_candidates`** for BEST MATCH recall (FTS over artist/album/track names).
- **FTS pulled out of the semantic blend** into a dedicated BEST MATCH leg, run in parallel with the CLAP KNN leg; the AI sections are now purely semantic.
- **Rendered above the AI suggestions** as its own section; presentation is backend-driven.
- **Expert config**: BEST MATCH fuzz cutoff + max results.
- Diacritic-insensitive matching; review cleanups; dead FTS-blend remnants removed.

## Stacking
The mood / descriptor-aware-suppression work builds directly on this; that PR (#85) targets this branch and should merge after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)