### PR TITLE
ai_search: context-aware query suggestions validated against the library

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/input_module_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/input_module_db.py
@@ -200,7 +200,7 @@ class LocalFilesInputModuleDb:
             cursor = conn.cursor()
             cursor.execute(
                 """
-                SELECT t.*, a.title as album_title, ar.name as artist_name 
+                SELECT t.*, a.title as album_title, a.genre as album_genre, ar.name as artist_name 
                 FROM tracks t
                 LEFT JOIN albums a ON t.album_id = a.id
                 LEFT JOIN artists ar ON t.artist_id = ar.id
@@ -224,7 +224,7 @@ class LocalFilesInputModuleDb:
             placeholders = ", ".join("?" for _ in track_ids)
             cursor.execute(
                 f"""
-                SELECT t.*, a.title as album_title, ar.name as artist_name
+                SELECT t.*, a.title as album_title, a.genre as album_genre, ar.name as artist_name
                 FROM tracks t
                 LEFT JOIN albums a ON t.album_id = a.id
                 LEFT JOIN artists ar ON t.artist_id = ar.id
@@ -350,7 +350,7 @@ class LocalFilesInputModuleDb:
             # Get results
             cursor.execute(
                 """
-                SELECT t.*, a.title as album_title, ar.name as artist_name
+                SELECT t.*, a.title as album_title, a.genre as album_genre, ar.name as artist_name
                 FROM tracks t
                 JOIN albums a ON t.album_id = a.id
                 JOIN artists ar ON t.artist_id = ar.id
@@ -502,7 +502,7 @@ class LocalFilesInputModuleDb:
             # Get results
             cursor.execute(
                 """
-                SELECT t.*, a.title as album_title, ar.name as artist_name
+                SELECT t.*, a.title as album_title, a.genre as album_genre, ar.name as artist_name
                 FROM tracks t
                 JOIN albums a ON t.album_id = a.id
                 JOIN artists ar ON t.artist_id = ar.id
@@ -533,7 +533,7 @@ class LocalFilesInputModuleDb:
             # Get results
             cursor.execute(
                 """
-                SELECT t.*, a.title as album_title, ar.name as artist_name
+                SELECT t.*, a.title as album_title, a.genre as album_genre, ar.name as artist_name
                 FROM tracks t
                 JOIN albums a ON t.album_id = a.id
                 JOIN artists ar ON t.artist_id = ar.id
@@ -620,7 +620,7 @@ class LocalFilesInputModuleDb:
 
             cursor.execute(
                 """
-                SELECT t.*, a.title as album_title, ar.name as artist_name
+                SELECT t.*, a.title as album_title, a.genre as album_genre, ar.name as artist_name
                 FROM tracks t
                 JOIN albums a ON t.album_id = a.id
                 JOIN artists ar ON t.artist_id = ar.id
@@ -655,7 +655,7 @@ class LocalFilesInputModuleDb:
             # Get results
             cursor.execute(
                 """
-                SELECT t.*, a.title as album_title, ar.name as artist_name
+                SELECT t.*, a.title as album_title, a.genre as album_genre, ar.name as artist_name
                 FROM tracks t
                 JOIN albums a ON t.album_id = a.id
                 JOIN artists ar ON t.artist_id = ar.id
@@ -753,7 +753,7 @@ class LocalFilesInputModuleDb:
             # Get results
             cursor.execute(
                 """
-                SELECT t.*, a.title as album_title, ar.name as artist_name, 
+                SELECT t.*, a.title as album_title, a.genre as album_genre, ar.name as artist_name, 
                        pt.position, pt.playlist_track_id
                 FROM playlist_tracks pt
                 JOIN tracks t ON pt.track_id = t.id

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/localfiles.py
@@ -27,6 +27,7 @@ from kalinka_plugin_sdk.datamodel import (
     Catalog,
     CatalogRole,
     FavoriteIds,
+    Genre,
     GenreList,
     Owner,
 )
@@ -943,6 +944,15 @@ class LocalFilesInputModule(InputModule):
             title=track["album_title"],
             artist=Artist(id=artist_id(track["artist_id"]), name=track["artist_name"]),
         )
+
+        # Enriched genre, when the query joined it in (album_genre). Carried
+        # on the card so clients — and the server's suggestion attestation —
+        # can see what the track is without another lookup.
+        if track.get("album_genre"):
+            album.genre = Genre(
+                id=genre_id(track["album_genre"].lower()),
+                name=track["album_genre"],
+            )
 
         # Add album image if available
         cover_path = self._get_album_image_urls(track["album_id"])

--- a/packages/kalinka-server/src/kalinka_server/config_model.py
+++ b/packages/kalinka-server/src/kalinka_server/config_model.py
@@ -298,6 +298,19 @@ class SearchConfig(BaseModel):
             "help": "How many artists appear in the Related Artists row",
         },
     )
+    suggest_min_score: int = Field(
+        default=25,
+        ge=0,
+        le=100,
+        title="Search suggestion validation threshold",
+        json_schema_extra={
+            "help": (
+                "How strongly a suggested search must match your library "
+                "(0–100) to be offered — higher offers fewer, safer "
+                "suggestions"
+            ),
+        },
+    )
     # Catalog routing (query_router.py): shortcuts to browse shelves shown
     # above the search results when the query names one ("recently added").
     # Floor default measured against MiniLM: bare artist names score up to
@@ -479,6 +492,7 @@ class KalinkaConfig(BaseModel):
                 leaf("search.best_match_max_results"),
                 leaf("search.candidate_limit"),
                 leaf("search.ai_suggestions_limit"),
+                leaf("search.suggest_min_score"),
                 leaf("search.related_max_results"),
                 leaf("search.route_max_results"),
                 leaf("search.route_min_similarity"),

--- a/packages/kalinka-server/src/kalinka_server/server.py
+++ b/packages/kalinka-server/src/kalinka_server/server.py
@@ -4,6 +4,7 @@ import logging
 import mimetypes
 import os
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -46,6 +47,7 @@ from .config_schema_processor import (
 )
 from .ai_search import assemble_ai_search
 from .query_router import CatalogRouter
+from .suggestions import SuggestionEngine, SuggestionList
 from .merge_utils import get_favorite_ids_merged, k_way_merge_browse_items
 from .dynamic_field_registry import build_dynamic_field_registry
 from .options_registry import OptionsRegistry
@@ -96,6 +98,10 @@ async def lifespan(app: FastAPI):
 
     finally:
         logger.info("Shutting down...")
+        # The suggestion engine's refresh loop runs forever by design.
+        task = getattr(app.state, "suggestions_task", None)
+        if task is not None:
+            task.cancel()
         if sd is not None:
             await sd.unregister_service()
 
@@ -244,6 +250,23 @@ async def create_app(
                 and isinstance(plugin.interface, InputModule)
             ]
         )
+    )
+
+    # Search-suggestion engine: validated against the user's own library
+    # (localfiles) when it is enabled — a discovery catalog like Jamendo has
+    # everything, so validating against it proves nothing. Attestation runs
+    # in the background for the server's lifetime; serving never blocks.
+    library = None
+    lf = modules.prepared_input_modules.get("localfiles")
+    if (
+        lf is not None
+        and "localfiles" in modules.enabled_input_modules
+        and isinstance(lf.interface, InputModule)
+    ):
+        library = lf.interface
+    app.state.suggestions = SuggestionEngine(library, config.search)
+    app.state.suggestions_task = asyncio.create_task(
+        app.state.suggestions.refresh_loop()
     )
 
     # Persist the overrides dict if plugin setup reconciled it — i.e. a
@@ -500,6 +523,23 @@ async def create_app(
             input_modules, query, offset, limit, app.state.config.search,
             router=app.state.query_router,
         )
+
+    @app.get("/ai_search/suggestions")
+    async def ai_search_suggestions(
+        count: int = 8,
+        tz_offset_min: Optional[int] = None,
+    ) -> SuggestionList:
+        """Ready-to-run ``/ai_search`` queries matched to the current moment.
+
+        ``count`` picks (validated against the local library, plus one
+        experimental slot); ``tz_offset_min`` is the client's UTC offset in
+        minutes so "morning" means the listener's morning, not the server's —
+        omitted, the server's local clock decides.
+        """
+        now = None
+        if tz_offset_min is not None:
+            now = datetime.now(timezone(timedelta(minutes=tz_offset_min)))
+        return app.state.suggestions.suggest(count, now=now)
 
     @app.get("/indexer/status")
     async def indexer_status(sources: Optional[str] = None) -> dict:

--- a/packages/kalinka-server/src/kalinka_server/server.py
+++ b/packages/kalinka-server/src/kalinka_server/server.py
@@ -526,16 +526,23 @@ async def create_app(
 
     @app.get("/ai_search/suggestions")
     async def ai_search_suggestions(
-        count: int = 8,
-        tz_offset_min: Optional[int] = None,
+        count: int = Query(
+            default=8, ge=1, le=32,
+            description="How many suggestions to return",
+        ),
+        tz_offset_min: Optional[int] = Query(
+            default=None, ge=-720, le=840,
+            description=(
+                "Client's UTC offset in MINUTES, east positive (UTC+3 = 180, "
+                "UTC-5 = -300; Dart: DateTime.now().timeZoneOffset.inMinutes) "
+                "— so 'morning' means the listener's morning, not the "
+                "server's. Omitted: the server's local clock decides."
+            ),
+        ),
     ) -> SuggestionList:
-        """Ready-to-run ``/ai_search`` queries matched to the current moment.
-
-        ``count`` picks (validated against the local library, plus one
-        experimental slot); ``tz_offset_min`` is the client's UTC offset in
-        minutes so "morning" means the listener's morning, not the server's —
-        omitted, the server's local clock decides.
-        """
+        """Ready-to-run ``/ai_search`` queries matched to the current moment
+        (daypart + in-window holidays), validated against the local library,
+        plus one experimental slot."""
         now = None
         if tz_offset_min is not None:
             now = datetime.now(timezone(timedelta(minutes=tz_offset_min)))

--- a/packages/kalinka-server/src/kalinka_server/server.py
+++ b/packages/kalinka-server/src/kalinka_server/server.py
@@ -102,6 +102,11 @@ async def lifespan(app: FastAPI):
         task = getattr(app.state, "suggestions_task", None)
         if task is not None:
             task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                # A crashed loop must not derail the rest of shutdown.
+                pass
         if sd is not None:
             await sd.unregister_service()
 

--- a/packages/kalinka-server/src/kalinka_server/suggestions.py
+++ b/packages/kalinka-server/src/kalinka_server/suggestions.py
@@ -555,16 +555,19 @@ class SuggestionEngine:
 
         picks: List[Suggestion] = []
 
+        # One slot stays reserved for the experimental pick when there is
+        # anything unvalidated to gamble on — but never at the expense of the
+        # only slot: count=1 serves a validated suggestion when one exists.
+        reserve_experimental = bool(unvalidated) and count > 1
+        reserved = count - 1 if reserve_experimental else count
+
         # An active holiday that survived validation always gets one slot —
         # it's the whole point of the date awareness, and score-weighted
         # sampling alone can bury two christmas chips under sixty dayparts.
         holiday_validated = [v for v in validated if v[1].startswith("holiday:")]
-        if holiday_validated and count > len(picks) + 1:
+        if holiday_validated and len(picks) < reserved:
             picks.append(self._pick_validated(holiday_validated, validated))
 
-        # One slot stays reserved for the experimental pick when there is
-        # anything unvalidated to gamble on.
-        reserved = count - 1 if unvalidated else count
         while validated and len(picks) < reserved:
             picks.append(self._pick_validated(validated, validated))
 

--- a/packages/kalinka-server/src/kalinka_server/suggestions.py
+++ b/packages/kalinka-server/src/kalinka_server/suggestions.py
@@ -1,0 +1,611 @@
+"""Context-aware AI-search query suggestions (``/ai_search/suggestions``).
+
+Serves N ready-to-run ``/ai_search`` queries matched to the moment — time of
+day (morning coffee / afternoon focus / evening wind-down / night) and the
+few public holidays CLAP can actually retrieve (christmas, halloween, …) —
+and validated against the user's own library, so a christmas chip never
+appears for a user who owns no christmas music.
+
+The design is three stages, and only the first two cost anything:
+
+  * **Candidate universe** — composed offline from piece tables below:
+    per-daypart mood words and activity phrases crossed with a genre/instrument
+    backbone, plus per-holiday full phrases. The vocabulary is restricted to
+    what the retrieval stack is measured to handle (MTG-Jamendo benchmark:
+    concrete genre/instrument strong; abstract mood words work only through
+    the searcher's valence/arousal leg, so mood words come from that
+    vocabulary). Negation — a known CLAP failure ("instrumental not rock"
+    retrieves rock) — never appears by construction.
+  * **Attestation** — a background job runs every candidate through the
+    library module's public ``ai_search()`` and scores whether the results
+    actually match the asked-for content: keyword agreement between the
+    candidate's genre/holiday tokens and the returned tracks' genre + titles,
+    damped by artist diversity. CLAP KNN *distance* is deliberately not used —
+    measured to carry no relevance signal (it always returns nearest
+    neighbours, relevant or not). Scores persist to the state dir keyed by a
+    fingerprint of the library's embedding-done counts, so a restart serves
+    from cache and only a changed library re-attests.
+  * **Serving** — a pure in-memory lookup: resolve daypart/holidays, filter
+    validated candidates by context, weighted-sample ``count`` of them.  One
+    slot per response is *experimental*: context-matched but not validated,
+    the serendipity outlet (and the only kind served for discovery sources
+    like Jamendo, whose catalog matches anything). No model runs here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import random
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from kalinka_plugin_sdk import paths
+from kalinka_plugin_sdk.inputmodule import InputModule
+
+from .config_model import SearchConfig
+
+logger = logging.getLogger(__name__.split(".")[-1])
+
+# Bump when the piece tables / templates / scoring change: invalidates the
+# persisted attestation cache so stale scores for queries that no longer
+# exist (or were scored differently) are not served.
+DATA_VERSION = 1
+
+# Tracks scored per candidate — the user-visible depth of a suggestion card.
+_ATTEST_TOP_K = 10
+# Pause between attestation probes: the searcher serializes queries behind
+# one lock, so a tight loop would starve a user typing a real search.
+_ATTEST_GAP_S = 0.25
+# Let startup settle (module subprocesses, first CLAP model load) before the
+# first attestation pass hits the searcher.
+_STARTUP_DELAY_S = 20.0
+# Periodic fingerprint re-check: catches a library that finished embedding
+# after startup without requiring a server restart.
+_REFRESH_INTERVAL_S = 6 * 3600
+# Below this share of results carrying album genre, keyword scoring can't
+# tell "irrelevant results" from "unenriched library" — the run degrades to
+# unvalidated serving instead of wrongly filtering everything out.
+_MIN_GENRE_COVERAGE = 0.2
+# Fraction of top-K results that must match the candidate's keywords for a
+# perfect-diversity score of 1.0*ratio; the config threshold cuts on the
+# combined score (0-100 scale, see SearchConfig.suggest_min_score).
+_RECENT_PENALTY = 0.25  # weight multiplier for queries served recently
+
+
+# ---------------------------------------------------------------------------
+# Piece tables
+# ---------------------------------------------------------------------------
+
+# Genre / instrument backbone: (phrase used in composed queries, match tokens
+# attested against result genre + titles). Tokens are whole words after
+# folding; multi-word tokens match as a phrase.
+_GENRES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("jazz", ("jazz", "swing", "bebop")),
+    ("blues", ("blues",)),
+    ("rock", ("rock",)),
+    ("heavy metal", ("metal",)),
+    ("hip hop", ("hip hop", "rap")),
+    ("electronic music", ("electronic", "electronica", "electro", "techno",
+                          "house", "trance", "edm", "dance")),
+    ("ambient electronic", ("ambient", "atmospheric", "downtempo", "chillout")),
+    ("classical music", ("classical", "orchestra", "orchestral", "symphony",
+                         "baroque", "chamber")),
+    ("piano music", ("piano",)),
+    ("acoustic guitar", ("acoustic", "guitar")),
+    ("folk", ("folk", "americana", "singer songwriter")),
+    ("country music", ("country",)),
+    ("funk", ("funk",)),
+    ("soul music", ("soul", "r&b", "rnb", "motown")),
+    ("reggae", ("reggae", "dub", "ska")),
+    ("latin music", ("latin", "salsa", "bossa", "samba")),
+    ("pop music", ("pop",)),
+    ("indie rock", ("indie", "alternative")),
+)
+
+# Dayparts: (start hour inclusive, end hour exclusive) in local time, mood
+# words (drawn from the searcher's valence/arousal vocabulary so the mood leg
+# engages, aligned with the daypart's V/A region), activity phrases.
+_DAYPARTS: dict[str, dict] = {
+    "morning": {
+        "hours": (5, 11),
+        "moods": ("upbeat", "cheerful", "warm", "energetic"),
+        "activities": ("for a slow morning coffee", "for a morning run",
+                       "to start the day"),
+    },
+    "afternoon": {
+        "hours": (11, 17),
+        "moods": ("smooth", "calm", "mellow"),
+        "activities": ("for deep focus", "for studying",
+                       "for an afternoon of work"),
+    },
+    "evening": {
+        "hours": (17, 22),
+        "moods": ("relaxing", "mellow", "warm", "dreamy"),
+        "activities": ("for a cozy evening", "to wind down",
+                       "for dinner with friends"),
+    },
+    "night": {
+        "hours": (22, 5),
+        "moods": ("dark", "atmospheric", "hypnotic", "energetic"),
+        "activities": ("for a late night drive", "for a night out",
+                       "to fall asleep to"),
+    },
+}
+
+# Holidays: date window (inclusive; may wrap the year end) and full phrases
+# with their attestation tokens. Only holidays with a *timbral* audio
+# signature CLAP retrieves (bells, organ, choir) or a strong title vocabulary
+# make this table. Easter's window is computed per year (see _active_holidays).
+_HOLIDAYS: dict[str, dict] = {
+    "christmas": {
+        "window": ((12, 1), (12, 26)),
+        "phrases": (
+            ("christmas carols with sleigh bells",
+             ("christmas", "xmas", "carol*", "jingle", "sleigh", "noel",
+              "santa", "silent night", "winter")),
+            ("cozy christmas jazz",
+             ("christmas", "xmas", "carol*", "jingle", "noel", "santa",
+              "winter", "jazz")),
+            ("festive winter holiday songs",
+             ("christmas", "xmas", "holiday*", "festive", "winter", "noel")),
+        ),
+    },
+    "new_year": {
+        "window": ((12, 27), (1, 2)),
+        "phrases": (
+            ("upbeat party anthems to celebrate",
+             ("party", "celebrat*", "dance", "anthem*")),
+            ("euphoric dance music for a party",
+             ("dance", "party", "club", "electronic", "house")),
+        ),
+    },
+    "valentine": {
+        "window": ((2, 7), (2, 14)),
+        "phrases": (
+            ("romantic love songs",
+             ("love*", "romanc*", "romantic", "heart*", "kiss*")),
+            ("slow romantic jazz",
+             ("love*", "romanc*", "romantic", "heart*", "jazz")),
+        ),
+    },
+    "easter": {
+        "window": None,  # computed from the Easter date
+        "phrases": (
+            ("peaceful choral music",
+             ("choral", "choir*", "hymn*", "gospel", "sacred", "chant*")),
+            ("gentle acoustic music for a spring morning",
+             ("spring", "acoustic", "morning", "gentle")),
+        ),
+    },
+    "halloween": {
+        "window": ((10, 24), (10, 31)),
+        "phrases": (
+            ("spooky eerie halloween music",
+             ("halloween", "spooky", "ghost*", "monster*", "witch*",
+              "haunt*", "creep*", "zombie*")),
+            ("dark haunting organ music",
+             ("organ", "haunt*", "dark", "gothic")),
+        ),
+    },
+}
+
+
+@dataclass
+class _Candidate:
+    query: str
+    contexts: set = field(default_factory=set)  # daypart names / "holiday:x"
+    keywords: tuple = ()
+
+
+def build_candidates() -> List[_Candidate]:
+    """Compose the candidate universe from the piece tables.
+
+    Per (daypart, genre) three short variants — "{mood} {genre}",
+    "{genre} {activity}", "{mood} {genre} {activity}" — with moods/activities
+    rotated deterministically so every piece gets used without a full cross
+    product (the universe must stay small enough to attest in ~a minute).
+    Duplicate query texts merge their context tags.
+    """
+    by_query: dict[str, _Candidate] = {}
+
+    def add(query: str, context: str, keywords: tuple) -> None:
+        cand = by_query.setdefault(query, _Candidate(query, set(), keywords))
+        cand.contexts.add(context)
+
+    for daypart, spec in _DAYPARTS.items():
+        moods, acts = spec["moods"], spec["activities"]
+        for i, (phrase, keywords) in enumerate(_GENRES):
+            mood_a = moods[i % len(moods)]
+            mood_b = moods[(i + 1) % len(moods)]
+            act_a = acts[i % len(acts)]
+            act_b = acts[(i + 1) % len(acts)]
+            add(f"{mood_a} {phrase}", daypart, keywords)
+            add(f"{phrase} {act_a}", daypart, keywords)
+            add(f"{mood_b} {phrase} {act_b}", daypart, keywords)
+
+    for name, spec in _HOLIDAYS.items():
+        for query, keywords in spec["phrases"]:
+            add(query, f"holiday:{name}", keywords)
+
+    return list(by_query.values())
+
+
+# ---------------------------------------------------------------------------
+# Context resolution
+# ---------------------------------------------------------------------------
+
+
+def easter_date(year: int) -> date:
+    """Western (Gregorian) Easter Sunday — anonymous/Butcher algorithm."""
+    a = year % 19
+    b, c = divmod(year, 100)
+    d, e = divmod(b, 4)
+    g = (8 * b + 13) // 25
+    h = (19 * a + b - d - g + 15) % 30
+    i, k = divmod(c, 4)
+    l = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * l) // 451
+    month, day = divmod(h + l - 7 * m + 114, 31)
+    return date(year, month, day + 1)
+
+
+def daypart_for(hour: int) -> str:
+    for name, spec in _DAYPARTS.items():
+        start, end = spec["hours"]
+        if (start <= hour < end) if start < end else (hour >= start or hour < end):
+            return name
+    return "evening"  # unreachable — the windows cover 0-23
+
+
+def _in_window(d: date, start: tuple[int, int], end: tuple[int, int]) -> bool:
+    """Inclusive (month, day) window test; ``start > end`` wraps the year."""
+    s, e, v = start, end, (d.month, d.day)
+    return (s <= v <= e) if s <= e else (v >= s or v <= e)
+
+
+def active_holidays(d: date) -> List[str]:
+    names: List[str] = []
+    for name, spec in _HOLIDAYS.items():
+        if name == "easter":
+            easter = easter_date(d.year)
+            if easter - timedelta(days=7) <= d <= easter + timedelta(days=1):
+                names.append(name)
+        elif _in_window(d, *spec["window"]):
+            names.append(name)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class Suggestion(BaseModel):
+    query: str
+    # Which context produced it: a daypart name or "holiday:<name>".
+    context: str
+    # True when the suggestion is NOT validated against the library — the
+    # per-response serendipity slot, or everything while attestation hasn't
+    # produced a usable pool yet.
+    experimental: bool = False
+    # Attestation score (0-1) when known; absent for experimental picks.
+    score: Optional[float] = None
+
+
+class SuggestionList(BaseModel):
+    suggestions: List[Suggestion]
+    # True when the non-experimental entries reflect a completed attestation
+    # run against the library with usable metadata.
+    attested: bool
+
+
+# ---------------------------------------------------------------------------
+# Matching helpers
+# ---------------------------------------------------------------------------
+
+
+def _fold(text: str) -> str:
+    """Casefold and collapse non-alphanumerics to single spaces, so keyword
+    matching is word-boundary safe ("pop" must not hit "popular") and
+    punctuation variants agree ("r&b" == "R&B" == "r b")."""
+    out = []
+    prev_space = True
+    for ch in text.casefold():
+        if ch.isalnum():
+            out.append(ch)
+            prev_space = False
+        elif not prev_space:
+            out.append(" ")
+            prev_space = True
+    return "".join(out).strip()
+
+
+def _keyword_hit(folded_text: str, keywords: tuple) -> bool:
+    padded = f" {folded_text} "
+    for kw in keywords:
+        # A trailing "*" marks a stem ("carol*" hits "carols", "caroling") —
+        # matched as a word prefix. Everything else matches whole words only,
+        # so "pop" never hits "popular".
+        if kw.endswith("*"):
+            fkw = _fold(kw[:-1])
+            if fkw and f" {fkw}" in padded:
+                return True
+        else:
+            fkw = _fold(kw)
+            if fkw and f" {fkw} " in padded:
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+
+class SuggestionEngine:
+    """Owns the candidate pool, its attestation scores, and serving.
+
+    ``library`` is the module suggestions are validated against — localfiles.
+    Discovery sources (Jamendo) match anything, so validating against them
+    proves nothing; without a library module the pool serves unvalidated.
+    """
+
+    def __init__(
+        self,
+        library: Optional[InputModule],
+        cfg: SearchConfig,
+        cache_path: Optional[str] = None,
+    ):
+        self._library = library
+        self._cfg = cfg
+        self._cache_path = cache_path or os.path.join(
+            paths.state_dir(), "server", "ai_suggestions.json"
+        )
+        self._candidates = build_candidates()
+        self._scores: dict[str, float] = {}
+        self._attested = False       # a run completed and was adopted
+        self._low_metadata = False   # run completed but genre coverage too thin
+        self._cached_fp: Optional[str] = None
+        self._recent: deque = deque(maxlen=24)
+        self._rng = random.Random()
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def refresh_loop(self) -> None:
+        """Load the persisted scores, then (re-)attest whenever the library
+        fingerprint moves. Runs for the server's lifetime; cancelled on
+        shutdown."""
+        self._load_cache()
+        if self._library is None:
+            logger.info("suggestions: no library module — serving unvalidated")
+            return
+        await asyncio.sleep(_STARTUP_DELAY_S)
+        while True:
+            try:
+                fp = await self._fingerprint()
+                if fp != self._cached_fp:
+                    await self._attest_all(fp)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("suggestions: attestation pass failed")
+            await asyncio.sleep(_REFRESH_INTERVAL_S)
+
+    async def _fingerprint(self) -> str:
+        """Identity of the attestation inputs: piece-table version + the
+        library's embedding **done** counts (stable once indexing finishes,
+        unlike pending/in-progress which move during a run)."""
+        done: dict = {}
+        status_fn = getattr(self._library, "get_indexer_status", None)
+        if status_fn is not None:
+            try:
+                status = await status_fn()
+                done = {k: v.get("done", 0) for k, v in status.items()}
+            except Exception as e:
+                logger.debug("suggestions: indexer status unavailable: %s", e)
+        raw = json.dumps({"v": DATA_VERSION, "done": done}, sort_keys=True)
+        return hashlib.sha1(raw.encode()).hexdigest()[:16]
+
+    # -- attestation -------------------------------------------------------
+
+    async def _attest_all(self, fingerprint: str) -> None:
+        logger.info("suggestions: attesting %d candidates against %s",
+                    len(self._candidates), self._library.module_name())
+        scores: dict[str, float] = {}
+        genre_seen = 0
+        tracks_seen = 0
+        for cand in self._candidates:
+            score, n_tracks, n_genre = await self._attest_one(cand)
+            scores[cand.query] = score
+            tracks_seen += n_tracks
+            genre_seen += n_genre
+            await asyncio.sleep(_ATTEST_GAP_S)
+
+        if tracks_seen == 0:
+            # Library empty or search stack not up yet: nothing was actually
+            # tested. Keep whatever pool we had; the next fingerprint change
+            # (embedding progressing) retries.
+            logger.info("suggestions: library returned no tracks — run discarded")
+            return
+
+        self._scores = scores
+        self._low_metadata = (genre_seen / tracks_seen) < _MIN_GENRE_COVERAGE
+        self._attested = True
+        self._cached_fp = fingerprint
+        self._save_cache()
+        thr = self._cfg.suggest_min_score / 100.0
+        logger.info(
+            "suggestions: attested — %d/%d candidates validated (genre "
+            "coverage %.0f%%%s)",
+            sum(1 for s in scores.values() if s >= thr), len(scores),
+            100.0 * genre_seen / tracks_seen,
+            ", too thin — serving unvalidated" if self._low_metadata else "",
+        )
+
+    async def _attest_one(self, cand: _Candidate) -> tuple[float, int, int]:
+        """Score one candidate: (score 0-1, tracks seen, tracks with genre).
+
+        Keyword agreement over the top-K returned tracks' genre + album/track
+        titles + artist name, damped by artist diversity so ten cuts of one
+        album can't validate a query.
+        """
+        try:
+            result = await self._library.ai_search(cand.query, 0, _ATTEST_TOP_K)
+        except Exception as e:
+            logger.warning("suggestions: probe %r failed: %s", cand.query, e)
+            return 0.0, 0, 0
+        tracks = [
+            item.track
+            for card in result.items
+            for item in (card.sections or [])
+            if item.track is not None
+        ][:_ATTEST_TOP_K]
+        if not tracks:
+            return 0.0, 0, 0
+
+        hits = 0
+        genre_known = 0
+        artists = set()
+        for t in tracks:
+            parts = [t.title]
+            if t.album is not None:
+                parts.append(t.album.title)
+                if t.album.genre is not None:
+                    genre_known += 1
+                    parts.append(t.album.genre.name)
+            if t.performer is not None:
+                parts.append(t.performer.name)
+                artists.add(t.performer.id.to_string)
+            if _keyword_hit(_fold(" ".join(p for p in parts if p)), cand.keywords):
+                hits += 1
+        diversity = len(artists) / len(tracks) if artists else 0.0
+        score = (hits / len(tracks)) * (0.5 + 0.5 * diversity)
+        return score, len(tracks), genre_known
+
+    # -- persistence -------------------------------------------------------
+
+    def _load_cache(self) -> None:
+        try:
+            with open(self._cache_path, encoding="utf-8") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            return
+        except Exception as e:
+            logger.warning("suggestions: unreadable cache %s: %s",
+                           self._cache_path, e)
+            return
+        if data.get("data_version") != DATA_VERSION:
+            logger.info("suggestions: cache is v%s, need v%d — re-attesting",
+                        data.get("data_version"), DATA_VERSION)
+            return
+        self._scores = {str(k): float(v) for k, v in data.get("scores", {}).items()}
+        self._low_metadata = bool(data.get("low_metadata", False))
+        self._cached_fp = data.get("fingerprint")
+        self._attested = bool(self._scores)
+        logger.info("suggestions: loaded %d cached scores", len(self._scores))
+
+    def _save_cache(self) -> None:
+        try:
+            os.makedirs(os.path.dirname(self._cache_path), exist_ok=True)
+            tmp = self._cache_path + ".part"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump({
+                    "data_version": DATA_VERSION,
+                    "fingerprint": self._cached_fp,
+                    "low_metadata": self._low_metadata,
+                    "scores": self._scores,
+                }, f)
+            os.replace(tmp, self._cache_path)
+        except OSError as e:
+            logger.warning("suggestions: cache write failed: %s", e)
+
+    # -- serving -----------------------------------------------------------
+
+    def suggest(self, count: int, now: Optional[datetime] = None) -> SuggestionList:
+        """Pick ``count`` context-matched suggestions — validated ones
+        weighted by score (recently served ones damped), plus one
+        experimental slot. Pure in-memory work, safe on the request path."""
+        now = now if now is not None else datetime.now().astimezone()
+        count = max(1, min(count, 32))
+        contexts = [daypart_for(now.hour)] + [
+            f"holiday:{h}" for h in active_holidays(now.date())
+        ]
+
+        usable = self._attested and not self._low_metadata
+        thr = self._cfg.suggest_min_score / 100.0
+        validated: List[tuple[_Candidate, str, float]] = []
+        unvalidated: List[tuple[_Candidate, str]] = []
+        for cand in self._candidates:
+            ctx = next((c for c in contexts if c in cand.contexts), None)
+            if ctx is None:
+                continue
+            score = self._scores.get(cand.query)
+            if usable and score is not None and score >= thr:
+                validated.append((cand, ctx, score))
+            else:
+                unvalidated.append((cand, ctx))
+
+        picks: List[Suggestion] = []
+
+        # An active holiday that survived validation always gets one slot —
+        # it's the whole point of the date awareness, and score-weighted
+        # sampling alone can bury two christmas chips under sixty dayparts.
+        holiday_validated = [v for v in validated if v[1].startswith("holiday:")]
+        if holiday_validated and count > len(picks) + 1:
+            picks.append(self._pick_validated(holiday_validated, validated))
+
+        # One slot stays reserved for the experimental pick when there is
+        # anything unvalidated to gamble on.
+        reserved = count - 1 if unvalidated else count
+        while validated and len(picks) < reserved:
+            picks.append(self._pick_validated(validated, validated))
+
+        # The experimental slot: context-matched, deliberately unvalidated.
+        # Prefer an active holiday's phrasing — the most interesting gamble —
+        # and let it fill remaining space when validation came up short.
+        self._rng.shuffle(unvalidated)
+        unvalidated.sort(key=lambda cv: not cv[1].startswith("holiday:"))
+        for cand, ctx in unvalidated:
+            if len(picks) >= count:
+                break
+            if any(p.query == cand.query for p in picks):
+                continue
+            picks.append(Suggestion(query=cand.query, context=ctx,
+                                    experimental=True))
+
+        self._recent.extend(p.query for p in picks)
+        return SuggestionList(suggestions=picks, attested=usable)
+
+    def _pick_validated(
+        self,
+        pool: List[tuple[_Candidate, str, float]],
+        validated: List[tuple[_Candidate, str, float]],
+    ) -> Suggestion:
+        """Weighted-sample one entry from ``pool`` and remove it from
+        ``validated`` (pool is a subset of / alias for validated)."""
+        weights = [
+            score * (_RECENT_PENALTY if cand.query in self._recent else 1.0)
+            for cand, _, score in pool
+        ]
+        total = sum(weights)
+        pick = pool[-1]
+        if total > 0:
+            r = self._rng.uniform(0, total)
+            for entry, w in zip(pool, weights):
+                r -= w
+                if r <= 0:
+                    pick = entry
+                    break
+        validated.remove(pick)
+        if pool is not validated and pick in pool:
+            pool.remove(pick)
+        cand, ctx, score = pick
+        return Suggestion(query=cand.query, context=ctx, score=round(score, 3))

--- a/packages/kalinka-server/tests/test_suggestions.py
+++ b/packages/kalinka-server/tests/test_suggestions.py
@@ -329,6 +329,36 @@ def test_cache_version_mismatch_ignored(tmp_path):
     assert not engine._attested and engine._scores == {}
 
 
+@pytest.mark.asyncio
+async def test_count_one_serves_validated_not_experimental(tmp_path, monkeypatch):
+    # The experimental slot must never starve the only slot: count=1 with a
+    # validated pool returns a validated pick, and during a holiday window
+    # the guaranteed holiday slot still applies.
+    monkeypatch.setattr("kalinka_server.suggestions._ATTEST_GAP_S", 0)
+
+    class ChristmasJazzLibrary(FakeLibrary):
+        async def ai_search(self, query, offset=0, limit=50):
+            titles = ["Jingle Bells", "Silent Night", "White Christmas"]
+            return _card(
+                [
+                    _track_item(i, "Jazz", title=titles[i % len(titles)])
+                    for i in range(10)
+                ]
+            )
+
+    engine = _engine(ChristmasJazzLibrary(), tmp_path)
+    await engine._attest_all("fp")
+
+    july = engine.suggest(1, now=datetime(2026, 7, 6, 9, 0))
+    assert len(july.suggestions) == 1
+    assert not july.suggestions[0].experimental
+
+    december = engine.suggest(1, now=datetime(2026, 12, 10, 9, 0))
+    assert len(december.suggestions) == 1
+    assert not december.suggestions[0].experimental
+    assert december.suggestions[0].context == "holiday:christmas"
+
+
 def test_count_clamped(tmp_path):
     engine = _engine(None, tmp_path)
     assert len(engine.suggest(0, now=datetime(2026, 7, 6, 9, 0)).suggestions) == 1

--- a/packages/kalinka-server/tests/test_suggestions.py
+++ b/packages/kalinka-server/tests/test_suggestions.py
@@ -1,0 +1,335 @@
+"""Tests for the /ai_search/suggestions engine (kalinka_server.suggestions)."""
+
+from datetime import date, datetime
+
+import pytest
+
+from kalinka_plugin_sdk.datamodel import (
+    Album,
+    Artist,
+    BrowseItem,
+    BrowseItemList,
+    Catalog,
+    EntityId,
+    EntityType,
+    Genre,
+    Preview,
+    PreviewContentType,
+    PreviewType,
+    Track,
+)
+from kalinka_server.config_model import SearchConfig
+from kalinka_server.suggestions import (
+    DATA_VERSION,
+    SuggestionEngine,
+    active_holidays,
+    build_candidates,
+    daypart_for,
+    easter_date,
+    _fold,
+    _keyword_hit,
+)
+
+
+# ---------------------------------------------------------------------------
+# Context resolution
+# ---------------------------------------------------------------------------
+
+
+def test_easter_dates():
+    assert easter_date(2024) == date(2024, 3, 31)
+    assert easter_date(2025) == date(2025, 4, 20)
+    assert easter_date(2026) == date(2026, 4, 5)
+
+
+@pytest.mark.parametrize(
+    "hour,expected",
+    [
+        (5, "morning"),
+        (10, "morning"),
+        (11, "afternoon"),
+        (16, "afternoon"),
+        (17, "evening"),
+        (21, "evening"),
+        (22, "night"),
+        (23, "night"),
+        (0, "night"),
+        (4, "night"),
+    ],
+)
+def test_daypart_boundaries(hour, expected):
+    assert daypart_for(hour) == expected
+
+
+def test_holiday_windows():
+    assert "christmas" in active_holidays(date(2026, 12, 10))
+    assert "christmas" not in active_holidays(date(2026, 11, 30))
+    # New year wraps the year end.
+    assert "new_year" in active_holidays(date(2026, 12, 28))
+    assert "new_year" in active_holidays(date(2026, 1, 1))
+    assert "valentine" in active_holidays(date(2026, 2, 10))
+    assert "halloween" in active_holidays(date(2026, 10, 28))
+    # Easter 2026 is April 5: window is the week before through Easter Monday.
+    assert "easter" in active_holidays(date(2026, 3, 29))
+    assert "easter" in active_holidays(date(2026, 4, 6))
+    assert "easter" not in active_holidays(date(2026, 4, 7))
+    # An ordinary summer day has no holiday context.
+    assert active_holidays(date(2026, 7, 6)) == []
+
+
+# ---------------------------------------------------------------------------
+# Candidate composition
+# ---------------------------------------------------------------------------
+
+
+def test_candidates_unique_and_tagged():
+    cands = build_candidates()
+    queries = [c.query for c in cands]
+    assert len(queries) == len(set(queries))
+    contexts = {ctx for c in cands for ctx in c.contexts}
+    assert {"morning", "afternoon", "evening", "night"} <= contexts
+    assert "holiday:christmas" in contexts
+    # Every candidate carries attestation keywords.
+    assert all(c.keywords for c in cands)
+
+
+def test_candidates_have_no_negation():
+    # Negation is CLAP's known failure ("instrumental not rock" retrieves
+    # rock) — the composed vocabulary must never contain it.
+    for c in build_candidates():
+        folded = f" {_fold(c.query)} "
+        for bad in (" not ", " no ", " without ", " except "):
+            assert bad not in folded, c.query
+
+
+# ---------------------------------------------------------------------------
+# Keyword matching
+# ---------------------------------------------------------------------------
+
+
+def test_keyword_word_boundaries():
+    assert _keyword_hit(_fold("Pop Anthems Vol. 2"), ("pop",))
+    assert not _keyword_hit(_fold("Popular Classics"), ("pop",))
+    assert _keyword_hit(_fold("Trip-Hop Essentials"), ("hop",))
+    assert not _keyword_hit(_fold("Trip-Hop Essentials"), ("hip hop",))
+    assert _keyword_hit(_fold("R&B Classics"), ("r&b",))
+
+
+def test_keyword_stems():
+    assert _keyword_hit(_fold("Christmas Carols"), ("carol*",))
+    assert _keyword_hit(_fold("The Haunting"), ("haunt*",))
+    assert not _keyword_hit(_fold("Charcoal Nights"), ("carol*",))
+
+
+# ---------------------------------------------------------------------------
+# Attestation + serving against a fake library
+# ---------------------------------------------------------------------------
+
+
+def _track_item(idx: int, genre: str | None, title: str | None = None) -> BrowseItem:
+    tid = EntityId(id=f"t{idx}", type=EntityType.TRACK, source="localfiles")
+    artist = Artist(
+        id=EntityId(id=f"a{idx}", type=EntityType.ARTIST, source="localfiles"),
+        name=f"Artist {idx}",
+    )
+    album = Album(
+        id=EntityId(id=f"al{idx}", type=EntityType.ALBUM, source="localfiles"),
+        title=f"Album {idx}",
+        artist=artist,
+        genre=(
+            Genre(
+                id=EntityId(id=genre, type=EntityType.GENRE, source="localfiles"),
+                name=genre,
+            )
+            if genre
+            else None
+        ),
+    )
+    track = Track(
+        id=tid,
+        title=title or f"Track {idx}",
+        duration=180,
+        album=album,
+        performer=artist,
+    )
+    return BrowseItem(
+        id=tid, name=track.title, can_browse=False, can_add=True, track=track
+    )
+
+
+def _card(items: list[BrowseItem]) -> BrowseItemList:
+    cat = EntityId(id="ai_search:tracks", type=EntityType.CATALOG, source="localfiles")
+    card = BrowseItem(
+        id=cat,
+        name="FROM YOUR LIBRARY",
+        can_browse=False,
+        can_add=False,
+        catalog=Catalog(
+            id=cat,
+            title="FROM YOUR LIBRARY",
+            sources=["localfiles"],
+            preview_config=Preview(
+                type=PreviewType.CARD,
+                content_type=PreviewContentType.TRACK,
+                items_count=len(items),
+            ),
+        ),
+        sections=items,
+    )
+    return BrowseItemList(offset=0, limit=10, total=1, items=[card])
+
+
+class FakeLibrary:
+    """Duck-typed library module: jazz-only collection."""
+
+    def __init__(self, genre="Jazz", n=10, with_genre=True):
+        self._genre = genre
+        self._n = n
+        self._with_genre = with_genre
+
+    def module_name(self):
+        return "localfiles"
+
+    async def ai_search(self, query, offset=0, limit=50):
+        return _card(
+            [
+                _track_item(i, self._genre if self._with_genre else None)
+                for i in range(self._n)
+            ]
+        )
+
+    async def get_indexer_status(self):
+        return {"clap_audio": {"total": 100, "done": 100}}
+
+
+def _engine(library, tmp_path, seed=1234):
+    engine = SuggestionEngine(
+        library, SearchConfig(), cache_path=str(tmp_path / "cache.json")
+    )
+    engine._rng.seed(seed)
+    return engine
+
+
+@pytest.mark.asyncio
+async def test_attest_scores_by_genre(tmp_path):
+    engine = _engine(FakeLibrary(), tmp_path)
+    jazz = next(c for c in engine._candidates if "jazz" in c.query.split())
+    metal = next(c for c in engine._candidates if "metal" in c.query)
+    jazz_score, n, genre_known = await engine._attest_one(jazz)
+    metal_score, _, _ = await engine._attest_one(metal)
+    assert n == 10 and genre_known == 10
+    assert jazz_score >= 0.8  # all hits, all-distinct artists
+    assert metal_score == 0.0  # jazz results can't validate a metal query
+
+
+@pytest.mark.asyncio
+async def test_attest_empty_library_discards_run(tmp_path, monkeypatch):
+    monkeypatch.setattr("kalinka_server.suggestions._ATTEST_GAP_S", 0)
+
+    class EmptyLibrary(FakeLibrary):
+        async def ai_search(self, query, offset=0, limit=50):
+            return BrowseItemList(offset=0, limit=10, total=0, items=[])
+
+    engine = _engine(EmptyLibrary(), tmp_path)
+    await engine._attest_all("fp")
+    assert not engine._attested
+    assert not (tmp_path / "cache.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_attest_low_metadata_serves_unvalidated(tmp_path, monkeypatch):
+    monkeypatch.setattr("kalinka_server.suggestions._ATTEST_GAP_S", 0)
+    engine = _engine(FakeLibrary(with_genre=False), tmp_path)
+    await engine._attest_all("fp")
+    assert engine._attested and engine._low_metadata
+    result = engine.suggest(5, now=datetime(2026, 7, 6, 9, 0))
+    assert not result.attested
+    assert len(result.suggestions) == 5
+    assert all(s.experimental for s in result.suggestions)
+
+
+@pytest.mark.asyncio
+async def test_serving_validated_pool(tmp_path, monkeypatch):
+    monkeypatch.setattr("kalinka_server.suggestions._ATTEST_GAP_S", 0)
+    engine = _engine(FakeLibrary(), tmp_path)
+    await engine._attest_all("fp")
+    assert engine._attested and not engine._low_metadata
+
+    # Ordinary July morning: daypart context only. The jazz-only library
+    # validates exactly the 3 morning jazz variants, so count=4 is 3
+    # validated + the one experimental slot.
+    result = engine.suggest(4, now=datetime(2026, 7, 6, 9, 0))
+    assert result.attested
+    assert len(result.suggestions) == 4
+    experimental = [s for s in result.suggestions if s.experimental]
+    validated = [s for s in result.suggestions if not s.experimental]
+    assert len(experimental) == 1  # exactly one serendipity slot
+    assert experimental[0] is result.suggestions[-1]
+    assert validated  # jazz candidates cleared the threshold
+    for s in validated:
+        assert s.context == "morning"
+        assert s.score is not None and s.score >= engine._cfg.suggest_min_score / 100
+
+
+@pytest.mark.asyncio
+async def test_holiday_context_served_in_window(tmp_path, monkeypatch):
+    monkeypatch.setattr("kalinka_server.suggestions._ATTEST_GAP_S", 0)
+
+    class ChristmasJazzLibrary(FakeLibrary):
+        async def ai_search(self, query, offset=0, limit=50):
+            titles = ["Jingle Bells", "Silent Night", "White Christmas"]
+            return _card(
+                [
+                    _track_item(i, "Jazz", title=titles[i % len(titles)])
+                    for i in range(10)
+                ]
+            )
+
+    engine = _engine(ChristmasJazzLibrary(), tmp_path)
+    await engine._attest_all("fp")
+
+    december = engine.suggest(6, now=datetime(2026, 12, 10, 9, 0))
+    assert any(s.context == "holiday:christmas" for s in december.suggestions)
+
+    july = engine.suggest(6, now=datetime(2026, 7, 6, 9, 0))
+    assert not any(s.context.startswith("holiday:") for s in july.suggestions)
+
+
+@pytest.mark.asyncio
+async def test_unattested_engine_serves_experimental(tmp_path):
+    engine = _engine(None, tmp_path)
+    result = engine.suggest(4, now=datetime(2026, 7, 6, 20, 0))
+    assert not result.attested
+    assert len(result.suggestions) == 4
+    assert all(s.experimental for s in result.suggestions)
+    assert all(s.context == "evening" for s in result.suggestions)
+
+
+@pytest.mark.asyncio
+async def test_cache_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr("kalinka_server.suggestions._ATTEST_GAP_S", 0)
+    engine = _engine(FakeLibrary(), tmp_path)
+    await engine._attest_all("fp-1")
+
+    fresh = _engine(FakeLibrary(), tmp_path)
+    fresh._load_cache()
+    assert fresh._attested
+    assert fresh._cached_fp == "fp-1"
+    assert fresh._scores == engine._scores
+
+
+def test_cache_version_mismatch_ignored(tmp_path):
+    path = tmp_path / "cache.json"
+    path.write_text(
+        '{"data_version": %d, "fingerprint": "x", "scores": {"q": 1.0}}'
+        % (DATA_VERSION + 1)
+    )
+    engine = SuggestionEngine(None, SearchConfig(), cache_path=str(path))
+    engine._load_cache()
+    assert not engine._attested and engine._scores == {}
+
+
+def test_count_clamped(tmp_path):
+    engine = _engine(None, tmp_path)
+    assert len(engine.suggest(0, now=datetime(2026, 7, 6, 9, 0)).suggestions) == 1
+    assert len(engine.suggest(500, now=datetime(2026, 7, 6, 9, 0)).suggestions) <= 32


### PR DESCRIPTION
## What

`GET /ai_search/suggestions?count=N&tz_offset_min=±M` — ready-to-run AI-search queries matched to the current moment and validated against the user's own library.

- **Context**: daypart (morning coffee / afternoon focus / evening wind-down / night) resolved from the client's UTC offset in minutes (east positive; falls back to the server clock), plus in-window holidays — christmas, new year, valentine, easter (computed per year), halloween.
- **Library-validated**: a suggestion is only offered when it provably returns matching results on *this* library — a christmas chip never appears for a user who owns no christmas music. Validation is against **localfiles only**: discovery catalogs (Jamendo) match anything, so validating against them proves nothing.
- **One experimental slot** per response: context-matched but deliberately unvalidated — the serendipity outlet, and servable by discovery sources.

## How

Three stages; only the first two cost anything:

1. **Candidate universe** (~220 short queries) composed from piece tables: per-daypart mood words × genre/instrument backbone × activity phrases, plus per-holiday phrases. Vocabulary is restricted to what the retrieval stack measurably handles (MTG-Jamendo benchmark: concrete genre/instrument strong; mood words work via the searcher's V/A leg). Negation — a known CLAP failure ("instrumental not rock" retrieves rock) — never appears by construction.
2. **Attestation**: a background job runs every candidate through the library's public `ai_search()` and scores keyword agreement between the candidate's tokens and the returned tracks' genre + titles, damped by artist diversity. CLAP KNN *distance* is deliberately unused (measured to carry no relevance signal). Scores persist to `<state_dir>/server/ai_suggestions.json`, fingerprinted by embedding-done counts — restarts serve from cache; only a changed library re-attests (re-checked every 6 h). Thin genre metadata degrades to unvalidated serving instead of wrongly filtering everything out.
3. **Serving**: pure in-memory weighted sample (score-weighted, recently-served damped ×0.25, guaranteed slot for a validated in-window holiday) — no model on the request path.

## Enabler

localfiles now joins `albums.genre` into its track queries and carries it as `Album.genre` on track cards — the attestation signal, and useful metadata for any client.

## Config

`search.suggest_min_score` (default 25) — validation threshold, expert tier.

## Verification

- 25 new tests (`test_suggestions.py`); full kalinka-server (365) and localfiles (229) suites pass.
- Live against a real dev library: 217 candidates attested in 76 s (57 validated, genre coverage 85 %); blues/metal scored 0 (absent from the library) while ambient/electronic/jazz led; cold start serves experimental chips instantly; `tz_offset_min=-300` flips evening→afternoon; restart serves attested results straight from the persisted cache.
- Param validation: out-of-range `tz_offset_min` → 422; units documented in the OpenAPI schema.

Flutter-app integration (zero-state chips consuming this endpoint) is staged separately in the app repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)