### PR TITLE
Serve the optional browser player (kalinka-web) at /

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,9 +138,9 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/$GITHUB_REPOSITORY/main/scripts/install-release.sh | sudo bash -s -- $VERSION
           \`\`\`
 
-          Detects your architecture, downloads the right packages from this release, and installs them with \`apt\` (drop the \`-s -- $VERSION\` to always get the latest release instead).
+          Detects your architecture, downloads the right packages from this release, and installs them with \`apt\` (drop the \`-s -- $VERSION\` to always get the latest release instead). It also pulls the browser player (\`kalinka-web\`) from the [app repo's latest release](https://github.com/madenvel/KalinkaAI/releases) — once installed, open \`http://<server-ip>:8000\` in any browser on your network to control playback.
 
-          **Manual install:** download the server package for your OS — \`debian-13.arm64\` for Raspberry Pi OS (trixie) / Debian 13, \`ubuntu-24.04.amd64\` for Ubuntu 24.04 — plus all the \`_all.deb\` plugin/SDK packages, then run \`sudo apt install ./*.deb\` in the download directory. Verify downloads with \`sha256sum -c SHA256SUMS --ignore-missing\`.
+          **Manual install:** download the server package for your OS — \`debian-13.arm64\` for Raspberry Pi OS (trixie) / Debian 13, \`ubuntu-24.04.amd64\` for Ubuntu 24.04 — plus all the \`_all.deb\` plugin/SDK packages, then run \`sudo apt install ./*.deb\` in the download directory. Verify downloads with \`sha256sum -c SHA256SUMS --ignore-missing\`. For the browser player, add \`kalinka-web_*_all.deb\` from the [app releases](https://github.com/madenvel/KalinkaAI/releases).
           EOF
 
           # Create the release if it doesn't exist yet (idempotent: re-runs and

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,6 +56,17 @@ no effect.
 > a clean tree**. Between tags you'll get dev versions like `0.2.1.dev3+g<sha>.dYYYYMMDD`,
 > which is expected for development builds but not for a release.
 
+### The browser UI package (kalinka-web)
+
+The browser player is released independently from the
+[KalinkaAI repo](https://github.com/madenvel/KalinkaAI/releases) (versioned by
+the app, not by `kalinka-v*`); the server serves its bundle from
+`/usr/share/kalinka-web`. It is **not** attached to server releases —
+`install-release.sh` fetches the latest `kalinka-web_*_all.deb` straight from
+the app repo at install time, so the two release cadences are decoupled and a
+web-UI update ships to users on their next `install-release.sh` run without a
+server release. Nothing to do here when cutting a server release.
+
 ---
 
 ## Data releases (models, indexes) — never let them become "latest"

--- a/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/paths.py
+++ b/packages/kalinka-plugin-sdk/src/kalinka_plugin_sdk/paths.py
@@ -27,6 +27,7 @@ _LOG = "var/log/kalinka"
 _RUN = "run/kalinka"
 _CACHE = "var/cache/kalinka"
 _MEDIA = "srv/kalinka/music"
+_WEB_UI = "usr/share/kalinka-web"
 
 
 def prefix() -> str:
@@ -68,3 +69,9 @@ def media_dir() -> str:
     """Default music drop-off — ``<prefix>/srv/kalinka/music`` (under /srv, FHS
     "served data", so the deb can provision it world-writable)."""
     return _under(_MEDIA)
+
+
+def web_ui_dir() -> str:
+    """Browser player bundle — ``<prefix>/usr/share/kalinka-web`` (installed by
+    the optional kalinka-web package; served at ``/`` when present)."""
+    return _under(_WEB_UI)

--- a/packages/kalinka-server/DEBIAN/control.in
+++ b/packages/kalinka-server/DEBIAN/control.in
@@ -13,5 +13,6 @@ Depends: python3 (>= @PYTHON_VERSION@), python3 (<< @PYTHON_VERSION_UPPER@),
     python3-setuptools,
     kalinka-plugin-sdk (>= 1.0), kalinka-plugin-sdk (<< 2),
     @SHLIBDEPS@
+Recommends: kalinka-web
 Description: Kalinka Music Player (server)
   Kalinka Music Player service used in a pair with Kalinka App.

--- a/packages/kalinka-server/src/kalinka_server/server.py
+++ b/packages/kalinka-server/src/kalinka_server/server.py
@@ -52,6 +52,7 @@ from .merge_utils import get_favorite_ids_merged, k_way_merge_browse_items
 from .dynamic_field_registry import build_dynamic_field_registry
 from .options_registry import OptionsRegistry
 from .multisearch import calculate_fuzzy_score
+from .web_ui import WebUiStaticFiles
 from .optional_packages_registry import (
     build_catalog as build_optional_packages_catalog,
     write_pending_installs,
@@ -1224,5 +1225,14 @@ async def create_app(
         await handle_device_websocket_connection(
             websocket, player_context.ext_device_eventbus, device
         )
+
+    # Browser player (optional kalinka-web package). Mounted last so every API
+    # route above wins; check_dir=False resolves per request, so installing the
+    # bundle after startup works without a server restart.
+    app.mount(
+        "/",
+        WebUiStaticFiles(directory=paths.web_ui_dir(), html=True, check_dir=False),
+        name="web-ui",
+    )
 
     return app

--- a/packages/kalinka-server/src/kalinka_server/web_ui.py
+++ b/packages/kalinka-server/src/kalinka_server/web_ui.py
@@ -1,0 +1,99 @@
+"""Serve the browser player bundle (the optional ``kalinka-web`` package).
+
+The bundle lives at :func:`paths.web_ui_dir` and is mounted at ``/``. When the
+package is not installed the directory is absent, so instead of a bare 404 we
+render a short, self-contained page telling the admin how to install it.
+"""
+
+import os
+
+from starlette.exceptions import HTTPException
+from starlette.responses import HTMLResponse, Response
+from starlette.staticfiles import StaticFiles
+from starlette.types import Scope
+
+# Self-contained: the bundle that would provide external assets is exactly what
+# is missing here.
+_NOT_INSTALLED_PAGE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Kalinka — web player not installed</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; display: flex; align-items: center;
+    justify-content: center; padding: 24px;
+    background: #0e0e10; color: #e7e7ea;
+    font: 15px/1.6 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  }
+  .card {
+    width: 100%; max-width: 520px; padding: 40px 36px;
+    background: #17171a; border: 1px solid #262629; border-radius: 16px;
+    box-shadow: 0 20px 60px rgba(0,0,0,.5);
+  }
+  .brand {
+    font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+    font-size: 12px; color: #c2394b; margin: 0 0 20px;
+  }
+  h1 { margin: 0 0 12px; font-size: 22px; font-weight: 600; }
+  p { margin: 0 0 16px; color: #a9a9b2; }
+  pre {
+    margin: 0 0 8px; padding: 14px 16px;
+    white-space: pre-wrap; overflow-wrap: anywhere;
+    background: #0e0e10; border: 1px solid #262629; border-radius: 10px;
+    font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; color: #e7e7ea;
+  }
+  code { color: #d8556a; }
+  .hint { font-size: 13px; color: #6f6f78; margin-bottom: 0; }
+  a { color: #d8556a; }
+</style>
+</head>
+<body>
+  <div class="card">
+    <p class="brand">Kalinka</p>
+    <h1>Web player not installed</h1>
+    <p>
+      The server is running, but the browser player package
+      (<code>kalinka-web</code>) is not installed on this machine.
+    </p>
+    <p>Install it, then reload this page:</p>
+    <pre>curl -fsSL https://kalinkaplayer.com/install.sh | sudo bash</pre>
+    <p class="hint">
+      The installer adds the web player alongside the server. It appears here
+      immediately — no restart needed.
+    </p>
+  </div>
+</body>
+</html>
+"""
+
+
+class WebUiStaticFiles(StaticFiles):
+    """``StaticFiles`` that renders an install page when the bundle is absent.
+
+    A genuine 404 for a path *within* an installed bundle is passed through
+    unchanged; only requests that miss because nothing is installed get the
+    friendly page.
+    """
+
+    async def check_config(self) -> None:
+        # An absent bundle is expected (package not installed); skip Starlette's
+        # missing-directory check, which otherwise 500s on the first request
+        # even with check_dir=False. get_response renders the install page.
+        return
+
+    async def get_response(self, path: str, scope: Scope) -> Response:
+        try:
+            return await super().get_response(path, scope)
+        except HTTPException as exc:
+            if exc.status_code == 404 and not self._bundle_installed():
+                if scope["method"] == "HEAD":
+                    return Response(status_code=200)
+                return HTMLResponse(_NOT_INSTALLED_PAGE, status_code=200)
+            raise
+
+    def _bundle_installed(self) -> bool:
+        return os.path.isfile(os.path.join(self.directory, "index.html"))

--- a/packages/kalinka-server/tests/test_web_ui.py
+++ b/packages/kalinka-server/tests/test_web_ui.py
@@ -1,0 +1,47 @@
+"""WebUiStaticFiles: install-page fallback vs. serving an installed bundle."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.exceptions import HTTPException
+from starlette.responses import FileResponse, HTMLResponse
+
+from kalinka_server.web_ui import WebUiStaticFiles
+
+
+def _scope(method: str, path: str) -> dict:
+    return {"type": "http", "method": method, "headers": [], "path": path}
+
+
+async def _get(directory, *, sub_path: str = "", url_path: str = "/", method: str = "GET"):
+    sf = WebUiStaticFiles(directory=str(directory), html=True, check_dir=False)
+    return await sf.get_response(sub_path, _scope(method, url_path))
+
+
+async def test_absent_bundle_serves_install_page(tmp_path):
+    resp = await _get(tmp_path / "missing")
+    assert isinstance(resp, HTMLResponse)
+    assert resp.status_code == 200
+    assert b"Web player not installed" in resp.body
+
+
+async def test_absent_bundle_head_has_empty_body(tmp_path):
+    resp = await _get(tmp_path / "missing", method="HEAD")
+    assert not isinstance(resp, HTMLResponse)
+    assert resp.status_code == 200
+    assert resp.body == b""
+
+
+async def test_installed_bundle_serves_index(tmp_path):
+    (tmp_path / "index.html").write_text("<h1>real bundle</h1>")
+    resp = await _get(tmp_path)
+    # A real file response — the install page must not shadow the bundle.
+    assert isinstance(resp, FileResponse)
+    assert resp.status_code == 200
+
+
+async def test_installed_bundle_missing_asset_is_404(tmp_path):
+    (tmp_path / "index.html").write_text("<h1>real bundle</h1>")
+    with pytest.raises(HTTPException) as exc_info:
+        await _get(tmp_path, sub_path="missing.js", url_path="/missing.js")
+    assert exc_info.value.status_code == 404

--- a/scripts/dev_run.sh
+++ b/scripts/dev_run.sh
@@ -13,6 +13,12 @@
 # picking up any edited Python (editable install). For C++ changes run
 # `make dev-rebuild-native` then restart.
 #
+# Web UI: served from <prefix>/usr/share/kalinka-web when present. Symlink an
+# app-repo build there to test it — rebuilds are picked up per request, no
+# server restart, just refresh the browser:
+#   mkdir -p "$KALINKA_PREFIX/usr/share"
+#   ln -sfn <app-repo>/build/web "$KALINKA_PREFIX/usr/share/kalinka-web"
+#
 # Stop with Ctrl-C. Extra args (e.g. --debug) are forwarded to the server.
 
 set -uo pipefail

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -8,15 +8,23 @@
 # architecture (arm64 on a Raspberry Pi, amd64 on a PC) and installs all the
 # arch-independent plugin + SDK packages alongside it.
 #
+# The browser player (kalinka-web) is released separately from the app repo;
+# its latest arch-independent package is fetched and installed too, so the
+# server can serve the player UI at its root URL. This is best-effort — the
+# server runs fine without it (and shows an install page), so a lookup failure
+# only warns.
+#
 # Usage:
 #   ./install-release.sh                 # install the latest kalinka-v* release
 #   ./install-release.sh 3.2.0           # install a specific version
 #   ./install-release.sh kalinka-v3.2.0  # same, full tag form
 #
 # Env:
-#   KALINKA_REPO   owner/repo to pull releases from (default: madenvel/KalinkaPlayer)
-#   GITHUB_TOKEN   optional, only to avoid the 60-req/hr anonymous API limit
-#   NO_APT_UPDATE  set to 1 to skip `apt-get update` before installing
+#   KALINKA_REPO     owner/repo to pull the server release from (default: madenvel/KalinkaPlayer)
+#   KALINKA_WEB_REPO owner/repo for the kalinka-web package (default: madenvel/KalinkaAI)
+#   KALINKA_WEB      set to 0 to skip installing the browser player
+#   GITHUB_TOKEN     optional, only to avoid the 60-req/hr anonymous API limit
+#   NO_APT_UPDATE    set to 1 to skip `apt-get update` before installing
 #
 # The download runs as your user; only the install step uses sudo. Running the
 # whole script under sudo is fine too.
@@ -89,8 +97,23 @@ fi
 # fed on stdin without colliding with the program source.
 TMPDIR_DL=""
 PARSER="$(mktemp --suffix=.py)"
-cleanup() { rm -rf "$PARSER" ${TMPDIR_DL:+"$TMPDIR_DL"}; }
+WEB_PARSER="$(mktemp --suffix=.py)"
+cleanup() { rm -rf "$PARSER" "$WEB_PARSER" ${TMPDIR_DL:+"$TMPDIR_DL"}; }
 trap cleanup EXIT
+
+# Picks the newest non-draft/prerelease's kalinka-web_*_all.deb asset URL, if any.
+cat > "$WEB_PARSER" <<'PY'
+import sys, json
+data = json.load(sys.stdin)
+for r in (data if isinstance(data, list) else [data]):
+    if r.get("draft") or r.get("prerelease"):
+        continue
+    for a in r.get("assets", []):
+        name = a.get("name", "")
+        if name.startswith("kalinka-web_") and name.endswith("_all.deb"):
+            print(a["browser_download_url"])
+            sys.exit(0)
+PY
 cat > "$PARSER" <<'PY'
 import sys, json
 arch = sys.argv[1]
@@ -125,6 +148,21 @@ parsed="$(printf '%s' "$json" | python3 "$PARSER" "$ARCH")" \
 TAG="$(printf '%s\n' "$parsed" | sed -n '1p')"
 mapfile -t URLS < <(printf '%s\n' "$parsed" | sed '1d')
 [ "${#URLS[@]}" -gt 0 ] || die "no installable .deb assets found for $TAG ($ARCH)"
+
+# --- resolve the browser player (kalinka-web) from the app repo ----------------
+if [ "${KALINKA_WEB:-1}" != "0" ]; then
+  WEB_REPO="${KALINKA_WEB_REPO:-madenvel/KalinkaAI}"
+  echo ">> Looking up the latest kalinka-web package in $WEB_REPO ..."
+  if web_json="$(fetch "https://api.github.com/repos/${WEB_REPO}/releases?per_page=30")" \
+     && web_url="$(printf '%s' "$web_json" | python3 "$WEB_PARSER")" \
+     && [ -n "$web_url" ]; then
+    URLS+=("$web_url")
+    echo "   found ${web_url##*/}"
+  else
+    echo ">> note: no kalinka-web package found in $WEB_REPO — installing without the" >&2
+    echo "   browser player (set KALINKA_WEB=0 to silence, or install it later)." >&2
+  fi
+fi
 
 echo ">> Release: $TAG   architecture: $ARCH   packages: ${#URLS[@]}"
 
@@ -163,7 +201,7 @@ echo ">> Installed:"
 if have dpkg-query; then
   for pkg in kalinka-server kalinka-plugin-sdk kalinka-plugin-localfiles \
              kalinka-plugin-musiccast kalinka-plugin-jamendo \
-             kalinka-plugin-dummydevice; do
+             kalinka-plugin-dummydevice kalinka-web; do
     dpkg-query -W -f='   ${Package} ${Version}\n' "$pkg" 2>/dev/null || true
   done
 fi


### PR DESCRIPTION
## What

Lets the Kalinka app be used **from a browser**. The optional `kalinka-web` package drops the Flutter web bundle at `/usr/share/kalinka-web`; the server mounts it at `/` so users open the **server's own address** to control playback — same origin as the API, no CORS, no extra port. Audio stays on the server; the browser is a pure remote.

> **Companion PR:** madenvel/KalinkaAI#24 builds and releases the `kalinka-web` package this serves. They can merge independently — without the package the server shows an install page (below).

## Changes

- **`server.py`** — mount `WebUiStaticFiles` at `/`, after all API/WS routes so those win. `check_dir=False` resolves per request, so installing the bundle later needs no restart.
- **`paths.web_ui_dir()`** — resolves the bundle under `$KALINKA_PREFIX` (dev-friendly), matching the other path helpers.
- **`web_ui.py`** (new) — when the package is absent, renders a self-contained "install `kalinka-web`" page instead of a 500/404. (`check_dir=False` alone still 500s on the first request; we skip `check_config` and catch the 404.)
- **`install-release.sh`** — also fetches the latest `kalinka-web` from the app repo and installs it with the bundle (best-effort; the server runs fine without it). The two release cadences stay **decoupled** — no mirroring into server releases (see `RELEASING.md`).
- **`control.in`** — `Recommends: kalinka-web`; **`dev_run.sh`** documents the symlink for testing the endpoint from an app checkout.

## Testing

- `py_compile` clean. `get_response` unit checks: GET(absent)→install page 200, HEAD(absent)→empty 200, bundle-present→passthrough, missing asset in an installed bundle→genuine 404.
- End-to-end: ran the server from a checkout serving the app bundle → browser opened connected; install-page path verified with the bundle removed (screenshotted); `install-release.sh` web-fetch parser tested against the live app-repo API (graceful when no asset yet) and synthetic release JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
