### PR TITLE
Enrichment redesign, Phases 0-1: evidence capture + folder-first album clustering

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/__init__.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/__init__.py
@@ -1,0 +1,5 @@
+"""Folder-first album clustering (Phase 1).
+
+Groups imported tracks into local album clusters from structural evidence,
+splitting a folder only on compelling signals rather than on tag variance.
+"""

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
@@ -1,0 +1,86 @@
+"""Shared V/A-compilation and disc-suffix helpers.
+
+Single source of truth for the folder-classification logic that used to live
+only inside the indexer's orphan_va pass. Both the indexer and the clustering
+planner import from here so the two cannot drift.
+"""
+
+import os
+import re
+from typing import Optional
+
+# A folder's tracks coalesce into a single V/A compilation album when they
+# span at least this many distinct artists AND at least this fraction of
+# tracks have unique artists. Both, so a mistagged album (Abbey Road with a
+# couple of wrong-artist tags) doesn't flip to V/A.
+VA_MIN_DISTINCT_ARTISTS = 4
+VA_MIN_ARTIST_UNIQUENESS = 0.5
+
+VARIOUS_ARTISTS_ID = "various_artists"
+
+# Dumping-ground / structural folder names — not compilations or artists.
+GENERIC_FOLDER_RE = re.compile(
+    r"^(music|musik|audio|downloads?|mp3s?|tracks?|songs?|various|"
+    r"streamed_music|unused|unsorted|sorted|misc|miscellaneous|temp|tmp|"
+    r"incoming|untitled|new folder|to ?sort|todo|.*\bmix(?:es)?\b.*)$",
+    re.IGNORECASE,
+)
+# Bare disc/volume folder names that need the parent dir for a real title.
+BARE_DISC_RE = re.compile(
+    r"^(cd[-_ ]?\d+|disc\s*\d+|disk\s*\d+|volume\s*\d+|vol\.?\s*\d+)$",
+    re.IGNORECASE,
+)
+VA_PREFIX_RE = re.compile(r"^(va|various artists?)\s*[-–—]\s*", re.IGNORECASE)
+# A trailing "(Disc 2)" / "CD1" / "Vol. 3" on an album title.
+_DISC_SUFFIX_RE = re.compile(
+    r"[\s\-–—_([]+(?:cd|disc|disk|volume|vol\.?)\s*\d+\s*[)\]]?\s*$",
+    re.IGNORECASE,
+)
+
+
+def is_va_folder(distinct_artists: int, n_tracks: int) -> bool:
+    """Whether a folder qualifies as various-artists by the count thresholds."""
+    if n_tracks <= 0:
+        return False
+    return (
+        distinct_artists >= VA_MIN_DISTINCT_ARTISTS
+        and (distinct_artists / n_tracks) >= VA_MIN_ARTIST_UNIQUENESS
+    )
+
+
+def compilation_title(folder: str) -> Optional[str]:
+    """Album title for a V/A folder, or None if it's a generic dump.
+
+    A folder explicitly marked ``VA -`` / ``Various Artists -`` is a declared
+    compilation and bypasses the generic-dump heuristic.
+    """
+    name = os.path.basename(folder).strip()
+    title = VA_PREFIX_RE.sub("", name).strip()
+    explicit_va = title != name
+    if not title:
+        return None
+    if not explicit_va and GENERIC_FOLDER_RE.match(title):
+        return None
+    if BARE_DISC_RE.match(title):
+        parent = os.path.basename(os.path.dirname(folder)).strip()
+        title = f"{parent} {title}".strip() if parent else title
+    return title or None
+
+
+def strip_artist_prefix(title: str, artist_name: str) -> str:
+    """Drop a leading artist name from a title (``Ratatat Remixes`` ->
+    ``Remixes``). Only at a separator/word boundary, so ``AB`` does not
+    corrupt ``ABBA Gold``."""
+    if title.lower().startswith(artist_name.lower()):
+        rest = title[len(artist_name):]
+        if not rest or rest[0] in " -–—":
+            return rest.lstrip(" -–—") or title
+    return title
+
+
+def strip_disc_suffix(title: str) -> str:
+    """Remove a trailing disc/volume marker so multi-disc-tagged sets share an
+    album key (``Album (Disc 1)`` and ``Album (Disc 2)`` -> ``Album``)."""
+    if not title:
+        return title
+    return _DISC_SUFFIX_RE.sub("", title).strip() or title

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
@@ -84,3 +84,63 @@ def strip_disc_suffix(title: str) -> str:
     if not title:
         return title
     return _DISC_SUFFIX_RE.sub("", title).strip() or title
+
+
+# --- title normalization (deterministic cleanup of a local title) -----------
+# Album titles are always locally derived (MusicBrainz never sets a title), so
+# this is a safe cleanup of folder/tag junk, not a competing title source.
+
+_BRACKET_TAG_RE = re.compile(r"^\s*\{[^}]*\}\s*")          # "{uaoa}Foo"
+_YEAR_PREFIX_RE = re.compile(r"^\s*(?:19|20)\d{2}\s*[.\-–—]\s*")  # "1993. Foo"
+_SOURCE_TAIL_RE = re.compile(
+    r"\s*[-–—]{1,3}\s*(?:jamendo|beatport|bandcamp|soundcloud)\b.*$", re.I)
+_DIGITS_TAIL_RE = re.compile(r"\s*[-–—]\s*\d{5,}\s*$")     # "… - 500604904"
+_FORMAT_TAIL_RE = re.compile(
+    r"\s*[-–—\[(]*\s*(?:mp3|flac|wav|web|webm|ogg|aac|hi-?res)\s*[)\]]*\s*$", re.I)
+_TRAILING_PAREN_RE = re.compile(r"\s*[([]([^()\[\]]*)[)\]]\s*$")
+
+_CATALOG_DIGITS_RE = re.compile(r"\d{5,}")
+_FORMAT_TOKEN_RE = re.compile(
+    r"\b(?:mp3|flac|wav|web|webm|ogg|aac|hi-?res|\d{2,3}-\d{2,3}|"
+    r"\d{2,3}\s?khz|\d{2,3}\s?bit)\b", re.I)
+# Parentheticals that are meaningful and must be kept.
+_DESCRIPTIVE_RE = re.compile(
+    r"\b(soundtrack|ost|live|remaster(?:ed)?|deluxe|anniversary|edition|"
+    r"remix(?:es)?|acoustic|mono|stereo|demo|bonus|expanded|special|single|"
+    r"ep|explicit|instrumental|reissue|collector'?s|complete|sessions?|"
+    r"unplugged|original|volume|vol\.?|part|disc|disk|cd)\b", re.I)
+
+
+def _is_catalog_paren(contents: str) -> bool:
+    """True for a pressing/catalog parenthetical (strip), False for a
+    descriptive one like (Soundtrack) / (Remastered) / a bare year (keep)."""
+    c = contents.strip()
+    if not c or _DESCRIPTIVE_RE.search(c):
+        return False
+    if re.fullmatch(r"(?:19|20)\d{2}", c):   # a bare year -> keep
+        return False
+    if _CATALOG_DIGITS_RE.search(c) or _FORMAT_TOKEN_RE.search(c):
+        return True
+    # "Label CAT123, Country" shape: has a comma and an uppercase label token.
+    return "," in c and bool(re.search(r"[A-Z]{2,}", c))
+
+
+def normalize_album_title(title: str) -> str:
+    """Strip folder/tag junk from a title: leading bracket tag + year prefix,
+    trailing source/format/catalog tokens and catalog parentheticals. Keeps
+    descriptive parentheticals and disc/volume markers. Returns the original
+    if cleanup would empty it."""
+    if not title:
+        return title
+    t = _BRACKET_TAG_RE.sub("", title.strip())
+    t = _YEAR_PREFIX_RE.sub("", t)
+    t = _SOURCE_TAIL_RE.sub("", t)
+    for _ in range(3):  # peel a few trailing catalog parentheticals
+        m = _TRAILING_PAREN_RE.search(t)
+        if not m or not _is_catalog_paren(m.group(1)):
+            break
+        t = t[: m.start()].rstrip()
+    t = _FORMAT_TAIL_RE.sub("", t)
+    t = _DIGITS_TAIL_RE.sub("", t)
+    t = t.strip(" -–—_.,/\t")
+    return t or title

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/cluster_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/cluster_db.py
@@ -1,0 +1,152 @@
+"""Data access for album_cluster, membership_constraint and entity_id_alias."""
+
+import os
+from contextlib import asynccontextmanager
+from typing import Any, Dict, List, Optional
+
+import aiosqlite
+
+from ..config_model import LocalFilesConfig
+from ..worker_utils import retry_db_locked
+
+
+@retry_db_locked
+class AsyncClusterDb:
+    """Reads/writes the Phase-1 clustering tables."""
+
+    def __init__(self, config: LocalFilesConfig):
+        self.db_path = os.path.expanduser(config.db_path)
+
+    def _get_connection(self):
+        return aiosqlite.connect(self.db_path, timeout=5.0)
+
+    @asynccontextmanager
+    async def _open(self):
+        async with self._get_connection() as conn:
+            await conn.execute("PRAGMA journal_mode=WAL")
+            await conn.execute("PRAGMA busy_timeout=5000")
+            yield conn
+
+    # -- id aliases ----------------------------------------------------------
+
+    async def resolve_id(self, entity_id: str) -> str:
+        """Return the current id for a (possibly aliased) id. One hop —
+        aliases are flattened on write."""
+        async with self._open() as conn:
+            cur = await conn.execute(
+                "SELECT current_id FROM entity_id_alias WHERE old_id = ?",
+                (entity_id,),
+            )
+            row = await cur.fetchone()
+            return row[0] if row else entity_id
+
+    async def add_alias(
+        self, old_id: str, current_id: str, entity_type: str
+    ) -> None:
+        """Redirect ``old_id`` to ``current_id``, keeping the table single-hop.
+
+        If ``current_id`` is itself aliased, the new row points at the final
+        target; existing aliases that pointed at ``old_id`` are repointed to
+        that target too. So A->B then merge(B into C) leaves both A and B
+        pointing directly at C.
+        """
+        if old_id == current_id:
+            return
+        async with self._open() as conn:
+            cur = await conn.execute(
+                "SELECT current_id FROM entity_id_alias WHERE old_id = ?",
+                (current_id,),
+            )
+            row = await cur.fetchone()
+            target = row[0] if row else current_id
+            await conn.execute(
+                "UPDATE entity_id_alias SET current_id = ? WHERE current_id = ?",
+                (target, old_id),
+            )
+            await conn.execute(
+                "INSERT OR REPLACE INTO entity_id_alias "
+                "(old_id, current_id, entity_type) VALUES (?, ?, ?)",
+                (old_id, target, entity_type),
+            )
+            await conn.commit()
+
+    # -- clusters ------------------------------------------------------------
+
+    async def get_cluster(self, album_id: str) -> Optional[Dict[str, Any]]:
+        async with self._open() as conn:
+            conn.row_factory = aiosqlite.Row
+            cur = await conn.execute(
+                "SELECT * FROM album_cluster WHERE album_id = ?", (album_id,)
+            )
+            row = await cur.fetchone()
+            return dict(row) if row else None
+
+    async def upsert_cluster(
+        self,
+        album_id: str,
+        primary_folder: str,
+        grouping_conf: float = 1.0,
+        grouping_basis: Optional[str] = None,
+        kind: Optional[str] = None,
+        needs_review: bool = False,
+        review_reason: Optional[str] = None,
+        bump_generation: bool = False,
+    ) -> None:
+        """Create or update a cluster row. ``generation`` is incremented on an
+        update when ``bump_generation`` is set (a re-cluster, for hysteresis)."""
+        gen_clause = (
+            "generation = album_cluster.generation + 1"
+            if bump_generation
+            else "generation = album_cluster.generation"
+        )
+        async with self._open() as conn:
+            await conn.execute(
+                f"""
+                INSERT INTO album_cluster
+                    (album_id, primary_folder, grouping_conf, grouping_basis,
+                     kind, generation, needs_review, review_reason)
+                VALUES (?, ?, ?, ?, ?, 0, ?, ?)
+                ON CONFLICT(album_id) DO UPDATE SET
+                    primary_folder = excluded.primary_folder,
+                    grouping_conf  = excluded.grouping_conf,
+                    grouping_basis = excluded.grouping_basis,
+                    kind           = excluded.kind,
+                    needs_review   = excluded.needs_review,
+                    review_reason  = excluded.review_reason,
+                    {gen_clause}
+                """,
+                (
+                    album_id,
+                    primary_folder,
+                    grouping_conf,
+                    grouping_basis,
+                    kind,
+                    int(needs_review),
+                    review_reason,
+                ),
+            )
+            await conn.commit()
+
+    async def delete_cluster(self, album_id: str) -> None:
+        async with self._open() as conn:
+            await conn.execute(
+                "DELETE FROM album_cluster WHERE album_id = ?", (album_id,)
+            )
+            await conn.commit()
+
+    # -- membership constraints ---------------------------------------------
+
+    async def get_constraints_for_tracks(
+        self, track_ids: List[str]
+    ) -> List[Dict[str, Any]]:
+        if not track_ids:
+            return []
+        placeholders = ", ".join("?" for _ in track_ids)
+        async with self._open() as conn:
+            conn.row_factory = aiosqlite.Row
+            cur = await conn.execute(
+                f"SELECT * FROM membership_constraint WHERE track_id "
+                f"IN ({placeholders})",
+                track_ids,
+            )
+            return [dict(r) for r in await cur.fetchall()]

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/engine.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/engine.py
@@ -1,0 +1,74 @@
+"""Folder-partition engine (§5.3).
+
+Decides how many local albums a folder holds. The default is one; a split
+happens only on compelling evidence (a folder that partitions into substantial
+subgroups which the signal scorer judges as genuinely distinct). Minority
+tag/art outliers are absorbed rather than split off.
+
+Pure over ``TrackFeatures`` — no DB, no config.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from .signals import TrackFeatures, pair_signal_score
+
+
+@dataclass
+class PartitionResult:
+    groups: List[List[TrackFeatures]]
+    split: bool = False
+    # Why a split happened / why not — for grouping_basis.
+    basis: Dict[str, object] = field(default_factory=dict)
+
+
+def partition_folder(tracks: List[TrackFeatures]) -> PartitionResult:
+    """Partition one folder's tracks into album clusters.
+
+    The album tag is the only axis that *proposes* a split — tracks bucket by
+    normalized album tag (untagged tracks share one bucket). Buckets are then
+    agglomeratively merged while the best pair still scores >= 0, so a split
+    survives only between buckets the signal scorer judges genuinely distinct
+    (different art, colliding track numbers with distinct complete runs,
+    different album-artist, disjoint disc sequences). Tag-only variance scores
+    non-negative and merges, and a mistagged outlier with no distinct art or
+    own sequence is absorbed into the majority.
+    """
+    n = len(tracks)
+    if n <= 1:
+        return PartitionResult(groups=[list(tracks)])
+
+    buckets: Dict[Optional[str], List[TrackFeatures]] = defaultdict(list)
+    for t in tracks:
+        buckets[t.album_key].append(t)
+
+    groups = [list(g) for g in buckets.values()]
+    if len(groups) == 1:
+        return PartitionResult(groups=groups)  # one tag (or all untagged)
+
+    while len(groups) > 1:
+        best = None  # (score, i, j)
+        for i in range(len(groups)):
+            for j in range(i + 1, len(groups)):
+                s = pair_signal_score(groups[i], groups[j])[0]
+                if best is None or s > best[0]:
+                    best = (s, i, j)
+        if best is None or best[0] < 0:
+            break  # every remaining pair is compelling split evidence
+        _, i, j = best
+        groups[i].extend(groups[j])
+        del groups[j]
+
+    split = len(groups) > 1
+    return PartitionResult(
+        groups=groups,
+        split=split,
+        basis={
+            "reason": "multi_album_split" if split else "single_album",
+            "tag_buckets": len(buckets),
+            "final_groups": len(groups),
+        },
+    )

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/identity.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/identity.py
@@ -1,0 +1,87 @@
+"""Stable album-id assignment for a re-cluster.
+
+A cluster keeps an existing album id when it holds the plurality (>= half) of
+that album's current members — so a re-cluster of an unchanged library is a
+semantic no-op and artwork/playlist references survive. Retired ids are
+aliased to their successor. Genuinely new clusters get a mint that is stable
+across runs for the same membership.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter, defaultdict
+from typing import Dict, List, Tuple
+
+from .planner import ClusterPlan
+
+_SENTINELS = ("unknown_album", "")
+
+
+def _mint(cluster: ClusterPlan) -> str:
+    payload = (cluster.folder + "\0" + "|".join(sorted(cluster.track_ids)))
+    return f"album_{hashlib.md5(payload.encode('utf-8')).hexdigest()[:16]}"
+
+
+def assign_stable_ids(
+    clusters: List[ClusterPlan],
+    current_album_of: Dict[str, str],
+) -> Tuple[List[str], List[Tuple[str, str]]]:
+    """Return (album_id per cluster, [(old_id, new_id)] aliases).
+
+    ``current_album_of`` maps track_id -> its current album_id.
+    """
+    track_cluster: Dict[str, int] = {}
+    for ci, c in enumerate(clusters):
+        for tid in c.track_ids:
+            track_cluster[tid] = ci
+
+    # For each old album, how many of its current members landed in each cluster.
+    old_counts: Dict[str, Counter] = defaultdict(Counter)
+    old_totals: Counter = Counter()
+    for tid, old in current_album_of.items():
+        ci = track_cluster.get(tid)
+        if ci is not None:
+            old_counts[old][ci] += 1
+            old_totals[old] += 1
+
+    # Each non-sentinel old album is claimed by its plurality cluster, but only
+    # if that cluster holds >= half of the album's members (overlap guard).
+    # Resolve greedily by overlap so a bigger claim wins a contested cluster.
+    candidates: List[Tuple[int, str, int]] = []
+    for old, counts in old_counts.items():
+        if old in _SENTINELS:
+            continue
+        ci, n = counts.most_common(1)[0]
+        if n / old_totals[old] >= 0.5:
+            candidates.append((n, old, ci))
+    candidates.sort(key=lambda x: (-x[0], x[1]))
+
+    cluster_claim: Dict[int, str] = {}
+    used_old: set = set()
+    for n, old, ci in candidates:
+        if ci in cluster_claim or old in used_old:
+            continue
+        cluster_claim[ci] = old
+        used_old.add(old)
+
+    ids: List[str] = []
+    for ci, c in enumerate(clusters):
+        if c.kind == "singles_pool":
+            ids.append("unknown_album")
+        elif ci in cluster_claim:
+            ids.append(cluster_claim[ci])
+        else:
+            ids.append(_mint(c))
+
+    # Retired old ids (not kept by any cluster) alias to their dominant cluster.
+    aliases: List[Tuple[str, str]] = []
+    for old, counts in old_counts.items():
+        if old in _SENTINELS or old in used_old:
+            continue
+        ci = counts.most_common(1)[0][0]
+        new_id = ids[ci]
+        if new_id != old and new_id not in _SENTINELS:
+            aliases.append((old, new_id))
+
+    return ids, aliases

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/merge.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/merge.py
@@ -1,0 +1,79 @@
+"""Cross-folder disc-sibling merge (§5.3 merge rule).
+
+Sibling folders whose names differ only by a disc/volume suffix (``… CD1`` /
+``… CD2`` / ``… CD3`` as separate directories — the case
+``album_folder_for_path`` does *not* already collapse) are one multi-disc
+album. Bare ``CD1``/``Disc 2`` subdirs are handled upstream by
+``album_folder_for_path``; this covers disc suffixes carried in the folder
+*name*.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from typing import List
+
+from ..utils.name_utils import normalize_for_id
+from .classify import strip_disc_suffix
+from .planner import ClusterPlan
+
+
+def _merge_key(folder: str):
+    """(parent dir, disc-suffix-stripped basename) — the shared album key."""
+    parent = os.path.dirname(folder)
+    base = os.path.basename(folder.rstrip("/"))
+    return parent, normalize_for_id(strip_disc_suffix(base))
+
+
+def _compatible(clusters: List[ClusterPlan]) -> bool:
+    """Same album-artist and complementary (disjoint) disc numbers."""
+    aa = {c.albumartist_key for c in clusters if c.albumartist_key}
+    if len(aa) > 1:
+        return False
+    seen: set = set()
+    for c in clusters:
+        if c.disc_numbers & seen:
+            return False  # a disc number repeats across siblings
+        seen |= c.disc_numbers
+    return True
+
+
+def merge_disc_siblings(clusters: List[ClusterPlan]) -> List[ClusterPlan]:
+    """Fuse album clusters that are disc-siblings; pass the rest through."""
+    groups = defaultdict(list)
+    for c in clusters:
+        # Only plain albums merge; compilations/singles-pools are left alone.
+        if c.kind == "album" and c.folder:
+            groups[_merge_key(c.folder)].append(c)
+        else:
+            groups[id(c)].append(c)  # unique key -> never grouped
+
+    out: List[ClusterPlan] = []
+    for key, members in groups.items():
+        # A real disc-sibling group needs >=2 distinct folders under one parent
+        # whose stripped basenames match, and compatible disc/artist evidence.
+        distinct_folders = {m.folder for m in members}
+        if len(members) < 2 or len(distinct_folders) < 2 or not _compatible(members):
+            out.extend(members)
+            continue
+        primary = max(members, key=lambda m: len(m.track_ids))
+        track_ids: List[str] = []
+        discs: frozenset = frozenset()
+        for m in members:
+            track_ids.extend(m.track_ids)
+            discs |= m.disc_numbers
+        out.append(
+            ClusterPlan(
+                track_ids=track_ids,
+                kind="multi_disc",
+                title=strip_disc_suffix(primary.title),
+                anchor_artist_id=primary.anchor_artist_id,
+                grouping_basis={"reason": "disc_sibling_merge",
+                                "folders": sorted(distinct_folders)},
+                folder=os.path.dirname(primary.folder) or primary.folder,
+                disc_numbers=discs,
+                albumartist_key=primary.albumartist_key,
+            )
+        )
+    return out

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
@@ -1,0 +1,158 @@
+"""Turn real track + evidence rows into a per-folder cluster plan.
+
+Read-only: builds ``TrackFeatures`` from the display row plus its
+``track_evidence``, runs the partition engine, and classifies each resulting
+group (album / compilation / singles_pool). It proposes assignments; applying
+them (album_id reassignment, album_cluster writes) is a later step.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+from ..utils.name_utils import clean_display_name, normalize_for_id
+from .classify import VARIOUS_ARTISTS_ID, compilation_title, is_va_folder, strip_disc_suffix
+from .engine import partition_folder
+from .signals import TrackFeatures
+
+# Tag names for the same concept across ID3 (MP3) and Vorbis (FLAC).
+_ALBUM_TAGS = ("album", "TALB")
+_ALBUMARTIST_TAGS = ("albumartist", "album artist", "TPE2")
+_COMPILATION_TAGS = ("compilation", "TCMP")
+
+
+def _loads(s: Optional[str]) -> Dict:
+    if not s:
+        return {}
+    try:
+        return json.loads(s)
+    except (ValueError, TypeError):
+        return {}
+
+
+def _tag(raw: Dict, *keys: str) -> Optional[str]:
+    for k in keys:
+        if k in raw:
+            v = raw[k]
+            v = v[0] if isinstance(v, list) else v
+            if v not in (None, ""):
+                return str(v)
+    return None
+
+
+def _album_display(raw: Dict) -> Optional[str]:
+    album = _tag(raw, *_ALBUM_TAGS)
+    return clean_display_name(album) if album else None
+
+
+def build_features(track: Dict, evidence: Optional[Dict]) -> TrackFeatures:
+    """Assemble the scorer's per-track features from a track row + evidence."""
+    evidence = evidence or {}
+    raw = _loads(evidence.get("raw_tags"))
+    stream = _loads(evidence.get("stream_info"))
+    art_phash = evidence.get("art_phash")
+    cue_sheet = evidence.get("cue_sheet")
+    import_batch = evidence.get("import_batch")
+
+    album_display = _album_display(raw)
+    # Album key: normalized, disc-suffix stripped so "X (Disc 1)"/"X (Disc 2)"
+    # share a bucket and are distinguished by disc_number within the cluster.
+    album_key = None
+    if album_display:
+        album_key = normalize_for_id(strip_disc_suffix(album_display)) or None
+
+    albumartist = _tag(raw, *_ALBUMARTIST_TAGS)
+    albumartist_key = normalize_for_id(albumartist) if albumartist else None
+    compilation = (_tag(raw, *_COMPILATION_TAGS) or "").strip() in ("1", "true", "True")
+
+    stream_key = None
+    if stream:
+        stream_key = (
+            f"{stream.get('codec')}|{stream.get('sample_rate')}|"
+            f"{stream.get('bits_per_sample')}"
+        )
+
+    return TrackFeatures(
+        track_id=track["id"],
+        album_key=album_key,
+        albumartist_key=albumartist_key,
+        artist_key=track.get("artist_id"),
+        track_number=track.get("track_number"),
+        disc_number=track.get("disc_number"),
+        art_phash=art_phash,
+        stream_key=stream_key,
+        compilation=compilation,
+        cue_sheet=cue_sheet,
+        import_batch=import_batch,
+    )
+
+
+@dataclass
+class ClusterPlan:
+    track_ids: List[str]
+    kind: str                       # album | compilation | singles_pool
+    title: str                      # "" for singles_pool (stays unknown_album)
+    anchor_artist_id: str
+    grouping_basis: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class FolderPlan:
+    folder: str
+    clusters: List[ClusterPlan]
+    split: bool = False
+
+
+def _dominant(values) -> Optional[str]:
+    vals = [v for v in values if v]
+    return Counter(vals).most_common(1)[0][0] if vals else None
+
+
+def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderPlan:
+    """Plan the clusters for one folder from (track_row, evidence_row) pairs."""
+    features = [build_features(t, e) for t, e in rows]
+    display_by_id = {
+        t["id"]: (t, _album_display(_loads((e or {}).get("raw_tags"))))
+        for t, e in rows
+    }
+
+    result = partition_folder(features)
+    clusters: List[ClusterPlan] = []
+    for group in result.groups:
+        ids = [f.track_id for f in group]
+        member_tracks = [display_by_id[i][0] for i in ids]
+        real_artists = {
+            t.get("artist_id")
+            for t in member_tracks
+            if t.get("artist_id") and t.get("artist_id") != "unknown_artist"
+        }
+
+        if is_va_folder(len(real_artists), len(ids)):
+            comp = compilation_title(folder)
+            if comp is None:
+                # A generic dump — leave tracks loose (unknown_album), no album.
+                clusters.append(
+                    ClusterPlan(ids, "singles_pool", "", "unknown_artist",
+                                {"reason": "generic_dump"})
+                )
+                continue
+            clusters.append(
+                ClusterPlan(ids, "compilation", comp, VARIOUS_ARTISTS_ID,
+                            {"reason": "va_compilation"})
+            )
+            continue
+
+        # A normal album: title from tag consensus, else the folder name so an
+        # untagged rip still gets a real album (today it falls to unknown_album).
+        titles = [display_by_id[i][1] for i in ids]
+        title = _dominant(titles) or os.path.basename(folder.rstrip("/")) or ""
+        anchor = _dominant(t.get("artist_id") for t in member_tracks) or "unknown_artist"
+        clusters.append(
+            ClusterPlan(ids, "album", title, anchor, dict(result.basis))
+        )
+
+    return FolderPlan(folder=folder, clusters=clusters, split=result.split)

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
@@ -15,7 +15,13 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
 from ..utils.name_utils import clean_display_name, normalize_for_id
-from .classify import VARIOUS_ARTISTS_ID, compilation_title, is_va_folder, strip_disc_suffix
+from .classify import (
+    VARIOUS_ARTISTS_ID,
+    compilation_title,
+    is_va_folder,
+    normalize_album_title,
+    strip_disc_suffix,
+)
 from .engine import partition_folder
 from .signals import TrackFeatures
 
@@ -148,8 +154,9 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
                 )
                 continue
             clusters.append(
-                ClusterPlan(ids, "compilation", comp, VARIOUS_ARTISTS_ID,
-                            {"reason": "va_compilation"}, folder, discs, aa_key)
+                ClusterPlan(ids, "compilation", normalize_album_title(comp),
+                            VARIOUS_ARTISTS_ID, {"reason": "va_compilation"},
+                            folder, discs, aa_key)
             )
             continue
 
@@ -168,6 +175,7 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
         if len(raw_titles) >= 2 and len({strip_disc_suffix(t) for t in raw_titles}) == 1:
             title = strip_disc_suffix(title)
             kind = "multi_disc"
+        title = normalize_album_title(title)
 
         clusters.append(
             ClusterPlan(ids, kind, title, anchor, dict(result.basis),

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
@@ -158,8 +158,19 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
         titles = [display_by_id[i][1] for i in ids]
         title = _dominant(titles) or os.path.basename(folder.rstrip("/")) or ""
         anchor = _dominant(t.get("artist_id") for t in member_tracks) or "unknown_artist"
+
+        # Multi-disc-in-one-folder: if the members' titles differ *only* by a
+        # disc suffix (e.g. "… (Disc 1)" / "… (Disc 2)"), it is one album — drop
+        # the suffix and mark it multi_disc. A standalone "… Vol. 2" (a single
+        # title variant) is left intact, so real volumed releases keep their name.
+        kind = "album"
+        raw_titles = {t for t in titles if t}
+        if len(raw_titles) >= 2 and len({strip_disc_suffix(t) for t in raw_titles}) == 1:
+            title = strip_disc_suffix(title)
+            kind = "multi_disc"
+
         clusters.append(
-            ClusterPlan(ids, "album", title, anchor, dict(result.basis),
+            ClusterPlan(ids, kind, title, anchor, dict(result.basis),
                         folder, discs, aa_key)
         )
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
@@ -94,10 +94,13 @@ def build_features(track: Dict, evidence: Optional[Dict]) -> TrackFeatures:
 @dataclass
 class ClusterPlan:
     track_ids: List[str]
-    kind: str                       # album | compilation | singles_pool
+    kind: str                       # album | compilation | singles_pool | multi_disc
     title: str                      # "" for singles_pool (stays unknown_album)
     anchor_artist_id: str
     grouping_basis: Dict[str, object] = field(default_factory=dict)
+    folder: str = ""
+    disc_numbers: frozenset = field(default_factory=frozenset)
+    albumartist_key: Optional[str] = None
 
 
 @dataclass
@@ -114,6 +117,8 @@ def _dominant(values) -> Optional[str]:
 
 def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderPlan:
     """Plan the clusters for one folder from (track_row, evidence_row) pairs."""
+    if not rows:
+        return FolderPlan(folder=folder, clusters=[], split=False)
     features = [build_features(t, e) for t, e in rows]
     display_by_id = {
         t["id"]: (t, _album_display(_loads((e or {}).get("raw_tags"))))
@@ -130,6 +135,8 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
             for t in member_tracks
             if t.get("artist_id") and t.get("artist_id") != "unknown_artist"
         }
+        discs = frozenset(f.disc_number for f in group if f.disc_number)
+        aa_key = _dominant(f.albumartist_key for f in group)
 
         if is_va_folder(len(real_artists), len(ids)):
             comp = compilation_title(folder)
@@ -137,12 +144,12 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
                 # A generic dump — leave tracks loose (unknown_album), no album.
                 clusters.append(
                     ClusterPlan(ids, "singles_pool", "", "unknown_artist",
-                                {"reason": "generic_dump"})
+                                {"reason": "generic_dump"}, folder, discs, aa_key)
                 )
                 continue
             clusters.append(
                 ClusterPlan(ids, "compilation", comp, VARIOUS_ARTISTS_ID,
-                            {"reason": "va_compilation"})
+                            {"reason": "va_compilation"}, folder, discs, aa_key)
             )
             continue
 
@@ -152,7 +159,8 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
         title = _dominant(titles) or os.path.basename(folder.rstrip("/")) or ""
         anchor = _dominant(t.get("artist_id") for t in member_tracks) or "unknown_artist"
         clusters.append(
-            ClusterPlan(ids, "album", title, anchor, dict(result.basis))
+            ClusterPlan(ids, "album", title, anchor, dict(result.basis),
+                        folder, discs, aa_key)
         )
 
     return FolderPlan(folder=folder, clusters=clusters, split=result.split)

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/signals.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/signals.py
@@ -137,6 +137,10 @@ def pair_signal_score(
     b_seq = sequence_analysis([t.track_number for t in b])
     joint_seq = sequence_analysis([t.track_number for t in a + b])
 
+    # "Tags differ" means both are present and distinct — a tagged-vs-untagged
+    # pair is not a tag conflict.
+    tags_differ = bool(a_album) and bool(b_album) and a_album != b_album
+
     if a_cue and a_cue == b_cue:
         fire("same_cue_sheet")
 
@@ -155,11 +159,10 @@ def pair_signal_score(
 
     if a_album and a_album == b_album:
         fire("same_album_tag")
-    elif a_album and b_album and a_album != b_album:
+    elif tags_differ and a_seq.is_plausible and b_seq.is_plausible:
         # Two distinct album tags that each stand on their own complete
         # sequence — the "two albums in one folder" signature.
-        if a_seq.is_plausible and b_seq.is_plausible:
-            fire("different_album_tags_both_sequences")
+        fire("different_album_tags_both_sequences")
 
     if a_aa and a_aa == b_aa:
         fire("same_albumartist")
@@ -176,13 +179,13 @@ def pair_signal_score(
         and a_discs.isdisjoint(b_discs)
         and a_seq.is_plausible
         and b_seq.is_plausible
-        and a_album != b_album
+        and tags_differ
     ):
         fire("disjoint_disc_sequences")
 
     if a_stream and a_stream == b_stream:
         fire("same_stream")
-    elif a_stream and b_stream and a_stream != b_stream and a_album != b_album:
+    elif a_stream and b_stream and a_stream != b_stream and tags_differ:
         fire("stream_mismatch_with_tag_split")
 
     if a_batch and a_batch == b_batch:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/signals.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/signals.py
@@ -1,0 +1,191 @@
+"""Membership signals — the evidence vocabulary for "do these tracks belong
+to the same local album".
+
+Pure functions over ``TrackFeatures``. They are not evaluated per track pair:
+the folder pass forms candidate subgroups first and only scores between two
+subgroups when a split is plausible. Positive score favours one album,
+negative favours a split.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+# Signal weights (§5.2). Positive favours "same album", negative favours split.
+WEIGHTS: Dict[str, int] = {
+    "same_cue_sheet": 6,
+    "same_art": 3,
+    "compatible_track_numbers": 2,
+    "same_album_tag": 2,
+    "same_albumartist": 2,
+    "same_stream": 1,
+    "same_import_batch": 1,
+    "track_number_collision": -3,
+    "different_art": -3,
+    "different_album_tags_both_sequences": -3,
+    "different_albumartist": -2,
+    "disjoint_disc_sequences": -2,
+    "stream_mismatch_with_tag_split": -1,
+}
+
+# Max Hamming distance (of a 64-bit dHash) for two covers to count as "same".
+ART_SAME_MAX_HAMMING = 8
+# Min distance for two covers to count as "clearly different".
+ART_DIFF_MIN_HAMMING = 22
+
+
+@dataclass
+class TrackFeatures:
+    """The per-track evidence the scorer reads (built by the engine in 1c)."""
+
+    track_id: str
+    album_key: Optional[str] = None       # normalized album tag
+    albumartist_key: Optional[str] = None
+    artist_key: Optional[str] = None
+    track_number: Optional[int] = None
+    disc_number: Optional[int] = None
+    art_phash: Optional[str] = None
+    stream_key: Optional[str] = None      # codec|sr|bitdepth
+    compilation: bool = False
+    cue_sheet: Optional[str] = None
+    import_batch: Optional[str] = None
+
+
+@dataclass
+class SequenceAnalysis:
+    numbers: List[int] = field(default_factory=list)
+    has_collision: bool = False
+    is_plausible: bool = False   # covers >=60% of a contiguous 1..max run, >=4
+
+
+def hamming_hex(a: str, b: str) -> int:
+    """Hamming distance between two equal-length hex strings (bit count)."""
+    return bin(int(a, 16) ^ int(b, 16)).count("1")
+
+
+def _dominant(values) -> Optional[str]:
+    vals = [v for v in values if v]
+    if not vals:
+        return None
+    return Counter(vals).most_common(1)[0][0]
+
+
+def sequence_analysis(numbers: List[Optional[int]]) -> SequenceAnalysis:
+    """Analyse a set of track numbers for collisions and plausible ordering."""
+    present = [n for n in numbers if n is not None and n > 0]
+    if not present:
+        return SequenceAnalysis()
+    counts = Counter(present)
+    has_collision = any(c > 1 for c in counts.values())
+    top = max(present)
+    distinct = len(counts)
+    # Plausible if it looks like a real 1..n run: at least 4 tracks and the
+    # distinct numbers cover >=60% of the 1..max range with no collisions.
+    is_plausible = (
+        not has_collision
+        and distinct >= 4
+        and top > 0
+        and distinct / top >= 0.6
+    )
+    return SequenceAnalysis(
+        numbers=sorted(present),
+        has_collision=has_collision,
+        is_plausible=is_plausible,
+    )
+
+
+def _art_relation(a: List[TrackFeatures], b: List[TrackFeatures]) -> Optional[str]:
+    """"same" / "different" / None from the closest cross-subgroup cover pair."""
+    pa = [t.art_phash for t in a if t.art_phash]
+    pb = [t.art_phash for t in b if t.art_phash]
+    if not pa or not pb:
+        return None
+    best = min(hamming_hex(x, y) for x in pa for y in pb)
+    if best <= ART_SAME_MAX_HAMMING:
+        return "same"
+    if best >= ART_DIFF_MIN_HAMMING:
+        return "different"
+    return None
+
+
+def pair_signal_score(
+    a: List[TrackFeatures], b: List[TrackFeatures]
+) -> Tuple[int, Dict[str, int]]:
+    """Signed weighted evidence that subgroups ``a`` and ``b`` are one album.
+
+    Returns (score, basis) where basis maps each fired signal to its weight.
+    """
+    basis: Dict[str, int] = {}
+
+    def fire(name: str) -> None:
+        basis[name] = WEIGHTS[name]
+
+    a_album = _dominant(t.album_key for t in a)
+    b_album = _dominant(t.album_key for t in b)
+    a_aa = _dominant(t.albumartist_key for t in a)
+    b_aa = _dominant(t.albumartist_key for t in b)
+    a_cue = _dominant(t.cue_sheet for t in a)
+    b_cue = _dominant(t.cue_sheet for t in b)
+    a_stream = _dominant(t.stream_key for t in a)
+    b_stream = _dominant(t.stream_key for t in b)
+    a_batch = _dominant(t.import_batch for t in a)
+    b_batch = _dominant(t.import_batch for t in b)
+
+    a_seq = sequence_analysis([t.track_number for t in a])
+    b_seq = sequence_analysis([t.track_number for t in b])
+    joint_seq = sequence_analysis([t.track_number for t in a + b])
+
+    if a_cue and a_cue == b_cue:
+        fire("same_cue_sheet")
+
+    art = _art_relation(a, b)
+    if art == "same":
+        fire("same_art")
+    elif art == "different":
+        fire("different_art")
+
+    # Track numbers: a collision across the union (two "track 4"s) is split
+    # evidence; a clean joint run is cohesion evidence.
+    if joint_seq.has_collision:
+        fire("track_number_collision")
+    elif joint_seq.is_plausible:
+        fire("compatible_track_numbers")
+
+    if a_album and a_album == b_album:
+        fire("same_album_tag")
+    elif a_album and b_album and a_album != b_album:
+        # Two distinct album tags that each stand on their own complete
+        # sequence — the "two albums in one folder" signature.
+        if a_seq.is_plausible and b_seq.is_plausible:
+            fire("different_album_tags_both_sequences")
+
+    if a_aa and a_aa == b_aa:
+        fire("same_albumartist")
+    elif a_aa and b_aa and a_aa != b_aa:
+        fire("different_albumartist")
+
+    # Disjoint discs each with their own run and differing tags -> multi-disc
+    # that should be handled as such rather than fused blindly.
+    a_discs = {t.disc_number for t in a if t.disc_number}
+    b_discs = {t.disc_number for t in b if t.disc_number}
+    if (
+        a_discs
+        and b_discs
+        and a_discs.isdisjoint(b_discs)
+        and a_seq.is_plausible
+        and b_seq.is_plausible
+        and a_album != b_album
+    ):
+        fire("disjoint_disc_sequences")
+
+    if a_stream and a_stream == b_stream:
+        fire("same_stream")
+    elif a_stream and b_stream and a_stream != b_stream and a_album != b_album:
+        fire("stream_mismatch_with_tag_split")
+
+    if a_batch and a_batch == b_batch:
+        fire("same_import_batch")
+
+    return sum(basis.values()), basis

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
@@ -326,6 +326,19 @@ class LocalFilesConfig(ModuleConfig):
         title="Enable file watching",
         json_schema_extra={"help": "Rescan on filesystem changes", **_SIMPLE},
     )
+    folder_first_clustering: bool = Field(
+        default=False,
+        title="Folder-first album grouping",
+        json_schema_extra={
+            "help": (
+                "Group albums from the folder and multiple signals rather than "
+                "one album tag per track, so tag variance and untagged rips no "
+                "longer fragment an album. Re-clusters the library on the next "
+                "scan."
+            ),
+            **_SIMPLE,
+        },
+    )
     quiescence_seconds: int = Field(
         default=5,
         title="Upload quiescence window",

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/config_model.py
@@ -26,9 +26,6 @@ class EmbedderClapConfig(BaseModel):
         ),
         json_schema_extra={"widget": "path"},
     )
-    dimensions: int = Field(
-        default=512, frozen=True, title="Embedding dimensions"
-    )
     current_version: int = Field(
         # v4: float32 -> int8 vectors. Keys embedding_jobs.model_version to
         # reschedule the embed jobs; independent of (and need not match)
@@ -41,25 +38,11 @@ class EmbedderClapConfig(BaseModel):
 
 
 class AiSearchConfig(BaseModel):
-    weight_clap_similarity: float = Field(
-        default=0.75, ge=0.0, le=1.0, title="CLAP similarity weight",
-    )
-    weight_popularity: float = Field(
-        default=0.10, ge=0.0, le=1.0, title="Popularity weight",
-    )
     max_results: int = Field(
         default=20, title="Max results per entity type",
     )
     knn_candidates: int = Field(
         default=50, title="KNN candidates before re-ranking",
-    )
-    fallback_coverage_threshold: float = Field(
-        default=10.0,
-        title="Fallback coverage threshold",
-        json_schema_extra={
-            "help": "Warn when less than this share of the library is indexed for AI search",
-            "constraints": {"unit": "%"},
-        },
     )
 
 
@@ -327,7 +310,7 @@ class LocalFilesConfig(ModuleConfig):
         json_schema_extra={"help": "Rescan on filesystem changes", **_SIMPLE},
     )
     folder_first_clustering: bool = Field(
-        default=False,
+        default=True,
         title="Folder-first album grouping",
         json_schema_extra={
             "help": (

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
@@ -129,6 +129,50 @@ async def init_db(db_path: str) -> None:
             """
         )
 
+        # Stable per-file identity, independent of path. A rename/move updates
+        # current_path and nothing else, so a track's id survives folder
+        # reorganisation (today's path-derived track id does not). file_id is
+        # the same value as tracks.id; move detection on rescan corroborates
+        # with (device_id, inode) and, later, content_hash/fingerprint before
+        # trusting size+mtime alone. Populated for existing rows by the
+        # backfill below; device/inode fill in on the file's next scan.
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS library_file (
+                file_id       TEXT PRIMARY KEY,
+                current_path  TEXT NOT NULL UNIQUE,
+                size_bytes    INTEGER,
+                modified_at   INTEGER,
+                device_id     TEXT,
+                inode         TEXT,
+                content_hash  TEXT,
+                first_indexed INTEGER NOT NULL
+            )
+            """
+        )
+
+        # Verbatim per-file evidence, kept as a current snapshot (upserted in
+        # place, never versioned). Holds everything the resolver/clusterer may
+        # need but the display tables don't carry: all raw tags (incl.
+        # albumartist and the compilation flag), stream characteristics, an
+        # embedded-art perceptual hash, cue-sheet membership, and a chromaprint
+        # once one is computed. track_id == library_file.file_id == tracks.id.
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS track_evidence (
+                track_id       TEXT PRIMARY KEY,
+                raw_tags       TEXT,
+                stream_info    TEXT,
+                art_phash      TEXT,
+                cue_sheet      TEXT,
+                fingerprint    TEXT,
+                fp_computed_at INTEGER,
+                import_batch   TEXT,
+                updated_at     INTEGER
+            )
+            """
+        )
+
         # Negative cache for files whose metadata could not be extracted.
         # Keyed by path + (size, mtime) so a still-uploading / partially
         # written file — which changes size or mtime between scans — keeps
@@ -342,6 +386,24 @@ async def init_db(db_path: str) -> None:
                 "ALTER TABLE albums ADD COLUMN image_generated INTEGER DEFAULT 0"
             )
             logger.info("Added albums.image_generated column")
+
+        # Backfill library_file from existing tracks so every already-indexed
+        # file has a stable identity row immediately (later phases key off it).
+        # tracks.id is currently path-derived, so it doubles as the initial
+        # file_id; current_path/size/mtime come straight across, and
+        # last_updated is the best available first_indexed for legacy rows.
+        # Idempotent: OR IGNORE skips files already present (and any duplicate
+        # current_path, which the UNIQUE constraint would otherwise reject).
+        await cursor.execute(
+            """
+            INSERT OR IGNORE INTO library_file
+                (file_id, current_path, size_bytes, modified_at, first_indexed)
+            SELECT id, file_path, file_size, modified_time,
+                   COALESCE(last_updated, ?)
+            FROM tracks
+            """,
+            (current_time,),
+        )
 
         # VA (mood) head migration (after the columns above exist). On a head
         # version change, clear stale mood so the backfill recomputes it with the

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
@@ -392,14 +392,20 @@ async def init_db(db_path: str) -> None:
         # tracks.id is currently path-derived, so it doubles as the initial
         # file_id; current_path/size/mtime come straight across, and
         # last_updated is the best available first_indexed for legacy rows.
+        # Columns are selected conditionally so a very old tracks table missing
+        # size/mtime/last_updated still backfills (those become NULL / now).
         # Idempotent: OR IGNORE skips files already present (and any duplicate
         # current_path, which the UNIQUE constraint would otherwise reject).
+        size_expr = "file_size" if "file_size" in track_cols else "NULL"
+        mtime_expr = "modified_time" if "modified_time" in track_cols else "NULL"
+        first_expr = (
+            "COALESCE(last_updated, ?)" if "last_updated" in track_cols else "?"
+        )
         await cursor.execute(
-            """
+            f"""
             INSERT OR IGNORE INTO library_file
                 (file_id, current_path, size_bytes, modified_at, first_indexed)
-            SELECT id, file_path, file_size, modified_time,
-                   COALESCE(last_updated, ?)
+            SELECT id, file_path, {size_expr}, {mtime_expr}, {first_expr}
             FROM tracks
             """,
             (current_time,),

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
@@ -129,13 +129,9 @@ async def init_db(db_path: str) -> None:
             """
         )
 
-        # Stable per-file identity, independent of path. A rename/move updates
-        # current_path and nothing else, so a track's id survives folder
-        # reorganisation (today's path-derived track id does not). file_id is
-        # the same value as tracks.id; move detection on rescan corroborates
-        # with (device_id, inode) and, later, content_hash/fingerprint before
-        # trusting size+mtime alone. Populated for existing rows by the
-        # backfill below; device/inode fill in on the file's next scan.
+        # Stable per-file identity. current_path is a mutable attribute, so a
+        # rename keeps the id. file_id == tracks.id; first_indexed is never
+        # rewritten. device/inode corroborate move detection later.
         await cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS library_file (
@@ -151,12 +147,9 @@ async def init_db(db_path: str) -> None:
             """
         )
 
-        # Verbatim per-file evidence, kept as a current snapshot (upserted in
-        # place, never versioned). Holds everything the resolver/clusterer may
-        # need but the display tables don't carry: all raw tags (incl.
-        # albumartist and the compilation flag), stream characteristics, an
-        # embedded-art perceptual hash, cue-sheet membership, and a chromaprint
-        # once one is computed. track_id == library_file.file_id == tracks.id.
+        # Verbatim per-file evidence the display tables don't carry (raw tags
+        # incl. albumartist/compilation, stream info, art hash, cue,
+        # chromaprint). Current snapshot: upserted, not versioned.
         await cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS track_evidence (
@@ -387,15 +380,10 @@ async def init_db(db_path: str) -> None:
             )
             logger.info("Added albums.image_generated column")
 
-        # Backfill library_file from existing tracks so every already-indexed
-        # file has a stable identity row immediately (later phases key off it).
-        # tracks.id is currently path-derived, so it doubles as the initial
-        # file_id; current_path/size/mtime come straight across, and
-        # last_updated is the best available first_indexed for legacy rows.
-        # Columns are selected conditionally so a very old tracks table missing
-        # size/mtime/last_updated still backfills (those become NULL / now).
-        # Idempotent: OR IGNORE skips files already present (and any duplicate
-        # current_path, which the UNIQUE constraint would otherwise reject).
+        # Backfill file identity from existing tracks (path-hash id becomes
+        # file_id; last_updated is the best first_indexed for legacy rows).
+        # Columns selected conditionally so a pre-size/mtime tracks table still
+        # migrates. Idempotent via OR IGNORE.
         size_expr = "file_size" if "file_size" in track_cols else "NULL"
         mtime_expr = "modified_time" if "modified_time" in track_cols else "NULL"
         first_expr = (

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
@@ -184,6 +184,56 @@ async def init_db(db_path: str) -> None:
             """
         )
 
+        # Per local-album-cluster grouping metadata, keyed 1:1 to an albums
+        # row. The folders a cluster occupies are derived from member tracks;
+        # primary_folder is the dominant one (display/blocking only).
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS album_cluster (
+                album_id       TEXT PRIMARY KEY,
+                primary_folder TEXT NOT NULL,
+                grouping_conf  REAL NOT NULL DEFAULT 1.0,
+                grouping_basis TEXT,
+                kind           TEXT,
+                generation     INTEGER NOT NULL DEFAULT 0,
+                needs_review   INTEGER NOT NULL DEFAULT 0,
+                review_reason  TEXT
+            )
+            """
+        )
+
+        # Durable user grouping decisions the reconciler treats as hard
+        # constraints (a relationship, not a metadata field).
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS membership_constraint (
+                id               TEXT PRIMARY KEY,
+                kind             TEXT NOT NULL,
+                track_id         TEXT NOT NULL,
+                album_id         TEXT,
+                related_track_id TEXT,
+                created_at       INTEGER NOT NULL
+            )
+            """
+        )
+
+        # Redirects a replaced id (after a cluster split/merge or a track-move)
+        # to its current one, so artwork caches, playlists and bookmarks keep
+        # resolving. Chains are flattened on write, so resolution is one hop.
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS entity_id_alias (
+                old_id      TEXT PRIMARY KEY,
+                current_id  TEXT NOT NULL,
+                entity_type TEXT NOT NULL
+            )
+            """
+        )
+        await cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_entity_id_alias_current "
+            "ON entity_id_alias(current_id)"
+        )
+
         await cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS playlists (

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
@@ -631,9 +631,8 @@ class AcoustIdPlugin(EnricherPlugin):
                 )
                 return None
 
-            # Persist the (expensive) chromaprint so a later attempt reuses it
-            # and duplicate/move detection has a signal. Best-effort: a write
-            # failure must not abort the lookup that follows.
+            # Persist the (expensive) chromaprint for reuse. Best-effort: a
+            # write failure must not abort the lookup.
             try:
                 await self.db_manager.save_fingerprint(track["id"], fingerprint)
             except Exception as e:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
@@ -631,6 +631,14 @@ class AcoustIdPlugin(EnricherPlugin):
                 )
                 return None
 
+            # Persist the (expensive) chromaprint so a later attempt reuses it
+            # and duplicate/move detection has a signal. Best-effort: a write
+            # failure must not abort the lookup that follows.
+            try:
+                await self.db_manager.save_fingerprint(track["id"], fingerprint)
+            except Exception as e:
+                logger.debug("Could not persist fingerprint: %s", e)
+
             # Look up fingerprint
             results = await asyncio.to_thread(
                 self._lookup_fingerprint, fingerprint, duration

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
@@ -9,9 +9,9 @@ import requests
 from typing import Dict, Optional, List, Tuple
 
 from ..config_model import LocalFilesConfig
-from ..utils.name_utils import album_folder_for_path, clean_display_name
+from ..utils.name_utils import clean_display_name
 from .enricher_plugin import EnricherPlugin
-from .id_generator import generate_artist_id, generate_album_id
+from .id_generator import generate_artist_id
 from .match_utils import duration_bonus
 
 
@@ -515,55 +515,6 @@ class AcoustIdPlugin(EnricherPlugin):
         await self.db_manager.insert_artist(artist_data)
         return artist_data["id"]
 
-    async def _create_or_get_album(
-        self,
-        album_title: str,
-        artist_id: Optional[str],
-        file_path: str,
-        album_mbid: Optional[str] = None,
-    ) -> Optional[str]:
-        """
-        Find album by folder+title or MBID, or create if not exists.
-
-        ``file_path`` is used to derive the album folder so quality variants
-        in sibling directories get distinct album IDs. ``artist_id`` is
-        stored on the row but no longer part of the ID key, so an album
-        with a known title and an unknown anchor artist is still useful
-        and is created as an orphan rather than dropped.
-
-        Returns:
-            Album ID, or None if the title is missing.
-        """
-        album_title = clean_display_name(album_title) if album_title else ""
-        if not album_title:
-            return None
-
-        # Try to find existing album by MBID first
-        if album_mbid:
-            existing_album = await self.db_manager.get_album_by_mbid(album_mbid)
-            if existing_album:
-                return existing_album["id"]
-
-        # Create new album (the folder-bounded ID is what disambiguates
-        # quality variants; we no longer fuzzy-match by title alone).
-        album_id = generate_album_id(album_title, album_folder_for_path(file_path))
-        existing_by_id = await self.db_manager.get_album_by_id(album_id)
-        if existing_by_id:
-            if album_mbid and not existing_by_id.get("mbid"):
-                await self.db_manager.update_album(album_id, {"mbid": album_mbid})
-            return album_id
-
-        album_data = {
-            "id": album_id,
-            "title": album_title,
-            "artist_id": artist_id or "unknown_artist",
-            "mbid": album_mbid,
-            "enriched": 0,
-            "last_updated": int(time.time()),
-        }
-
-        await self.db_manager.insert_album(album_data)
-        return album_id
 
     def can_enrich_artist(self) -> bool:
         return False  # This plugin doesn't directly enrich artists, only via track identification
@@ -709,28 +660,10 @@ class AcoustIdPlugin(EnricherPlugin):
                         )
                         changed_items["artists"].add(artist_id)
 
-                    # Create or get album if we have artist and album info
-                    if match_info.get("album_title") and artist_id:
-                        # Store original album ID to check if a new one was created
-                        original_album_id = track.get("album_id")
-
-                        album_id = await self._create_or_get_album(
-                            match_info["album_title"],
-                            artist_id,
-                            track["file_path"],
-                            match_info.get("album_mbid"),
-                        )
-
-                        if album_id:
-                            updates["album_id"] = album_id
-                            updates["album_title"] = match_info["album_title"]
-
-                            # Check if this is a newly created or different album
-                            if album_id != original_album_id:
-                                logger.debug(
-                                    f"Adding album {album_id} to changed items for further enrichment"
-                                )
-                                changed_items["albums"].add(album_id)
+            # AcoustID no longer creates albums or moves a track between them:
+            # album membership is owned by the clustering pass (§3 invariant),
+            # so a single confident fingerprint match can't fragment a
+            # coherent local album by re-pointing one track to a new album row.
 
             result = {"updates": updates}
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
@@ -46,6 +46,28 @@ class AsyncEnricherDb:
             await conn.execute("PRAGMA busy_timeout=5000")
             yield conn
 
+    async def save_fingerprint(self, track_id: str, fingerprint: str) -> None:
+        """Persist a computed chromaprint into track_evidence.
+
+        fpcalc is expensive (up to a 30 s timeout) and today the fingerprint
+        is recomputed on every AcoustID attempt. Storing it lets a re-attempt
+        reuse it and gives duplicate/move detection a signal. Upsert so it
+        works whether or not the indexer's evidence row exists yet, and only
+        touches the fingerprint columns.
+        """
+        async with self._open() as conn:
+            await conn.execute(
+                """
+                INSERT INTO track_evidence (track_id, fingerprint, fp_computed_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(track_id) DO UPDATE SET
+                    fingerprint    = excluded.fingerprint,
+                    fp_computed_at = excluded.fp_computed_at
+                """,
+                (track_id, fingerprint, int(time.time())),
+            )
+            await conn.commit()
+
     async def get_track_by_id(self, track_id: str) -> Optional[Dict]:
         """Get track information by ID"""
         async with self._open() as conn:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
@@ -47,14 +47,10 @@ class AsyncEnricherDb:
             yield conn
 
     async def save_fingerprint(self, track_id: str, fingerprint: str) -> None:
-        """Persist a computed chromaprint into track_evidence.
-
-        fpcalc is expensive (up to a 30 s timeout) and today the fingerprint
-        is recomputed on every AcoustID attempt. Storing it lets a re-attempt
-        reuse it and gives duplicate/move detection a signal. Upsert so it
-        works whether or not the indexer's evidence row exists yet, and only
-        touches the fingerprint columns.
-        """
+        """Persist a computed chromaprint (upsert; only the fingerprint
+        columns, and works whether or not the evidence row exists yet).
+        fpcalc is expensive and was recomputed every attempt; storing it lets
+        a retry reuse it and feeds duplicate/move detection."""
         async with self._open() as conn:
             await conn.execute(
                 """

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
@@ -1,12 +1,15 @@
 import logging
 import os
-import re
 import time
 from pathlib import Path
 from typing import Dict, Optional
 
 from ..config_model import LocalFilesConfig
-from ..utils.name_utils import album_folder_for_path, clean_display_name
+from ..utils.name_utils import (
+    TRACK_NUMBER_PREFIX_PATTERNS,
+    album_folder_for_path,
+    clean_display_name,
+)
 from .enricher_plugin import EnricherPlugin
 from .id_generator import generate_artist_id, generate_album_id
 
@@ -61,12 +64,9 @@ class FilesystemFallbackPlugin(EnricherPlugin):
             str(Path(folder).expanduser().resolve()) for folder in config.music_folders
         ]
 
-        # Track number regex patterns
-        self.track_number_patterns = [
-            r"^(\d+)\.?\s+",  # "1. " or "1 " or "1."
-            r"^(\d+)-\s+",  # "1- "
-            r"^(\d+)_\s+",  # "1_ "
-        ]
+        # Track-number prefix patterns are shared with the indexer (which now
+        # parses them at scan time too) so the two never disagree.
+        self.track_number_patterns = TRACK_NUMBER_PREFIX_PATTERNS
 
         # Per-folder V/A determination, cached for the lifetime of the
         # plugin instance so we don't re-query the DB for every track.
@@ -104,7 +104,7 @@ class FilesystemFallbackPlugin(EnricherPlugin):
 
         # First, try to extract track number if present
         for pattern in self.track_number_patterns:
-            match = re.match(pattern, filename)
+            match = pattern.match(filename)
             if match:
                 try:
                     track_number = int(match.group(1))

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
@@ -44,7 +44,8 @@ class FilesystemFallbackPlugin(EnricherPlugin):
     This plugin does NOT set the "enriched" flag to allow other plugins to re-check the data.
     """
 
-    ENRICHER_VERSION = 1
+    # v2: no-space "N.Title" prefix pattern + stem-echo title guard.
+    ENRICHER_VERSION = 2
 
     # Match the indexer's V/A detection criteria
     # (``orphan_va_folder_tracks``). Filesystem fallback skips album
@@ -443,10 +444,15 @@ class FilesystemFallbackPlugin(EnricherPlugin):
         updates = {}
         changed_items = {"artists": set(), "albums": set()}
 
-        # Handle track title
+        # Handle track title. A title equal to the basename OR its stem is
+        # still just a filename echo (a prior pass may have stripped only the
+        # extension), so a re-run can keep improving it — e.g. dropping a
+        # "1."-prefix once the number patterns learn to match it.
         current_title = track.get("title", "")
-        if not current_title or current_title == os.path.basename(track["file_path"]):
-            if fs_metadata.get("title"):
+        basename = os.path.basename(track["file_path"])
+        stem = os.path.splitext(basename)[0]
+        if not current_title or current_title in (basename, stem):
+            if fs_metadata.get("title") and fs_metadata["title"] != current_title:
                 updates["title"] = fs_metadata["title"]
 
         # Handle track number

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -396,6 +396,8 @@ class FileIndexer:
 
         file_size = stat.st_size
         modified_time = int(stat.st_mtime)
+        device_id = str(stat.st_dev)
+        inode = str(stat.st_ino)
         # Nanosecond mtime for the failure-cache key. With second resolution a
         # broken file that gets fixed within the same integer second and keeps
         # the same size would collide on the key and never be retried. The
@@ -513,8 +515,23 @@ class FileIndexer:
             "enriched": 0,
             "last_updated": int(time.time()),
         }
-        await self.db_manager.insert_track(track_data)
+        if existing_track is None:
+            await self.db_manager.insert_track(track_data)
+        else:
+            # Surgical update: overwrite only the indexer-owned columns (present
+            # in track_data). Columns owned by later passes — mbid, match_score,
+            # embeddings, mood — are absent from track_data and so survive,
+            # instead of being dropped by the old INSERT OR REPLACE. enriched is
+            # reset to 0 (track_data), so a changed file is re-enriched, but its
+            # existing embeddings are reused rather than recomputed.
+            await self.db_manager.update_track(track_id, track_data)
         changes["tracks"] = track_id
+
+        # Maintain stable file identity (first_indexed preserved across
+        # re-reads; path/size/mtime/device/inode refreshed).
+        await self.db_manager.upsert_library_file(
+            track_id, file_path, file_size, modified_time, device_id, inode
+        )
 
         # Persist verbatim evidence alongside the display row. Kept as a
         # current snapshot (upserted), so a re-read of a changed file refreshes

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -516,6 +516,17 @@ class FileIndexer:
         await self.db_manager.insert_track(track_data)
         changes["tracks"] = track_id
 
+        # Persist verbatim evidence alongside the display row. Kept as a
+        # current snapshot (upserted), so a re-read of a changed file refreshes
+        # it; the art-phash/fingerprint columns are left to later passes.
+        await self.db_manager.upsert_track_evidence(
+            track_id,
+            {
+                "raw_tags": metadata.get("raw_tags"),
+                "stream_info": metadata.get("stream_info"),
+            },
+        )
+
         await self.db_manager.update_album_stats(album_id)
         # Successfully indexed — drop any stale failure record (e.g. an
         # earlier partial upload that has since completed).
@@ -607,6 +618,24 @@ class FileIndexer:
                 apic = id3[tag]
                 metadata["album_art"] = apic.data
                 break
+        # Evidence for the clusterer/resolver (Phase 1+): verbatim text frames
+        # (incl. TPE2 album-artist and TCMP compilation, which the display
+        # tables don't carry) plus stream characteristics. Binary frames like
+        # APIC are skipped.
+        metadata["raw_tags"] = {
+            key: str(frame)
+            for key, frame in id3.items()
+            if not key.startswith("APIC")
+        }
+        metadata["stream_info"] = {
+            "sample_rate": getattr(mp3.info, "sample_rate", None),
+            "channels": getattr(mp3.info, "channels", None),
+            "bitrate": getattr(mp3.info, "bitrate", None),
+            "codec": "mp3",
+            "encoder": str(id3["TSSE"])
+            if "TSSE" in id3
+            else (str(id3["TENC"]) if "TENC" in id3 else None),
+        }
         return metadata
 
     def _extract_flac_metadata(self, file_path: str, metadata: Dict) -> Dict:
@@ -665,6 +694,17 @@ class FileIndexer:
                     break
             else:
                 metadata["album_art"] = pictures[0].data
+        # Evidence for the clusterer/resolver (Phase 1+): every Vorbis comment
+        # verbatim (incl. albumartist and compilation) plus stream info. Vorbis
+        # keys can repeat, so each maps to a list of values.
+        metadata["raw_tags"] = {key: list(flac[key]) for key in flac.keys()}
+        metadata["stream_info"] = {
+            "sample_rate": getattr(flac.info, "sample_rate", None),
+            "bits_per_sample": getattr(flac.info, "bits_per_sample", None),
+            "channels": getattr(flac.info, "channels", None),
+            "codec": "flac",
+            "encoder": flac["encoder"][0] if "encoder" in flac else None,
+        }
         return metadata
 
     def _save_images(self, image_data: bytes, entity_id: str, entity_type: str):

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -31,6 +31,7 @@ from ..utils.name_utils import (
     album_folder_for_path,
     clean_display_name,
     expand_music_folders,
+    parse_leading_track_number,
     path_within_roots,
 )
 from ..worker_utils import set_proc_title
@@ -491,6 +492,16 @@ class FileIndexer:
             await self.db_manager.insert_album(album_data)
             changes["albums"] = album_id
 
+        # Track number: prefer the tag; otherwise parse a leading "NN." from
+        # the filename so albums sort correctly at scan time, not only after
+        # the enricher's filesystem fallback runs (same patterns, so the two
+        # agree). The fallback still fills it later when a file has neither.
+        track_number = metadata.get("track_number")
+        if track_number is None:
+            track_number = parse_leading_track_number(
+                os.path.splitext(os.path.basename(file_path))[0]
+            )
+
         track_id = generate_track_id(file_path)
         track_data: Dict[str, Any] = {
             "id": track_id,
@@ -501,7 +512,7 @@ class FileIndexer:
             "album_id": album_id,
             "artist_id": artist_id,
             "duration": metadata.get("duration", 0),
-            "track_number": metadata.get("track_number"),
+            "track_number": track_number,
             "disc_number": metadata.get("disc_number"),
             "file_path": file_path,
             "format": metadata.get("format", "unknown"),

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -41,29 +41,16 @@ from .id_generator import (
 from .indexer_db import AsyncIndexerDb
 
 
-# A folder's tracks coalesce into a single V/A compilation album when:
-#   1. they span at least this many distinct artists, AND
-#   2. at least this fraction of tracks have unique artists.
-# Both have to be true so we don't misfire on mistagged albums (e.g.
-# Abbey Road with 2-3 wrong-artist tags out of 17 tracks).
-VA_MIN_DISTINCT_ARTISTS = 4
-VA_MIN_ARTIST_UNIQUENESS = 0.5
-
-# Folder names that are dumping grounds / structural dirs, not compilations or
-# artists. Used both to keep such folders' tracks loose under unknown_album and
-# to reject them as a parent-artist (e.g. ".../unused/8bit Remixes").
-_GENERIC_FOLDER_RE = re.compile(
-    r"^(music|musik|audio|downloads?|mp3s?|tracks?|songs?|various|"
-    r"streamed_music|unused|unsorted|sorted|misc|miscellaneous|temp|tmp|"
-    r"incoming|untitled|new folder|to ?sort|todo|.*\bmix(?:es)?\b.*)$",
-    re.IGNORECASE,
+# V/A-compilation classification (thresholds, folder heuristics, title
+# helpers) lives in clustering.classify so the planner and this pass share it.
+from ..clustering.classify import (  # noqa: E402
+    GENERIC_FOLDER_RE as _GENERIC_FOLDER_RE,
+    VA_MIN_ARTIST_UNIQUENESS,
+    VA_MIN_DISTINCT_ARTISTS,
+    VARIOUS_ARTISTS_ID,
+    compilation_title as _compilation_title,
+    strip_artist_prefix as _strip_artist_prefix,
 )
-# Bare disc/volume folder names that need the parent dir for a meaningful title.
-_BARE_DISC_RE = re.compile(
-    r"^(cd[-_ ]?\d+|disc\s*\d+|disk\s*\d+|volume\s*\d+|vol\.?\s*\d+)$", re.IGNORECASE
-)
-_VA_PREFIX_RE = re.compile(r"^(va|various artists?)\s*[-–—]\s*", re.IGNORECASE)
-VARIOUS_ARTISTS_ID = "various_artists"
 
 
 SUPPORTED_AUDIO_EXTENSIONS = {".mp3", ".flac"}
@@ -852,7 +839,7 @@ class FileIndexer:
             #     tracks are remixer-credited -> that artist's album (so it
             #     doesn't masquerade as a Various-Artists compilation)
             #   * otherwise           -> a Various-Artists compilation album
-            comp_title = self._compilation_title(folder)
+            comp_title = _compilation_title(folder)
             album_reanchored = False
             if comp_title is None:
                 target_id = "unknown_album"
@@ -863,7 +850,7 @@ class FileIndexer:
                 )
                 if parent_artist is not None:
                     owner_id = parent_artist["id"]
-                    display_title = self._strip_artist_prefix(
+                    display_title = _strip_artist_prefix(
                         comp_title, parent_artist["name"]
                     )
                     dest = f"album '{display_title}' under {parent_artist['name']}"
@@ -930,31 +917,6 @@ class FileIndexer:
             "orphans": deleted_albums,
         }
 
-    def _compilation_title(self, folder: str) -> Optional[str]:
-        """Album title for a V/A folder, or None if it's a generic dump that
-        shouldn't become an album (a top-level ``music`` dir, a personal
-        ``90s Mixes`` pile, etc.).
-
-        A folder explicitly marked ``VA -`` / ``Various Artists -`` is a
-        declared compilation, so it bypasses the generic-dump heuristic (e.g.
-        ``VA - Trance Mixes`` must not be rejected by the ``mix`` rule)."""
-        name = os.path.basename(folder).strip()
-        # Strip the V/A marker first so the heuristic and the title both see
-        # the real name.
-        title = _VA_PREFIX_RE.sub("", name).strip()
-        explicit_va = title != name
-        if not title:
-            return None
-        if not explicit_va and _GENERIC_FOLDER_RE.match(title):
-            return None
-        # A bare "Disc 1" / "Volume 2" folder is meaningless on its own — most
-        # disc subdirs are already collapsed by album_folder_for_path, but for
-        # the rest borrow the parent dir for a real title.
-        if _BARE_DISC_RE.match(title):
-            parent = os.path.basename(os.path.dirname(folder)).strip()
-            title = f"{parent} {title}".strip() if parent else title
-        return title or None
-
     async def _ensure_various_artists(self) -> None:
         """Seed the Various-Artists sentinel artist (compilation albums hang
         off it; real per-track artists are preserved on the tracks)."""
@@ -985,18 +947,6 @@ class FileIndexer:
         if not (artist_folders.get(artist_id, set()) - {folder}):
             return None
         return await self.db_manager.get_artist_by_id(artist_id)
-
-    @staticmethod
-    def _strip_artist_prefix(title: str, artist_name: str) -> str:
-        """Drop a leading artist name from a title so it reads cleanly once the
-        album is attributed to that artist (``Ratatat Remixes Vol. 2`` ->
-        ``Remixes Vol. 2``). Only strips at a separator/word boundary, so
-        artist ``AB`` does not corrupt ``ABBA Gold``."""
-        if title.lower().startswith(artist_name.lower()):
-            rest = title[len(artist_name) :]
-            if not rest or rest[0] in " -–—":  # boundary required
-                return rest.lstrip(" -–—") or title
-        return title
 
     async def _ensure_compilation_album(
         self, album_id: str, title: str, artist_id: str

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -839,10 +839,18 @@ class FileIndexer:
                             "last_updated": int(time.time()),
                         }
                     )
-                elif existing.get("artist_id") != anchor:
-                    # Fix the anchor (e.g. re-point to Various Artists) without
-                    # clobbering an enriched title / cover.
-                    await self.db_manager.update_album(album_id, {"artist_id": anchor})
+                else:
+                    # Refresh the anchor (e.g. re-point to Various Artists) and
+                    # the title. Titles are always locally derived (MusicBrainz
+                    # never sets one), so cleaning a folder/tag-junk title here
+                    # can't clobber an external title; covers are untouched.
+                    fixes = {}
+                    if existing.get("artist_id") != anchor:
+                        fixes["artist_id"] = anchor
+                    if cluster.title and existing.get("title") != cluster.title:
+                        fixes["title"] = cluster.title
+                    if fixes:
+                        await self.db_manager.update_album(album_id, fixes)
                 await cluster_db.upsert_cluster(
                     album_id,
                     primary_folder=cluster.folder,

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -403,11 +403,38 @@ class FileIndexer:
         mtime_ns = stat.st_mtime_ns
 
         existing_track = await self.db_manager.get_track_by_path(file_path)
+        if existing_track is None:
+            # Move/rename detection: an unknown path whose (device, inode)
+            # matches a known file — with the same size and the old path gone —
+            # is that file after a rename, not a new one. Re-point the paths
+            # and keep the identity (id, first_indexed, evidence, enrichment).
+            # A copy (old path still present) or a cross-device move (new
+            # inode) legitimately mints a new identity. Works for both inotify
+            # moves and rescans, because stale-row cleanup runs after this.
+            known = await self.db_manager.get_library_file_by_inode(
+                device_id, inode
+            )
+            if (
+                known
+                and known["current_path"] != file_path
+                and known["size_bytes"] == file_size
+                and not os.path.exists(known["current_path"])
+            ):
+                logger.info(
+                    f"File moved: {known['current_path']} -> {file_path}"
+                )
+                await self.db_manager.move_track(known["file_id"], file_path)
+                existing_track = await self.db_manager.get_track_by_path(
+                    file_path
+                )
         if (
             existing_track
             and existing_track["modified_time"] == modified_time
             and existing_track["file_size"] == file_size
         ):
+            # Unchanged content (incl. a pure rename — the paths were just
+            # re-pointed above; regrouping for a folder move happens in the
+            # clustering pass at the end of this scan).
             logger.debug(f"File unchanged, skipping: {file_path}")
             return None
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -536,11 +536,17 @@ class FileIndexer:
         # Persist verbatim evidence alongside the display row. Kept as a
         # current snapshot (upserted), so a re-read of a changed file refreshes
         # it; the art-phash/fingerprint columns are left to later passes.
+        art_phash = (
+            await asyncio.to_thread(self._art_phash, metadata["album_art"])
+            if "album_art" in metadata
+            else None
+        )
         await self.db_manager.upsert_track_evidence(
             track_id,
             {
                 "raw_tags": metadata.get("raw_tags"),
                 "stream_info": metadata.get("stream_info"),
+                "art_phash": art_phash,
             },
         )
 
@@ -723,6 +729,31 @@ class FileIndexer:
             "encoder": flac["encoder"][0] if "encoder" in flac else None,
         }
         return metadata
+
+    @staticmethod
+    def _art_phash(image_data: bytes) -> Optional[str]:
+        """64-bit dHash of embedded art as 16 hex chars, or None on failure.
+
+        Row-wise difference hash: adjacent-pixel brightness comparisons on a
+        9x8 grayscale downscale. Cheap (the image is already decoded here) and
+        robust to re-encoding/resizing, so two files carrying the same cover
+        hash close in Hamming distance — the Phase-1 art-group signal.
+        """
+        try:
+            img = Image.open(io.BytesIO(image_data)).convert("L").resize(
+                (9, 8), Image.Resampling.LANCZOS
+            )
+            px = img.tobytes()  # 72 bytes, one grayscale value per pixel
+            bits = 0
+            for row in range(8):
+                for col in range(8):
+                    left = px[row * 9 + col]
+                    right = px[row * 9 + col + 1]
+                    bits = (bits << 1) | (1 if left > right else 0)
+            return f"{bits:016x}"
+        except Exception as e:
+            logger.debug("art phash failed: %s", e)
+            return None
 
     def _save_images(self, image_data: bytes, entity_id: str, entity_type: str):
         """Save artwork images in different sizes"""

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -518,24 +518,16 @@ class FileIndexer:
         if existing_track is None:
             await self.db_manager.insert_track(track_data)
         else:
-            # Surgical update: overwrite only the indexer-owned columns (present
-            # in track_data). Columns owned by later passes — mbid, match_score,
-            # embeddings, mood — are absent from track_data and so survive,
-            # instead of being dropped by the old INSERT OR REPLACE. enriched is
-            # reset to 0 (track_data), so a changed file is re-enriched, but its
-            # existing embeddings are reused rather than recomputed.
+            # Surgical update, not INSERT OR REPLACE: track_data carries only
+            # indexer-owned columns, so mbid/embeddings/mood survive. enriched
+            # resets to 0, so a changed file re-enriches but reuses embeddings.
             await self.db_manager.update_track(track_id, track_data)
         changes["tracks"] = track_id
 
-        # Maintain stable file identity (first_indexed preserved across
-        # re-reads; path/size/mtime/device/inode refreshed).
         await self.db_manager.upsert_library_file(
             track_id, file_path, file_size, modified_time, device_id, inode
         )
 
-        # Persist verbatim evidence alongside the display row. Kept as a
-        # current snapshot (upserted), so a re-read of a changed file refreshes
-        # it; the art-phash/fingerprint columns are left to later passes.
         art_phash = (
             await asyncio.to_thread(self._art_phash, metadata["album_art"])
             if "album_art" in metadata
@@ -641,10 +633,8 @@ class FileIndexer:
                 apic = id3[tag]
                 metadata["album_art"] = apic.data
                 break
-        # Evidence for the clusterer/resolver (Phase 1+): verbatim text frames
-        # (incl. TPE2 album-artist and TCMP compilation, which the display
-        # tables don't carry) plus stream characteristics. Binary frames like
-        # APIC are skipped.
+        # Verbatim text frames (incl. TPE2 album-artist, TCMP compilation) +
+        # stream info for the clusterer. Binary frames (APIC) skipped.
         metadata["raw_tags"] = {
             key: str(frame)
             for key, frame in id3.items()
@@ -717,9 +707,8 @@ class FileIndexer:
                     break
             else:
                 metadata["album_art"] = pictures[0].data
-        # Evidence for the clusterer/resolver (Phase 1+): every Vorbis comment
-        # verbatim (incl. albumartist and compilation) plus stream info. Vorbis
-        # keys can repeat, so each maps to a list of values.
+        # Every Vorbis comment verbatim (incl. albumartist/compilation) +
+        # stream info. Keys can repeat, so values are lists.
         metadata["raw_tags"] = {key: list(flac[key]) for key in flac.keys()}
         metadata["stream_info"] = {
             "sample_rate": getattr(flac.info, "sample_rate", None),
@@ -732,12 +721,10 @@ class FileIndexer:
 
     @staticmethod
     def _art_phash(image_data: bytes) -> Optional[str]:
-        """64-bit dHash of embedded art as 16 hex chars, or None on failure.
+        """64-bit row-difference hash (dHash) of embedded art, 16 hex or None.
 
-        Row-wise difference hash: adjacent-pixel brightness comparisons on a
-        9x8 grayscale downscale. Cheap (the image is already decoded here) and
-        robust to re-encoding/resizing, so two files carrying the same cover
-        hash close in Hamming distance — the Phase-1 art-group signal.
+        Adjacent-pixel brightness on a 9x8 grayscale downscale. Same cover ->
+        small Hamming distance; robust to re-encoding/resize.
         """
         try:
             img = Image.open(io.BytesIO(image_data)).convert("L").resize(

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import io
+import json
 import time
 import logging
 import asyncio
@@ -183,18 +184,27 @@ class FileIndexer:
                 "Removed stale tracks from database, proceeding with enrichment for valid tracks only"
             )
 
-        # Coalesce V/A folders into compilation albums (or leave generic
-        # dumps loose under unknown_album). Each track keeps its real artist
-        # and still surfaces under it via the orphan-tracks fallback. Runs
-        # after the stale-track cleanup so it doesn't operate on rows about to
-        # be removed, and before notifying the enricher so it sees the result.
-        va_results = await self.orphan_va_folder_tracks()
-        if va_results["folders"]:
-            logger.info(
-                f"V/A coalesce: {va_results['folders']} folder(s), "
-                f"{va_results['tracks']} track(s) re-pointed, "
-                f"{va_results['orphans']} orphan album(s) deleted"
-            )
+        # Group tracks into albums. Folder-first clustering (when enabled)
+        # supersedes the V/A-only coalesce pass — it does V/A folding plus
+        # tag-variance merging, untagged-rip titling and multi-album splits.
+        # Both run after stale-track cleanup and before the enricher nudge.
+        if getattr(self.config, "folder_first_clustering", False):
+            res = await self.recluster()
+            if res.get("reassigned"):
+                logger.info(
+                    "Clustering: %d album(s), %d track(s) re-pointed, "
+                    "%d alias(es), %d orphan album(s) deleted",
+                    res["clusters"], res["reassigned"],
+                    res["aliases"], res["orphans"],
+                )
+        else:
+            va_results = await self.orphan_va_folder_tracks()
+            if va_results["folders"]:
+                logger.info(
+                    f"V/A coalesce: {va_results['folders']} folder(s), "
+                    f"{va_results['tracks']} track(s) re-pointed, "
+                    f"{va_results['orphans']} orphan album(s) deleted"
+                )
 
         # If anything changed and we have an enricher callback, notify it
         if any(changed_items.values()):
@@ -761,6 +771,96 @@ class FileIndexer:
                 f"Error saving artwork for {entity_type} {entity_id}: {str(e)}"
             )
             return False
+
+    async def recluster(self) -> Dict[str, int]:
+        """Folder-first album grouping over the whole library.
+
+        Plans each folder (folder-first partition + V/A classification), merges
+        disc-sibling folders, assigns stable album ids (overlap reattach so an
+        unchanged library is a no-op), then applies: album rows, guarded
+        album_id reassignment, album_cluster rows, and id aliases. Replaces the
+        V/A-only pass when folder_first_clustering is on.
+        """
+        from ..clustering.cluster_db import AsyncClusterDb
+        from ..clustering.identity import assign_stable_ids
+        from ..clustering.merge import merge_disc_siblings
+        from ..clustering.planner import plan_folder
+
+        rows = await self.db_manager.get_tracks_with_evidence()
+        if not rows:
+            return {"clusters": 0, "reassigned": 0, "aliases": 0, "orphans": 0}
+
+        by_folder: Dict[str, List] = {}
+        current_album_of: Dict[str, str] = {}
+        for track, ev in rows:
+            folder = album_folder_for_path(track.get("file_path") or "")
+            if not folder:
+                continue
+            by_folder.setdefault(folder, []).append((track, ev))
+            current_album_of[track["id"]] = track.get("album_id") or "unknown_album"
+
+        clusters = []
+        for folder, folder_rows in by_folder.items():
+            clusters.extend(plan_folder(folder, folder_rows).clusters)
+        clusters = merge_disc_siblings(clusters)
+
+        ids, aliases = assign_stable_ids(clusters, current_album_of)
+
+        cluster_db = AsyncClusterDb(self.config)
+        va_seeded = False
+        reassigned = 0
+        affected_albums: Set[str] = set()
+
+        for cluster, album_id in zip(clusters, ids):
+            if cluster.kind != "singles_pool":
+                anchor = cluster.anchor_artist_id
+                if cluster.kind == "compilation" and not va_seeded:
+                    await self._ensure_various_artists()
+                    va_seeded = True
+                existing = await self.db_manager.get_album_by_id(album_id)
+                if existing is None:
+                    await self.db_manager.insert_album(
+                        {
+                            "id": album_id,
+                            "title": cluster.title or "Unknown Album",
+                            "artist_id": anchor,
+                            "enriched": 0,
+                            "last_updated": int(time.time()),
+                        }
+                    )
+                elif existing.get("artist_id") != anchor:
+                    # Fix the anchor (e.g. re-point to Various Artists) without
+                    # clobbering an enriched title / cover.
+                    await self.db_manager.update_album(album_id, {"artist_id": anchor})
+                await cluster_db.upsert_cluster(
+                    album_id,
+                    primary_folder=cluster.folder,
+                    grouping_conf=1.0,
+                    grouping_basis=json.dumps(cluster.grouping_basis),
+                    kind=cluster.kind,
+                    bump_generation=True,
+                )
+            affected_albums.add(album_id)
+            for tid in cluster.track_ids:
+                if current_album_of.get(tid) != album_id:
+                    await self.db_manager.reassign_album(tid, album_id)
+                    affected_albums.add(current_album_of.get(tid) or "unknown_album")
+                    reassigned += 1
+
+        for old_id, new_id in aliases:
+            await cluster_db.add_alias(old_id, new_id, "album")
+
+        for album_id in affected_albums:
+            if album_id and album_id != "unknown_album":
+                await self.db_manager.update_album_stats(album_id)
+
+        deleted_albums, _ = await self.db_manager.delete_orphaned_albums_and_artists()
+        return {
+            "clusters": len(clusters),
+            "reassigned": reassigned,
+            "aliases": len(aliases),
+            "orphans": deleted_albums,
+        }
 
     async def orphan_va_folder_tracks(self) -> Dict[str, int]:
         """Coalesce a V/A folder's per-track albums into one compilation album.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -229,6 +229,39 @@ class AsyncIndexerDb:
             )
             await conn.commit()
 
+    async def get_library_file_by_inode(
+        self, device_id: str, inode: str
+    ) -> Optional[Dict]:
+        """The library_file row for a (device, inode) pair, if any — the
+        move-detection lookup."""
+        async with self._open() as conn:
+            conn.row_factory = aiosqlite.Row
+            cur = await conn.execute(
+                "SELECT * FROM library_file WHERE device_id = ? AND inode = ?",
+                (device_id, inode),
+            )
+            row = await cur.fetchone()
+            return dict(row) if row else None
+
+    async def move_track(self, track_id: str, new_path: str) -> None:
+        """Re-point a moved/renamed file to its new path, keeping identity.
+
+        Updates tracks.file_path and library_file.current_path together; the
+        id, first_indexed, evidence and enrichment all stay. This is the
+        "rename is an UPDATE, not delete-plus-create" half of stable file
+        identity.
+        """
+        async with self._open() as conn:
+            await conn.execute(
+                "UPDATE tracks SET file_path = ? WHERE id = ?",
+                (new_path, track_id),
+            )
+            await conn.execute(
+                "UPDATE library_file SET current_path = ? WHERE file_id = ?",
+                (new_path, track_id),
+            )
+            await conn.commit()
+
     async def upsert_track_evidence(
         self, track_id: str, evidence: Dict[str, Any]
     ) -> None:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -280,6 +280,29 @@ class AsyncIndexerDb:
             )
             await conn.commit()
 
+    async def get_tracks_with_evidence(self) -> List[Tuple[Dict, Dict]]:
+        """All tracks paired with their track_evidence (empty dict if none),
+        for the clustering pass."""
+        _ev_cols = ("raw_tags", "stream_info", "art_phash", "cue_sheet",
+                    "import_batch")
+        async with self._open() as conn:
+            conn.row_factory = aiosqlite.Row
+            cur = await conn.execute(
+                """
+                SELECT t.*, e.raw_tags, e.stream_info, e.art_phash,
+                       e.cue_sheet, e.import_batch
+                FROM tracks t
+                LEFT JOIN track_evidence e ON e.track_id = t.id
+                """
+            )
+            rows = await cur.fetchall()
+        out: List[Tuple[Dict, Dict]] = []
+        for r in rows:
+            d = dict(r)
+            ev = {c: d.pop(c) for c in _ev_cols}
+            out.append((d, ev))
+        return out
+
     async def get_all_tracks(self) -> List[Dict]:
         """Get all tracks in the database"""
         async with self._open() as conn:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -138,6 +138,13 @@ class AsyncIndexerDb:
         """Update track information"""
         await self._update("tracks", track_id, data)
 
+    async def reassign_album(self, track_id: str, album_id: str) -> None:
+        """The single owner of tracks.album_id writes — clustering / reconciler
+        only. Album membership must flow through here, never through an
+        enrichment plugin (§3 invariant: membership changes only in the
+        clustering pass)."""
+        await self._update("tracks", track_id, {"album_id": album_id})
+
     async def update_album(self, album_id: str, data: Dict[str, Any]) -> None:
         """Update album information (only columns that exist in the table)."""
         await self._update("albums", album_id, data)

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -184,6 +184,48 @@ class AsyncIndexerDb:
             await cursor.execute(query, values)
             await conn.commit()
 
+    async def upsert_library_file(
+        self,
+        file_id: str,
+        current_path: str,
+        size_bytes: int,
+        modified_at: int,
+        device_id: Optional[str],
+        inode: Optional[str],
+    ) -> None:
+        """Maintain the stable file-identity row for a processed file.
+
+        ``first_indexed`` is set once, on the file's first appearance, and
+        **never** rewritten — it is the durable add-time (unlike
+        ``last_updated``, which enrichment legitimately bumps). Path, size,
+        mtime and device/inode are refreshed on every pass.
+        """
+        async with self._open() as conn:
+            await conn.execute(
+                """
+                INSERT INTO library_file
+                    (file_id, current_path, size_bytes, modified_at,
+                     device_id, inode, first_indexed)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(file_id) DO UPDATE SET
+                    current_path = excluded.current_path,
+                    size_bytes   = excluded.size_bytes,
+                    modified_at  = excluded.modified_at,
+                    device_id    = excluded.device_id,
+                    inode        = excluded.inode
+                """,
+                (
+                    file_id,
+                    current_path,
+                    size_bytes,
+                    modified_at,
+                    device_id,
+                    inode,
+                    int(time.time()),
+                ),
+            )
+            await conn.commit()
+
     async def upsert_track_evidence(
         self, track_id: str, evidence: Dict[str, Any]
     ) -> None:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -232,8 +232,9 @@ class AsyncIndexerDb:
         """Upsert the current-snapshot evidence row for a track.
 
         JSON-encodes ``raw_tags`` / ``stream_info``. Only the named columns are
-        written, so art-phash / cue-sheet / fingerprint set by later passes are
-        preserved. ``import_batch`` is kept if a refresh doesn't supply one.
+        written, so cue-sheet / fingerprint set by later passes are preserved.
+        ``import_batch`` and ``art_phash`` are kept when a refresh doesn't
+        supply them (a retag without embedded art shouldn't drop the hash).
         """
         raw_tags = evidence.get("raw_tags")
         stream_info = evidence.get("stream_info")
@@ -241,11 +242,14 @@ class AsyncIndexerDb:
             await conn.execute(
                 """
                 INSERT INTO track_evidence
-                    (track_id, raw_tags, stream_info, import_batch, updated_at)
-                VALUES (?, ?, ?, ?, ?)
+                    (track_id, raw_tags, stream_info, art_phash,
+                     import_batch, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
                 ON CONFLICT(track_id) DO UPDATE SET
                     raw_tags     = excluded.raw_tags,
                     stream_info  = excluded.stream_info,
+                    art_phash    = COALESCE(excluded.art_phash,
+                                            track_evidence.art_phash),
                     import_batch = COALESCE(excluded.import_batch,
                                             track_evidence.import_batch),
                     updated_at   = excluded.updated_at
@@ -254,6 +258,7 @@ class AsyncIndexerDb:
                     track_id,
                     json.dumps(raw_tags) if raw_tags is not None else None,
                     json.dumps(stream_info) if stream_info is not None else None,
+                    evidence.get("art_phash"),
                     evidence.get("import_batch"),
                     int(time.time()),
                 ),

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -193,13 +193,9 @@ class AsyncIndexerDb:
         device_id: Optional[str],
         inode: Optional[str],
     ) -> None:
-        """Maintain the stable file-identity row for a processed file.
-
-        ``first_indexed`` is set once, on the file's first appearance, and
-        **never** rewritten — it is the durable add-time (unlike
-        ``last_updated``, which enrichment legitimately bumps). Path, size,
-        mtime and device/inode are refreshed on every pass.
-        """
+        """Maintain the file-identity row. first_indexed is written once and
+        never rewritten (the durable add-time; last_updated is bumped by
+        enrichment). Path/size/mtime/device/inode refresh on every pass."""
         async with self._open() as conn:
             await conn.execute(
                 """
@@ -229,13 +225,10 @@ class AsyncIndexerDb:
     async def upsert_track_evidence(
         self, track_id: str, evidence: Dict[str, Any]
     ) -> None:
-        """Upsert the current-snapshot evidence row for a track.
-
-        JSON-encodes ``raw_tags`` / ``stream_info``. Only the named columns are
-        written, so cue-sheet / fingerprint set by later passes are preserved.
-        ``import_batch`` and ``art_phash`` are kept when a refresh doesn't
-        supply them (a retag without embedded art shouldn't drop the hash).
-        """
+        """Upsert the current-snapshot evidence row (only named columns, so
+        fingerprint/cue set later survive). art_phash/import_batch are kept
+        when a refresh omits them — a retag without art shouldn't drop the
+        hash."""
         raw_tags = evidence.get("raw_tags")
         stream_info = evidence.get("stream_info")
         async with self._open() as conn:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -184,6 +184,40 @@ class AsyncIndexerDb:
             await cursor.execute(query, values)
             await conn.commit()
 
+    async def upsert_track_evidence(
+        self, track_id: str, evidence: Dict[str, Any]
+    ) -> None:
+        """Upsert the current-snapshot evidence row for a track.
+
+        JSON-encodes ``raw_tags`` / ``stream_info``. Only the named columns are
+        written, so art-phash / cue-sheet / fingerprint set by later passes are
+        preserved. ``import_batch`` is kept if a refresh doesn't supply one.
+        """
+        raw_tags = evidence.get("raw_tags")
+        stream_info = evidence.get("stream_info")
+        async with self._open() as conn:
+            await conn.execute(
+                """
+                INSERT INTO track_evidence
+                    (track_id, raw_tags, stream_info, import_batch, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(track_id) DO UPDATE SET
+                    raw_tags     = excluded.raw_tags,
+                    stream_info  = excluded.stream_info,
+                    import_batch = COALESCE(excluded.import_batch,
+                                            track_evidence.import_batch),
+                    updated_at   = excluded.updated_at
+                """,
+                (
+                    track_id,
+                    json.dumps(raw_tags) if raw_tags is not None else None,
+                    json.dumps(stream_info) if stream_info is not None else None,
+                    evidence.get("import_batch"),
+                    int(time.time()),
+                ),
+            )
+            await conn.commit()
+
     async def update_album_stats(self, album_id: str) -> None:
         """Update album statistics (track count and duration)"""
         async with self._open() as conn:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/utils/name_utils.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/utils/name_utils.py
@@ -41,10 +41,13 @@ _DISC_SUBDIR_RE = re.compile(r"^(cd|disc|disk)[\s\-_]*\d+$", re.IGNORECASE)
 # Leading "NN." / "NN " / "NN- " / "NN_ " track-number prefixes on a filename
 # stem. Shared by the indexer (so ordering is right at scan time) and the
 # enricher's filesystem fallback, so the two can't disagree on parsing.
+# The no-space form ("1.Кончится лето") is capped at two digits so a year
+# prefix ("1985.Some Song") is never eaten as a track number.
 TRACK_NUMBER_PREFIX_PATTERNS = (
-    re.compile(r"^(\d+)\.?\s+"),  # "1. " / "1 " / "1."
-    re.compile(r"^(\d+)-\s+"),    # "1- "
-    re.compile(r"^(\d+)_\s+"),    # "1_ "
+    re.compile(r"^(\d+)\.?\s+"),       # "1. " / "1 " / "1."
+    re.compile(r"^(\d+)-\s+"),         # "1- "
+    re.compile(r"^(\d+)_\s+"),         # "1_ "
+    re.compile(r"^(\d{1,2})\.(?=\S)"), # "1.Title" (no space after the dot)
 )
 
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/utils/name_utils.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/utils/name_utils.py
@@ -41,12 +41,13 @@ _DISC_SUBDIR_RE = re.compile(r"^(cd|disc|disk)[\s\-_]*\d+$", re.IGNORECASE)
 # Leading "NN." / "NN " / "NN- " / "NN_ " track-number prefixes on a filename
 # stem. Shared by the indexer (so ordering is right at scan time) and the
 # enricher's filesystem fallback, so the two can't disagree on parsing.
-# The no-space form ("1.Кончится лето") is capped at two digits so a year
-# prefix ("1985.Some Song") is never eaten as a track number.
+# Digit runs are capped so a 4-digit year prefix ("1985. Some Song",
+# "1985.Some Song") is never eaten as a track number: three digits for the
+# spaced forms (big compilations reach 100+), two for the no-space form.
 TRACK_NUMBER_PREFIX_PATTERNS = (
-    re.compile(r"^(\d+)\.?\s+"),       # "1. " / "1 " / "1."
-    re.compile(r"^(\d+)-\s+"),         # "1- "
-    re.compile(r"^(\d+)_\s+"),         # "1_ "
+    re.compile(r"^(\d{1,3})\.?\s+"),   # "1. " / "1 " / "1."
+    re.compile(r"^(\d{1,3})-\s+"),     # "1- "
+    re.compile(r"^(\d{1,3})_\s+"),     # "1_ "
     re.compile(r"^(\d{1,2})\.(?=\S)"), # "1.Title" (no space after the dot)
 )
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/utils/name_utils.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/utils/name_utils.py
@@ -30,12 +30,34 @@ import re
 import unicodedata
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Optional
 
 _LEADING_TRAILING_PUNCT_RE = re.compile(r"^[\-_.,/ \t]+|[\-_.,/ \t]+$")
 _WHITESPACE_RUN_RE = re.compile(r"\s+")
 _PUNCT_FOR_ID_RE = re.compile(r"[\-_./]")
 _NON_WORD_RE = re.compile(r"[^\w\s]")
 _DISC_SUBDIR_RE = re.compile(r"^(cd|disc|disk)[\s\-_]*\d+$", re.IGNORECASE)
+
+# Leading "NN." / "NN " / "NN- " / "NN_ " track-number prefixes on a filename
+# stem. Shared by the indexer (so ordering is right at scan time) and the
+# enricher's filesystem fallback, so the two can't disagree on parsing.
+TRACK_NUMBER_PREFIX_PATTERNS = (
+    re.compile(r"^(\d+)\.?\s+"),  # "1. " / "1 " / "1."
+    re.compile(r"^(\d+)-\s+"),    # "1- "
+    re.compile(r"^(\d+)_\s+"),    # "1_ "
+)
+
+
+def parse_leading_track_number(name: str) -> Optional[int]:
+    """Leading track number from a filename stem ("1. Title" -> 1), else None."""
+    for pat in TRACK_NUMBER_PREFIX_PATTERNS:
+        m = pat.match(name)
+        if m:
+            try:
+                return int(m.group(1))
+            except (ValueError, IndexError):
+                continue
+    return None
 
 
 def clean_display_name(name: str) -> str:

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_classify.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_classify.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Tests for the shared V/A / disc-suffix classification helpers (Phase 1 1d)."""
+
+from kalinka_plugin_localfiles.clustering.classify import (
+    compilation_title,
+    is_va_folder,
+    strip_disc_suffix,
+)
+
+
+def test_is_va_folder_thresholds():
+    assert is_va_folder(4, 6)          # >=4 artists, ratio 0.67
+    assert not is_va_folder(3, 6)      # too few distinct artists
+    assert not is_va_folder(4, 12)     # ratio 0.33 < 0.5
+    assert not is_va_folder(0, 0)
+
+
+def test_compilation_title_generic_dump_rejected():
+    assert compilation_title("/m/90s Mixes") is None
+    assert compilation_title("/m/music") is None
+    assert compilation_title("/m/VA - Trance Mixes") == "Trance Mixes"
+    assert compilation_title("/m/Now That's Music 50") == "Now That's Music 50"
+
+
+def test_compilation_title_bare_disc_borrows_parent():
+    assert compilation_title("/m/Ministry of Sound/CD1") == "Ministry of Sound CD1"
+
+
+def test_strip_disc_suffix():
+    assert strip_disc_suffix("Album (Disc 1)") == "Album"
+    assert strip_disc_suffix("Album CD2") == "Album"
+    assert strip_disc_suffix("Album - Vol. 3") == "Album"
+    assert strip_disc_suffix("Album [Disk 2]") == "Album"
+    assert strip_disc_suffix("Greatest Hits") == "Greatest Hits"  # no suffix
+    # A title that is only a disc marker stays intact (nothing left otherwise).
+    assert strip_disc_suffix("CD1") == "CD1"

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_db.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_db.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Tests for Phase-1 1a: the clustering schema and its data layer —
+album_cluster / membership_constraint / entity_id_alias — with emphasis on
+alias flatten-on-write (chains must stay single-hop) and cluster generation
+bumping (hysteresis).
+"""
+
+import aiosqlite
+import pytest
+
+from kalinka_plugin_localfiles.clustering.cluster_db import AsyncClusterDb
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+
+
+async def _cols(db_path, table):
+    async with aiosqlite.connect(db_path) as conn:
+        cur = await conn.execute(f"PRAGMA table_info({table})")
+        return {r[1] for r in await cur.fetchall()}
+
+
+@pytest.fixture
+def config(tmp_path):
+    return LocalFilesConfig(
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_tables_exist(config):
+    await init_db(config.db_path)
+    assert "primary_folder" in await _cols(config.db_path, "album_cluster")
+    assert {"kind", "track_id", "album_id"} <= await _cols(
+        config.db_path, "membership_constraint"
+    )
+    assert {"old_id", "current_id", "entity_type"} == await _cols(
+        config.db_path, "entity_id_alias"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_id_passthrough_and_alias(config):
+    await init_db(config.db_path)
+    db = AsyncClusterDb(config)
+    assert await db.resolve_id("album_x") == "album_x"  # no alias -> itself
+    await db.add_alias("album_old", "album_new", "album")
+    assert await db.resolve_id("album_old") == "album_new"
+
+
+@pytest.mark.asyncio
+async def test_alias_chain_is_flattened(config):
+    await init_db(config.db_path)
+    db = AsyncClusterDb(config)
+    # A -> B, then B merged into C: both A and B must resolve directly to C.
+    await db.add_alias("A", "B", "album")
+    await db.add_alias("B", "C", "album")
+    assert await db.resolve_id("A") == "C"  # single hop, not A->B->C
+    assert await db.resolve_id("B") == "C"
+    # And the stored row for A points straight at C.
+    async with aiosqlite.connect(config.db_path) as conn:
+        cur = await conn.execute(
+            "SELECT current_id FROM entity_id_alias WHERE old_id='A'"
+        )
+        assert (await cur.fetchone())[0] == "C"
+
+
+@pytest.mark.asyncio
+async def test_add_alias_noop_on_self(config):
+    await init_db(config.db_path)
+    db = AsyncClusterDb(config)
+    await db.add_alias("X", "X", "album")
+    assert await db.resolve_id("X") == "X"
+    async with aiosqlite.connect(config.db_path) as conn:
+        cur = await conn.execute("SELECT COUNT(*) FROM entity_id_alias")
+        assert (await cur.fetchone())[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_cluster_upsert_and_generation(config):
+    await init_db(config.db_path)
+    db = AsyncClusterDb(config)
+    await db.upsert_cluster("album_1", "/m/A", grouping_conf=0.8, kind="album")
+    c = await db.get_cluster("album_1")
+    assert c["primary_folder"] == "/m/A"
+    assert c["kind"] == "album"
+    assert c["generation"] == 0
+
+    # Plain update: generation unchanged.
+    await db.upsert_cluster("album_1", "/m/A", grouping_conf=0.9)
+    assert (await db.get_cluster("album_1"))["generation"] == 0
+
+    # Re-cluster: generation bumped.
+    await db.upsert_cluster("album_1", "/m/A", bump_generation=True)
+    assert (await db.get_cluster("album_1"))["generation"] == 1
+
+
+@pytest.mark.asyncio
+async def test_constraints_lookup(config):
+    await init_db(config.db_path)
+    db = AsyncClusterDb(config)
+    async with aiosqlite.connect(config.db_path) as conn:
+        await conn.execute(
+            "INSERT INTO membership_constraint "
+            "(id, kind, track_id, album_id, created_at) VALUES "
+            "('c1', 'include', 't1', 'album_1', 1), "
+            "('c2', 'exclude', 't2', 'album_1', 1)"
+        )
+        await conn.commit()
+    rows = await db.get_constraints_for_tracks(["t1", "t2", "t3"])
+    assert {r["id"] for r in rows} == {"c1", "c2"}
+    assert await db.get_constraints_for_tracks([]) == []

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_engine.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_engine.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Tests for Phase-1 1c: the folder-partition engine. One folder is one album by
+default; a split needs compelling evidence; minority outliers are absorbed.
+Covers the proposal's worked examples.
+"""
+
+from kalinka_plugin_localfiles.clustering.engine import partition_folder
+from kalinka_plugin_localfiles.clustering.signals import TrackFeatures
+
+
+def _album(prefix, n, start=1, **common):
+    return [
+        TrackFeatures(track_id=f"{prefix}{i}", track_number=i, **common)
+        for i in range(start, start + n)
+    ]
+
+
+def _ids(groups):
+    return [sorted(t.track_id for t in g) for g in groups]
+
+
+def test_coherent_folder_is_one_album():
+    tracks = _album("t", 10, album_key="x", albumartist_key="aa",
+                    art_phash="0000000000000000")
+    res = partition_folder(tracks)
+    assert not res.split
+    assert len(res.groups) == 1
+    assert len(res.groups[0]) == 10
+
+
+def test_untagged_folder_is_one_album():
+    # No album tags at all (a bare rip) -> one cluster, not fragmented.
+    tracks = _album("t", 6, album_key=None, art_phash="0000000000000000")
+    res = partition_folder(tracks)
+    assert not res.split and len(res.groups) == 1
+
+
+def test_two_complete_albums_in_one_folder_split():
+    # 1..12 twice, distinct tags + distinct art -> two clusters.
+    a = _album("a", 12, album_key="alpha", albumartist_key="one",
+               art_phash="0000000000000000")
+    b = _album("b", 12, album_key="beta", albumartist_key="two",
+               art_phash="ffffffffffffffff")
+    res = partition_folder(a + b)
+    assert res.split
+    assert len(res.groups) == 2
+    groups = _ids(res.groups)
+    assert sorted([f"a{i}" for i in range(1, 13)]) in groups
+    assert sorted([f"b{i}" for i in range(1, 13)]) in groups
+
+
+def test_one_mistagged_track_stays_one_album():
+    # 11 tracks "Album X" + 1 stray tagged "Album Y" (no own sequence).
+    tracks = _album("t", 11, album_key="x", albumartist_key="aa")
+    tracks.append(TrackFeatures(track_id="t12", track_number=12,
+                                album_key="y", albumartist_key="aa"))
+    res = partition_folder(tracks)
+    assert not res.split
+    assert len(res.groups) == 1
+    assert len(res.groups[0]) == 12  # the stray absorbed
+
+
+def test_tag_variants_same_album_merge():
+    # "Everybody Hertz" vs "Air - Everybody Hertz": different keys, same art +
+    # albumartist, one joint run. Must NOT split (the fragmentation bug).
+    a = _album("a", 6, album_key="everybody hertz", albumartist_key="air",
+               art_phash="0000000000000000")
+    b = _album("b", 5, start=7, album_key="air everybody hertz",
+               albumartist_key="air", art_phash="0000000000000000")
+    res = partition_folder(a + b)
+    assert not res.split
+    assert len(res.groups) == 1
+
+
+def test_single_artist_many_singles_not_over_merged():
+    # The Netsky over-merge risk: one folder, one artist, many tiny distinct
+    # releases each with its own cover. Different art -> they stay separate.
+    # Covers chosen with pairwise Hamming >= 32 (clearly different).
+    covers = [
+        "0000000000000000",
+        "ffffffff00000000",
+        "0000ffffffff0000",
+        "00000000ffffffff",
+    ]
+    groups_in = []
+    for k in range(4):
+        groups_in += [
+            TrackFeatures(track_id=f"r{k}_{i}", track_number=i,
+                          album_key=f"single{k}", albumartist_key="netsky",
+                          art_phash=covers[k])
+            for i in (1, 2)
+        ]
+    res = partition_folder(groups_in)
+    # Distinct covers are strong split evidence even for 2-track groups.
+    assert res.split
+    assert len(res.groups) == 4
+
+
+def test_singleton_folder():
+    res = partition_folder([TrackFeatures(track_id="only", track_number=1)])
+    assert not res.split and len(res.groups) == 1

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_identity.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_identity.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Tests for Phase-1 1g stable-id assignment (overlap reattach + aliasing)."""
+
+from kalinka_plugin_localfiles.clustering.identity import assign_stable_ids
+from kalinka_plugin_localfiles.clustering.planner import ClusterPlan
+
+
+def _album(ids, folder="/m/A", kind="album"):
+    return ClusterPlan(track_ids=list(ids), kind=kind, title="A",
+                       anchor_artist_id="artist_a", folder=folder)
+
+
+def test_single_cluster_keeps_plurality_id():
+    # 3 tracks in old album X, 1 in Y -> cluster keeps X, aliases Y->X.
+    clusters = [_album(["t1", "t2", "t3", "t4"])]
+    current = {"t1": "X", "t2": "X", "t3": "X", "t4": "Y"}
+    ids, aliases = assign_stable_ids(clusters, current)
+    assert ids == ["X"]
+    assert ("Y", "X") in aliases
+
+
+def test_untagged_cluster_gets_minted_id():
+    clusters = [_album(["t1", "t2"])]
+    current = {"t1": "unknown_album", "t2": "unknown_album"}
+    ids, aliases = assign_stable_ids(clusters, current)
+    assert ids[0].startswith("album_")
+    assert aliases == []              # unknown_album is never aliased
+
+
+def test_singles_pool_maps_to_unknown_album():
+    clusters = [_album(["t1", "t2"], kind="singles_pool")]
+    ids, _ = assign_stable_ids(clusters, {"t1": "X", "t2": "X"})
+    assert ids == ["unknown_album"]
+
+
+def test_two_clusters_do_not_both_claim_same_old_id():
+    # Old album Z split into two new clusters; only the larger keeps Z.
+    a = _album(["a1", "a2", "a3"], folder="/m/A")
+    b = _album(["b1", "b2"], folder="/m/B")
+    current = {t: "Z" for t in ["a1", "a2", "a3", "b1", "b2"]}
+    ids, aliases = assign_stable_ids([a, b], current)
+    assert ids.count("Z") == 1        # Z used at most once
+    assert ids[0] == "Z"              # larger overlap keeps it
+    assert ids[1].startswith("album_")
+
+
+def test_idempotent_on_second_run():
+    # Run 1 over old ids, then run 2 with tracks pointing at the run-1 ids must
+    # reproduce the same assignment (semantic no-op).
+    clusters = [_album(["t1", "t2", "t3", "t4"])]
+    current = {"t1": "X", "t2": "X", "t3": "X", "t4": "Y"}
+    ids1, _ = assign_stable_ids(clusters, current)
+    current2 = {t: ids1[0] for t in ["t1", "t2", "t3", "t4"]}
+    ids2, aliases2 = assign_stable_ids(clusters, current2)
+    assert ids2 == ids1
+    assert aliases2 == []
+
+
+def test_minted_id_stable_for_same_membership():
+    c1 = _album(["t2", "t1"])       # order-independent
+    c2 = _album(["t1", "t2"])
+    id1, _ = assign_stable_ids([c1], {"t1": "unknown_album", "t2": "unknown_album"})
+    id2, _ = assign_stable_ids([c2], {"t1": "unknown_album", "t2": "unknown_album"})
+    assert id1 == id2

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_merge.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_merge.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Tests for Phase-1 1e: cross-folder disc-sibling merge."""
+
+from kalinka_plugin_localfiles.clustering.merge import merge_disc_siblings
+from kalinka_plugin_localfiles.clustering.planner import ClusterPlan
+
+
+def _album(folder, title, ids, disc, aa="the band"):
+    return ClusterPlan(
+        track_ids=list(ids), kind="album", title=title,
+        anchor_artist_id="artist_a", folder=folder,
+        disc_numbers=frozenset({disc}) if disc else frozenset(),
+        albumartist_key=aa,
+    )
+
+
+def test_disc_siblings_merge():
+    clusters = [
+        _album("/m/Friends CD1", "Friends CD1", ["a1", "a2"], 1),
+        _album("/m/Friends CD2", "Friends CD2", ["b1", "b2"], 2),
+        _album("/m/Friends CD3", "Friends CD3", ["c1", "c2"], 3),
+    ]
+    out = merge_disc_siblings(clusters)
+    assert len(out) == 1
+    m = out[0]
+    assert m.kind == "multi_disc"
+    assert m.title == "Friends"
+    assert sorted(m.track_ids) == ["a1", "a2", "b1", "b2", "c1", "c2"]
+    assert m.disc_numbers == frozenset({1, 2, 3})
+
+
+def test_different_artists_do_not_merge():
+    clusters = [
+        _album("/m/Hits CD1", "Hits CD1", ["a1"], 1, aa="artist one"),
+        _album("/m/Hits CD2", "Hits CD2", ["b1"], 2, aa="artist two"),
+    ]
+    out = merge_disc_siblings(clusters)
+    assert len(out) == 2  # incompatible album-artists -> kept apart
+
+
+def test_colliding_discs_do_not_merge():
+    clusters = [
+        _album("/m/X CD1", "X CD1", ["a1"], 1),
+        _album("/m/X Disc 1", "X Disc 1", ["b1"], 1),  # both claim disc 1
+    ]
+    out = merge_disc_siblings(clusters)
+    assert len(out) == 2
+
+
+def test_unrelated_albums_pass_through():
+    clusters = [
+        _album("/m/Alpha", "Alpha", ["a1"], None),
+        _album("/m/Beta", "Beta", ["b1"], None),
+    ]
+    out = merge_disc_siblings(clusters)
+    assert len(out) == 2
+    assert {c.title for c in out} == {"Alpha", "Beta"}
+
+
+def test_compilations_not_merged():
+    comp1 = ClusterPlan(["a1"], "compilation", "Comp CD1", "various_artists",
+                        folder="/m/Comp CD1")
+    comp2 = ClusterPlan(["b1"], "compilation", "Comp CD2", "various_artists",
+                        folder="/m/Comp CD2")
+    out = merge_disc_siblings([comp1, comp2])
+    assert len(out) == 2  # only plain albums merge

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
@@ -114,6 +114,37 @@ def test_plan_generic_dump_is_singles_pool():
     assert c.anchor_artist_id == "unknown_artist"
 
 
+def test_multidisc_in_one_folder_strips_disc_suffix_from_title():
+    # Both discs tagged "… (Disc N)" in one folder collapse to one album whose
+    # title drops the disc marker.
+    rows = []
+    for i in range(1, 6):
+        rows.append((_track(f"a{i}", track_number=i, disc_number=1),
+                     _ev(album="Best Of MJ (Disk 1)", albumartist="MJ")))
+    for i in range(1, 6):
+        rows.append((_track(f"b{i}", track_number=i, disc_number=2),
+                     _ev(album="Best Of MJ (Disk 2)", albumartist="MJ")))
+    plan = plan_folder("/music/Best Of MJ (2CD)", rows)
+    assert len(plan.clusters) == 1
+    c = plan.clusters[0]
+    assert c.title == "Best Of MJ"      # (Disk N) stripped
+    assert c.kind == "multi_disc"
+    assert len(c.track_ids) == 10
+
+
+def test_standalone_volume_keeps_its_name():
+    # A single "Vol. 2" release (one title variant) must NOT be stripped.
+    rows = [
+        (_track(f"t{i}", track_number=i), _ev(album="Greatest Hits Vol. 2",
+                                              albumartist="Band"))
+        for i in range(1, 7)
+    ]
+    plan = plan_folder("/music/Greatest Hits Vol 2", rows)
+    assert len(plan.clusters) == 1
+    assert plan.clusters[0].title == "Greatest Hits Vol. 2"
+    assert plan.clusters[0].kind == "album"
+
+
 def test_plan_empty_folder():
     plan = plan_folder("/music/empty", [])
     assert plan.clusters == [] and not plan.split

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Tests for Phase-1 1d planner: build_features (from track row + evidence) and
+plan_folder (engine + V/A classification). Read-only — no DB writes.
+"""
+
+import json
+
+from kalinka_plugin_localfiles.clustering.planner import (
+    build_features,
+    plan_folder,
+)
+
+
+def _ev(album=None, albumartist=None, compilation=None, art=None,
+        codec="flac", sr=44100, bd=16, vorbis=True):
+    raw = {}
+    if vorbis:
+        if album:
+            raw["album"] = [album]
+        if albumartist:
+            raw["albumartist"] = [albumartist]
+        if compilation:
+            raw["compilation"] = [compilation]
+    else:
+        if album:
+            raw["TALB"] = album
+        if albumartist:
+            raw["TPE2"] = albumartist
+        if compilation:
+            raw["TCMP"] = compilation
+    return {
+        "raw_tags": json.dumps(raw),
+        "stream_info": json.dumps({"codec": codec, "sample_rate": sr,
+                                   "bits_per_sample": bd}),
+        "art_phash": art,
+        "cue_sheet": None,
+        "import_batch": None,
+    }
+
+
+def _track(tid, artist_id="artist_a", track_number=1, disc_number=None):
+    return {"id": tid, "artist_id": artist_id, "track_number": track_number,
+            "disc_number": disc_number}
+
+
+def test_build_features_reads_albumartist_and_disc_suffix():
+    f = build_features(
+        _track("t1"),
+        _ev(album="Some Album (Disc 2)", albumartist="The Band", compilation="1"),
+    )
+    assert f.album_key == "some album"           # disc suffix stripped
+    assert f.albumartist_key == "the band"
+    assert f.compilation is True
+    assert f.stream_key == "flac|44100|16"
+
+
+def test_build_features_id3_vocabulary():
+    f = build_features(
+        _track("t1"), _ev(album="X", albumartist="AA", vorbis=False)
+    )
+    assert f.album_key == "x"
+    assert f.albumartist_key == "aa"
+
+
+def test_plan_untagged_folder_gets_folder_name_title():
+    rows = [(_track(f"t{i}", track_number=i), _ev()) for i in range(1, 6)]
+    plan = plan_folder("/music/Some Album", rows)
+    assert not plan.split
+    assert len(plan.clusters) == 1
+    c = plan.clusters[0]
+    assert c.kind == "album"
+    assert c.title == "Some Album"        # folder name, not unknown_album
+    assert len(c.track_ids) == 5
+
+
+def test_plan_coherent_album_uses_tag_title():
+    rows = [
+        (_track(f"t{i}", track_number=i), _ev(album="Real Title",
+                                              albumartist="Band"))
+        for i in range(1, 9)
+    ]
+    plan = plan_folder("/music/folder", rows)
+    assert len(plan.clusters) == 1
+    assert plan.clusters[0].title == "Real Title"
+    assert plan.clusters[0].kind == "album"
+
+
+def test_plan_va_folder_is_compilation():
+    # 6 tracks, 6 distinct artists, clean album-named folder.
+    rows = [
+        (_track(f"t{i}", artist_id=f"artist_{i}", track_number=i),
+         _ev(album=f"track by {i}"))
+        for i in range(1, 7)
+    ]
+    plan = plan_folder("/music/VA - Summer Hits", rows)
+    assert len(plan.clusters) == 1
+    c = plan.clusters[0]
+    assert c.kind == "compilation"
+    assert c.title == "Summer Hits"
+    assert c.anchor_artist_id == "various_artists"
+
+
+def test_plan_generic_dump_is_singles_pool():
+    rows = [
+        (_track(f"t{i}", artist_id=f"artist_{i}", track_number=i), _ev())
+        for i in range(1, 7)
+    ]
+    plan = plan_folder("/music/90s Mixes", rows)
+    assert len(plan.clusters) == 1
+    c = plan.clusters[0]
+    assert c.kind == "singles_pool"
+    assert c.title == ""
+    assert c.anchor_artist_id == "unknown_artist"
+
+
+def test_plan_two_albums_split():
+    a = [(_track(f"a{i}", artist_id="one", track_number=i),
+          _ev(album="Alpha", albumartist="one", art="0000000000000000"))
+         for i in range(1, 7)]
+    b = [(_track(f"b{i}", artist_id="two", track_number=i),
+          _ev(album="Beta", albumartist="two", art="ffffffffffffffff"))
+         for i in range(1, 7)]
+    plan = plan_folder("/music/mixed", a + b)
+    assert plan.split
+    assert len(plan.clusters) == 2
+    titles = {c.title for c in plan.clusters}
+    assert titles == {"Alpha", "Beta"}

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
@@ -114,6 +114,11 @@ def test_plan_generic_dump_is_singles_pool():
     assert c.anchor_artist_id == "unknown_artist"
 
 
+def test_plan_empty_folder():
+    plan = plan_folder("/music/empty", [])
+    assert plan.clusters == [] and not plan.split
+
+
 def test_plan_two_albums_split():
     a = [(_track(f"a{i}", artist_id="one", track_number=i),
           _ev(album="Alpha", albumartist="one", art="0000000000000000"))

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_signals.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_signals.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Tests for Phase-1 1b: the membership signal primitives and scorer.
+
+These are pure functions — no DB. They encode the §5.2 evidence table: a
+positive score favours one album, negative favours a split.
+"""
+
+from kalinka_plugin_localfiles.clustering.signals import (
+    TrackFeatures,
+    hamming_hex,
+    pair_signal_score,
+    sequence_analysis,
+)
+
+
+def _tracks(n, **common):
+    """n tracks numbered 1..n sharing the given feature values."""
+    out = []
+    for i in range(1, n + 1):
+        out.append(TrackFeatures(track_id=f"t{i}", track_number=i, **common))
+    return out
+
+
+def test_hamming_hex():
+    assert hamming_hex("0000000000000000", "0000000000000000") == 0
+    assert hamming_hex("0000000000000000", "0000000000000001") == 1
+    assert hamming_hex("00000000000000ff", "0000000000000000") == 8
+
+
+def test_sequence_analysis_plausible_run():
+    s = sequence_analysis([1, 2, 3, 4, 5, 6])
+    assert s.is_plausible and not s.has_collision
+
+
+def test_sequence_analysis_collision():
+    s = sequence_analysis([1, 2, 3, 4, 4])
+    assert s.has_collision and not s.is_plausible
+
+
+def test_sequence_analysis_too_short_or_sparse():
+    assert not sequence_analysis([1, 2]).is_plausible          # too few
+    assert not sequence_analysis([1, 2, 3, 30]).is_plausible   # sparse coverage
+    assert not sequence_analysis([]).is_plausible
+
+
+def test_coherent_folder_scores_positive():
+    # One album: same tag, same albumartist, one art group, clean 1..6 run.
+    a = _tracks(3, album_key="x", albumartist_key="aa",
+                art_phash="0000000000000000", stream_key="flac|44100|16")
+    b = [TrackFeatures(track_id=f"t{i}", track_number=i, album_key="x",
+                       albumartist_key="aa", art_phash="0000000000000000",
+                       stream_key="flac|44100|16") for i in range(4, 7)]
+    score, basis = pair_signal_score(a, b)
+    assert score > 0
+    assert "same_album_tag" in basis and "same_art" in basis
+    assert "same_albumartist" in basis and "compatible_track_numbers" in basis
+
+
+def test_two_albums_same_folder_scores_negative():
+    # Both subgroups are complete 1..5 runs, different tags, different art.
+    a = [TrackFeatures(track_id=f"a{i}", track_number=i, album_key="alpha",
+                       albumartist_key="one", art_phash="0000000000000000")
+         for i in range(1, 6)]
+    b = [TrackFeatures(track_id=f"b{i}", track_number=i, album_key="beta",
+                       albumartist_key="two", art_phash="ffffffffffffffff")
+         for i in range(1, 6)]
+    score, basis = pair_signal_score(a, b)
+    assert score < 0
+    assert "different_album_tags_both_sequences" in basis
+    assert "different_art" in basis
+    assert "different_albumartist" in basis
+    assert "track_number_collision" in basis  # two "track 1..5" runs collide
+
+
+def test_mistagged_outlier_does_not_force_split():
+    # 5 tracks album X + a single stray tagged Y at position 6 (no own run).
+    a = _tracks(5, album_key="x", albumartist_key="aa")
+    stray = [TrackFeatures(track_id="t6", track_number=6, album_key="y",
+                           albumartist_key="aa")]
+    score, basis = pair_signal_score(a, stray)
+    # Different tags but the stray is not its own sequence -> no strong split
+    # signal; albumartist agrees and the joint run is clean.
+    assert "different_album_tags_both_sequences" not in basis
+    assert score >= 0
+
+
+def test_art_relation_thresholds():
+    same = pair_signal_score(
+        [TrackFeatures("a", art_phash="0000000000000000")],
+        [TrackFeatures("b", art_phash="0000000000000003")],  # dist 2
+    )[1]
+    assert "same_art" in same
+    diff = pair_signal_score(
+        [TrackFeatures("a", art_phash="0000000000000000")],
+        [TrackFeatures("b", art_phash="ffffffffff000000")],  # far
+    )[1]
+    assert "different_art" in diff
+
+
+def test_cue_sheet_is_strong_cohesion():
+    a = [TrackFeatures("a1", track_number=1, cue_sheet="/m/x.cue",
+                       album_key="x")]
+    b = [TrackFeatures("b1", track_number=2, cue_sheet="/m/x.cue",
+                       album_key="y")]  # differing tags, but one cue
+    score, basis = pair_signal_score(a, b)
+    assert "same_cue_sheet" in basis
+    assert score > 0

--- a/packages/kalinka-plugin-localfiles/tests/test_filesystem_fallback.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_filesystem_fallback.py
@@ -121,3 +121,38 @@ class TestFilesystemFallbackPlugin:
         metadata = plugin._extract_metadata_from_path(path)
         assert metadata.get("album") is None
         assert metadata.get("artist") is None
+
+
+class TestNoSpaceDotPrefix:
+    """"N.Title" filenames (no space after the dot) parse number + clean title,
+    and a stem-echo title (basename minus extension) still counts as a
+    filename placeholder so a retry can improve it."""
+
+    def test_extract_number_and_title_no_space(self, plugin):
+        num, title, artist = plugin._extract_track_number_and_title(
+            "1.Кончится лето"
+        )
+        assert num == 1
+        assert title == "Кончится лето"
+        assert artist is None
+
+    def test_year_prefix_not_a_track_number(self, plugin):
+        num, title, _ = plugin._extract_track_number_and_title("1985.Some Song")
+        assert num is None
+        assert title == "1985.Some Song"
+
+    @pytest.mark.asyncio
+    async def test_stem_echo_title_gets_replaced(self, plugin):
+        track = {
+            "id": "t1",
+            "title": "1.Кончится лето",  # stem of the file below
+            "file_path": "/home/user/Music/В.Цой - Черный альбом/1.Кончится лето.flac",
+            "artist_id": "artist_x",
+            "album_id": "album_x",
+            "track_number": None,
+        }
+        result = await plugin.enrich_track(track)
+        assert result is not None
+        updates = result["updates"]
+        assert updates["title"] == "Кончится лето"   # prefix stripped
+        assert updates["track_number"] == 1

--- a/packages/kalinka-plugin-localfiles/tests/test_filesystem_fallback.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_filesystem_fallback.py
@@ -124,8 +124,8 @@ class TestFilesystemFallbackPlugin:
 
 
 class TestNoSpaceDotPrefix:
-    """"N.Title" filenames (no space after the dot) parse number + clean title,
-    and a stem-echo title (basename minus extension) still counts as a
+    """Filenames shaped N.Title (no space after the dot) parse number + clean
+    title, and a stem-echo title (basename minus extension) still counts as a
     filename placeholder so a retry can improve it."""
 
     def test_extract_number_and_title_no_space(self, plugin):

--- a/packages/kalinka-plugin-localfiles/tests/test_indexer_evidence.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_indexer_evidence.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Tests for Phase-0 evidence capture (0b): the indexer records verbatim raw
+tags (including albumartist and the compilation flag, which the display
+tables don't carry) and stream info into track_evidence when it processes a
+file.
+
+Uses a real FLAC (soundfile) so the mutagen extraction path is exercised
+end-to-end, plus a stubbed-extraction case for the process_file write path.
+"""
+
+import json
+
+import numpy as np
+import pytest
+import pytest_asyncio
+import soundfile as sf
+from mutagen.flac import FLAC
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.indexer.indexer import FileIndexer
+from kalinka_plugin_localfiles.indexer.indexer_db import AsyncIndexerDb
+
+
+@pytest_asyncio.fixture
+async def indexer(tmp_path):
+    music_dir = tmp_path / "music"
+    music_dir.mkdir()
+    config = LocalFilesConfig(
+        music_folders=[str(music_dir)],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+        quiescence_seconds=0,
+    )
+    await init_db(config.db_path)
+    return FileIndexer(config, AsyncIndexerDb(config)), music_dir, config
+
+
+def _write_flac(path, tags):
+    # A short, valid FLAC so the real mutagen path runs.
+    sf.write(str(path), np.zeros(4410, dtype="float32"), 44100, format="FLAC")
+    audio = FLAC(str(path))
+    for k, v in tags.items():
+        audio[k] = v
+    audio.save()
+
+
+async def _evidence(config, track_id):
+    import aiosqlite
+
+    async with aiosqlite.connect(config.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        cur = await conn.execute(
+            "SELECT * FROM track_evidence WHERE track_id = ?", (track_id,)
+        )
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
+
+@pytest.mark.asyncio
+async def test_flac_evidence_captures_albumartist_and_compilation(indexer):
+    fi, music_dir, config = indexer
+    path = music_dir / "01 - track.flac"
+    _write_flac(
+        path,
+        {
+            "title": "Track One",
+            "artist": "The Performer",
+            "albumartist": "Various Artists",
+            "album": "Some Comp",
+            "compilation": "1",
+            "tracknumber": "1",
+        },
+    )
+
+    changes = await fi.process_file(str(path))
+    track_id = changes["tracks"]
+
+    ev = await _evidence(config, track_id)
+    assert ev is not None
+    raw = json.loads(ev["raw_tags"])
+    # albumartist + compilation are captured verbatim even though the tracks
+    # table has no column for them.
+    assert raw["albumartist"] == ["Various Artists"]
+    assert raw["compilation"] == ["1"]
+    assert raw["artist"] == ["The Performer"]
+
+    stream = json.loads(ev["stream_info"])
+    assert stream["codec"] == "flac"
+    assert stream["sample_rate"] == 44100
+    assert stream["channels"] == 1
+    assert stream["bits_per_sample"] == 16
+
+
+@pytest.mark.asyncio
+async def test_evidence_refreshed_on_reprocess(indexer):
+    fi, music_dir, config = indexer
+    path = music_dir / "02 - track.flac"
+    _write_flac(path, {"title": "V1", "artist": "A", "album": "X"})
+    changes = await fi.process_file(str(path))
+    track_id = changes["tracks"]
+
+    # Retag and bump mtime so process_file re-reads the file.
+    audio = FLAC(str(path))
+    audio["albumartist"] = "New AA"
+    audio.save()
+    import os
+
+    st = os.stat(path)
+    os.utime(path, (st.st_atime, st.st_mtime + 10))
+
+    await fi.process_file(str(path))
+    ev = await _evidence(config, track_id)
+    raw = json.loads(ev["raw_tags"])
+    assert raw["albumartist"] == ["New AA"]  # snapshot refreshed in place
+
+
+@pytest.mark.asyncio
+async def test_evidence_written_via_process_file_write_path(indexer):
+    """Stubbed extraction: confirms process_file persists whatever evidence
+    the extractor returns, independent of the mutagen path."""
+    fi, music_dir, config = indexer
+    path = music_dir / "03 - track.mp3"
+    path.write_bytes(b"x")
+    fi._extract_metadata = lambda _p: {
+        "format": "audio/mpeg",
+        "duration": 100,
+        "title": "Stub",
+        "artist": "Stub Artist",
+        "raw_tags": {"TPE2": "Album Artist", "TCMP": "1"},
+        "stream_info": {"codec": "mp3", "sample_rate": 44100},
+    }
+    changes = await fi.process_file(str(path))
+    ev = await _evidence(config, changes["tracks"])
+    assert json.loads(ev["raw_tags"])["TPE2"] == "Album Artist"
+    assert json.loads(ev["stream_info"])["codec"] == "mp3"

--- a/packages/kalinka-plugin-localfiles/tests/test_indexer_phash_fingerprint.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_indexer_phash_fingerprint.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Tests for Phase-0 0d: persist an embedded-art perceptual hash at index time
+and a computed chromaprint when AcoustID runs. Both land in track_evidence
+without disturbing the other evidence columns.
+"""
+
+import io
+
+import aiosqlite
+import numpy as np
+import pytest
+import pytest_asyncio
+import soundfile as sf
+from mutagen.flac import FLAC, Picture
+from PIL import Image
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.enricher.enricher_db import AsyncEnricherDb
+from kalinka_plugin_localfiles.indexer.indexer import FileIndexer
+from kalinka_plugin_localfiles.indexer.indexer_db import AsyncIndexerDb
+
+
+@pytest_asyncio.fixture
+async def indexer(tmp_path):
+    music_dir = tmp_path / "music"
+    music_dir.mkdir()
+    config = LocalFilesConfig(
+        music_folders=[str(music_dir)],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+        quiescence_seconds=0,
+    )
+    await init_db(config.db_path)
+    return FileIndexer(config, AsyncIndexerDb(config)), music_dir, config
+
+
+def _cover_png(color):
+    buf = io.BytesIO()
+    Image.new("RGB", (64, 64), color).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _write_flac(path, tags, cover=None):
+    sf.write(str(path), np.zeros(4410, dtype="float32"), 44100, format="FLAC")
+    audio = FLAC(str(path))
+    for k, v in tags.items():
+        audio[k] = v
+    if cover is not None:
+        pic = Picture()
+        pic.type = 3
+        pic.mime = "image/png"
+        pic.data = cover
+        audio.add_picture(pic)
+    audio.save()
+
+
+async def _evidence(config, track_id):
+    async with aiosqlite.connect(config.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        cur = await conn.execute(
+            "SELECT * FROM track_evidence WHERE track_id = ?", (track_id,)
+        )
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
+
+def test_art_phash_is_16_hex_and_stable():
+    a1 = FileIndexer._art_phash(_cover_png((120, 30, 200)))
+    a2 = FileIndexer._art_phash(_cover_png((120, 30, 200)))
+    assert a1 is not None and len(a1) == 16
+    int(a1, 16)  # valid hex
+    assert a1 == a2  # same image -> same hash
+    assert FileIndexer._art_phash(b"not an image") is None
+
+
+@pytest.mark.asyncio
+async def test_indexing_stores_art_phash(indexer):
+    fi, music_dir, config = indexer
+    path = music_dir / "01 - track.flac"
+    _write_flac(path, {"title": "T", "artist": "A", "album": "X"},
+                cover=_cover_png((10, 200, 90)))
+    changes = await fi.process_file(str(path))
+    ev = await _evidence(config, changes["tracks"])
+    assert ev["art_phash"] is not None and len(ev["art_phash"]) == 16
+
+
+@pytest.mark.asyncio
+async def test_retag_without_art_preserves_phash(indexer):
+    fi, music_dir, config = indexer
+    path = music_dir / "02 - track.flac"
+    _write_flac(path, {"title": "T", "artist": "A", "album": "X"},
+                cover=_cover_png((200, 10, 10)))
+    changes = await fi.process_file(str(path))
+    track_id = changes["tracks"]
+    phash = (await _evidence(config, track_id))["art_phash"]
+    assert phash is not None
+
+    # Strip the picture, retag, bump mtime, reprocess.
+    audio = FLAC(str(path))
+    audio.clear_pictures()
+    audio["album"] = "Y"
+    audio.save()
+    import os
+
+    st = os.stat(path)
+    os.utime(path, (st.st_atime, st.st_mtime + 10))
+    await fi.process_file(str(path))
+
+    ev = await _evidence(config, track_id)
+    assert ev["art_phash"] == phash  # preserved, not nulled
+
+
+@pytest.mark.asyncio
+async def test_save_fingerprint_upserts_without_disturbing_evidence(indexer):
+    fi, music_dir, config = indexer
+    path = music_dir / "03 - track.flac"
+    _write_flac(path, {"title": "T", "artist": "A", "album": "X"})
+    changes = await fi.process_file(str(path))
+    track_id = changes["tracks"]
+    # Indexer wrote raw_tags/stream_info; the enricher now adds a fingerprint.
+    before = await _evidence(config, track_id)
+    assert before["raw_tags"] is not None
+    assert before["fingerprint"] is None
+
+    enr_db = AsyncEnricherDb(config)
+    await enr_db.save_fingerprint(track_id, "AQADtMkYhYkYnGiOQ")
+
+    after = await _evidence(config, track_id)
+    assert after["fingerprint"] == "AQADtMkYhYkYnGiOQ"
+    assert after["fp_computed_at"] is not None
+    assert after["raw_tags"] == before["raw_tags"]  # untouched
+    assert after["art_phash"] == before["art_phash"]
+
+
+@pytest.mark.asyncio
+async def test_save_fingerprint_creates_row_if_absent(tmp_path):
+    config = LocalFilesConfig(
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+    )
+    await init_db(config.db_path)
+    enr_db = AsyncEnricherDb(config)
+    await enr_db.save_fingerprint("track_orphan", "FPX")
+    async with aiosqlite.connect(config.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        cur = await conn.execute(
+            "SELECT * FROM track_evidence WHERE track_id='track_orphan'"
+        )
+        row = dict(await cur.fetchone())
+    assert row["fingerprint"] == "FPX"
+    assert row["raw_tags"] is None

--- a/packages/kalinka-plugin-localfiles/tests/test_indexer_surgical_update.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_indexer_surgical_update.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Tests for Phase-0 0c: re-indexing a changed file uses a surgical UPDATE
+instead of INSERT OR REPLACE, so enricher/embedder-owned columns survive,
+and library_file.first_indexed is written once and never rewritten.
+"""
+
+import os
+
+import aiosqlite
+import numpy as np
+import pytest
+import pytest_asyncio
+import soundfile as sf
+from mutagen.flac import FLAC
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.indexer.indexer import FileIndexer
+from kalinka_plugin_localfiles.indexer.indexer_db import AsyncIndexerDb
+
+
+@pytest_asyncio.fixture
+async def indexer(tmp_path):
+    music_dir = tmp_path / "music"
+    music_dir.mkdir()
+    config = LocalFilesConfig(
+        music_folders=[str(music_dir)],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+        quiescence_seconds=0,
+    )
+    await init_db(config.db_path)
+    return FileIndexer(config, AsyncIndexerDb(config)), music_dir, config
+
+
+def _write_flac(path, tags):
+    sf.write(str(path), np.zeros(4410, dtype="float32"), 44100, format="FLAC")
+    audio = FLAC(str(path))
+    for k, v in tags.items():
+        audio[k] = v
+    audio.save()
+
+
+async def _row(config, sql, params):
+    async with aiosqlite.connect(config.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        cur = await conn.execute(sql, params)
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
+
+@pytest.mark.asyncio
+async def test_reindex_preserves_enricher_columns(indexer):
+    fi, music_dir, config = indexer
+    path = music_dir / "01 - track.flac"
+    _write_flac(path, {"title": "T", "artist": "A", "album": "Old Album"})
+    changes = await fi.process_file(str(path))
+    track_id = changes["tracks"]
+    old_album_id = (await _row(config, "SELECT album_id FROM tracks WHERE id=?", (track_id,)))[
+        "album_id"
+    ]
+
+    # Simulate downstream enrichment + embedding on the row.
+    async with aiosqlite.connect(config.db_path) as conn:
+        await conn.execute(
+            "UPDATE tracks SET mbid=?, match_score=?, enriched=1, "
+            "embedding_clap_audio=?, embedding_version=3, mood_valence=5.0 "
+            "WHERE id=?",
+            ("rec-mbid-123", 118, b"\x01\x02\x03", track_id),
+        )
+        await conn.commit()
+
+    # Retag (new album) and bump mtime so the file is re-processed.
+    audio = FLAC(str(path))
+    audio["album"] = "New Album"
+    audio.save()
+    st = os.stat(path)
+    os.utime(path, (st.st_atime, st.st_mtime + 10))
+
+    await fi.process_file(str(path))
+
+    t = await _row(config, "SELECT * FROM tracks WHERE id=?", (track_id,))
+    # Enricher/embedder columns preserved (would be NULL under INSERT OR REPLACE)
+    assert t["mbid"] == "rec-mbid-123"
+    assert t["match_score"] == 118
+    assert t["embedding_clap_audio"] == b"\x01\x02\x03"
+    assert t["embedding_version"] == 3
+    assert t["mood_valence"] == 5.0
+    # Indexer-owned columns updated; enriched reset so it is re-enriched
+    assert t["album_id"] != old_album_id
+    assert t["enriched"] == 0
+
+
+@pytest.mark.asyncio
+async def test_first_indexed_preserved_across_reindex(indexer):
+    fi, music_dir, config = indexer
+    path = music_dir / "02 - track.flac"
+    _write_flac(path, {"title": "T", "artist": "A", "album": "X"})
+    changes = await fi.process_file(str(path))
+    track_id = changes["tracks"]
+
+    lf1 = await _row(config, "SELECT * FROM library_file WHERE file_id=?", (track_id,))
+    assert lf1 is not None
+    assert lf1["first_indexed"] is not None
+    assert lf1["device_id"] is not None and lf1["inode"] is not None
+    original_first_indexed = lf1["first_indexed"]
+
+    # Reprocess a changed file after time passes.
+    audio = FLAC(str(path))
+    audio["album"] = "Y"
+    audio.save()
+    st = os.stat(path)
+    os.utime(path, (st.st_atime, st.st_mtime + 100))
+    await fi.process_file(str(path))
+
+    lf2 = await _row(config, "SELECT * FROM library_file WHERE file_id=?", (track_id,))
+    assert lf2["first_indexed"] == original_first_indexed  # never rewritten
+    assert lf2["modified_at"] == int(os.stat(path).st_mtime)  # refreshed

--- a/packages/kalinka-plugin-localfiles/tests/test_indexer_va_albums.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_indexer_va_albums.py
@@ -12,6 +12,10 @@ orphan/appears-on query.
 import pytest
 import pytest_asyncio
 
+from kalinka_plugin_localfiles.clustering.classify import (
+    compilation_title,
+    strip_artist_prefix,
+)
 from kalinka_plugin_localfiles.config_model import LocalFilesConfig
 from kalinka_plugin_localfiles.db_schema import init_db
 from kalinka_plugin_localfiles.indexer.id_generator import generate_artist_id
@@ -126,7 +130,7 @@ async def test_generic_dump_folder_stays_unknown_album(indexer):
 
 
 def test_strip_artist_prefix_requires_a_boundary():
-    f = FileIndexer._strip_artist_prefix
+    f = strip_artist_prefix
     assert f("Ratatat Remixes Vol. 2", "Ratatat") == "Remixes Vol. 2"
     assert f("Massive Attack - Sessions", "Massive Attack") == "Sessions"
     assert f("Remixes", "Netsky") == "Remixes"  # no prefix -> unchanged
@@ -138,5 +142,5 @@ async def test_va_marked_folder_bypasses_generic_filter(indexer):
     """An explicit "VA -" marker declares a compilation, so a name that would
     otherwise be treated as a generic dump (e.g. "Mixes") is still honoured."""
     fi, music_dir, _ = indexer
-    assert fi._compilation_title(str(music_dir / "VA - Trance Mixes")) == "Trance Mixes"
-    assert fi._compilation_title(str(music_dir / "90s Mixes")) is None  # no marker
+    assert compilation_title(str(music_dir / "VA - Trance Mixes")) == "Trance Mixes"
+    assert compilation_title(str(music_dir / "90s Mixes")) is None  # no marker

--- a/packages/kalinka-plugin-localfiles/tests/test_membership_guard.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_membership_guard.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Tests for Phase-1 1f: album membership is owned by a single guarded writer,
+and AcoustID can no longer create albums or move a track between them.
+"""
+
+import aiosqlite
+import pytest
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.enricher.acoustid_plugin import AcoustIdPlugin
+from kalinka_plugin_localfiles.indexer.indexer_db import AsyncIndexerDb
+
+
+@pytest.fixture
+def config(tmp_path):
+    return LocalFilesConfig(
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_reassign_album_touches_only_album_id(config):
+    await init_db(config.db_path)
+    db = AsyncIndexerDb(config)
+    async with aiosqlite.connect(config.db_path) as conn:
+        await conn.execute(
+            "INSERT INTO tracks (id, title, album_id, artist_id, file_path, "
+            "format, mbid, enriched) VALUES ('t1', 'T', 'old_album', 'a', "
+            "'/m/t1.flac', 'flac', 'rec-mbid', 1)"
+        )
+        await conn.execute(
+            "INSERT INTO albums (id, title) VALUES ('old_album', 'Old'), "
+            "('new_album', 'New')"
+        )
+        await conn.commit()
+
+    await db.reassign_album("t1", "new_album")
+
+    async with aiosqlite.connect(config.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        row = dict(await (await conn.execute(
+            "SELECT * FROM tracks WHERE id='t1'")).fetchone())
+    assert row["album_id"] == "new_album"
+    assert row["mbid"] == "rec-mbid"   # enricher column preserved
+    assert row["enriched"] == 1
+
+
+def test_acoustid_has_no_album_creation_path():
+    # The album-create/track-move code is gone; enrich_track can no longer
+    # emit album_id.
+    assert not hasattr(AcoustIdPlugin, "_create_or_get_album")

--- a/packages/kalinka-plugin-localfiles/tests/test_recluster_apply.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_recluster_apply.py
@@ -107,6 +107,25 @@ async def test_untagged_folder_gets_named_album(indexer):
 
 
 @pytest.mark.asyncio
+async def test_recluster_cleans_path_artifact_title(indexer):
+    fi, music, config = indexer
+    folder = music / "1993. Jean Michel Jarre - Chronology (Sony 88875129492, Russia)"
+    for i in range(1, 5):
+        _flac(folder / f"{i}. Track {i}.flac", title=f"T{i}",
+              artist="Jean Michel Jarre", albumartist="Jean Michel Jarre",
+              album="Chronology (Sony 88875129492, Russia)", tracknumber=str(i))
+        await fi.process_file(str(folder / f"{i}. Track {i}.flac"))
+
+    await fi.recluster()
+
+    title = await _scalar(
+        config, "SELECT title FROM albums WHERE id IN "
+        "(SELECT DISTINCT album_id FROM tracks WHERE file_path LIKE ?)",
+        (f"{folder}%",))
+    assert title == "Chronology"   # catalog parenthetical stripped
+
+
+@pytest.mark.asyncio
 async def test_recluster_idempotent(indexer):
     fi, music, config = indexer
     folder = music / "Album X"

--- a/packages/kalinka-plugin-localfiles/tests/test_recluster_apply.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_recluster_apply.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Tests for Phase-1 1g/2: the recluster applier. Indexes real files, runs
+recluster(), and checks album grouping, album_cluster rows, aliasing and
+idempotency.
+"""
+
+import aiosqlite
+import numpy as np
+import pytest
+import pytest_asyncio
+import soundfile as sf
+from mutagen.flac import FLAC
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.indexer.indexer import FileIndexer
+from kalinka_plugin_localfiles.indexer.indexer_db import AsyncIndexerDb
+
+
+@pytest_asyncio.fixture
+async def indexer(tmp_path):
+    music = tmp_path / "music"
+    music.mkdir()
+    config = LocalFilesConfig(
+        music_folders=[str(music)],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+        quiescence_seconds=0,
+        folder_first_clustering=True,
+    )
+    await init_db(config.db_path)
+    return FileIndexer(config, AsyncIndexerDb(config)), music, config
+
+
+def _flac(path, **tags):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(path), np.zeros(2205, dtype="float32"), 44100, format="FLAC")
+    a = FLAC(str(path))
+    for k, v in tags.items():
+        a[k] = v
+    a.save()
+
+
+async def _albums_of(config, track_ids):
+    async with aiosqlite.connect(config.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        out = {}
+        for tid in track_ids:
+            row = await (await conn.execute(
+                "SELECT album_id FROM tracks WHERE id=?", (tid,))).fetchone()
+            out[tid] = row["album_id"] if row else None
+        return out
+
+
+async def _scalar(config, sql, params=()):
+    async with aiosqlite.connect(config.db_path) as conn:
+        return (await (await conn.execute(sql, params)).fetchone())[0]
+
+
+@pytest.mark.asyncio
+async def test_tag_variants_merge_into_one_album(indexer):
+    fi, music, config = indexer
+    # Same folder, two album-tag variants that today would be two albums.
+    folder = music / "Air - Everybody Hertz"
+    ids = []
+    for i in range(1, 7):
+        p = folder / f"{i:02d}.flac"
+        _flac(p, title=f"T{i}", artist="Air", albumartist="Air",
+              album="Everybody Hertz", tracknumber=str(i))
+        ids.append((await fi.process_file(str(p)))["tracks"])
+    for i in range(7, 11):
+        p = folder / f"{i:02d}.flac"
+        _flac(p, title=f"T{i}", artist="Air", albumartist="Air",
+              album="Air - Everybody Hertz", tracknumber=str(i))
+        ids.append((await fi.process_file(str(p)))["tracks"])
+
+    # Before reclustering: two distinct albums (the fragmentation bug).
+    assert len(set((await _albums_of(config, ids)).values())) == 2
+
+    await fi.recluster()
+
+    albums = await _albums_of(config, ids)
+    assert len(set(albums.values())) == 1  # one album now
+    # album_cluster row exists for it.
+    assert await _scalar(config, "SELECT COUNT(*) FROM album_cluster") >= 1
+
+
+@pytest.mark.asyncio
+async def test_untagged_folder_gets_named_album(indexer):
+    fi, music, config = indexer
+    folder = music / "Some Bootleg"
+    ids = []
+    for i in range(1, 5):
+        p = folder / f"{i:02d}.flac"
+        _flac(p, artist="Unknown", tracknumber=str(i))  # no album tag
+        ids.append((await fi.process_file(str(p)))["tracks"])
+
+    await fi.recluster()
+
+    albums = await _albums_of(config, ids)
+    assert len(set(albums.values())) == 1
+    album_id = next(iter(albums.values()))
+    assert album_id != "unknown_album"
+    title = await _scalar(config, "SELECT title FROM albums WHERE id=?", (album_id,))
+    assert title == "Some Bootleg"
+
+
+@pytest.mark.asyncio
+async def test_recluster_idempotent(indexer):
+    fi, music, config = indexer
+    folder = music / "Album X"
+    for i in range(1, 6):
+        _flac(folder / f"{i:02d}.flac", title=f"T{i}", artist="Band",
+              albumartist="Band", album="Album X", tracknumber=str(i))
+        await fi.process_file(str(folder / f"{i:02d}.flac"))
+
+    r1 = await fi.recluster()
+    snapshot = await _scalar(config, "SELECT COUNT(*) FROM tracks")
+    r2 = await fi.recluster()
+    # Second run re-points nothing and creates no aliases (semantic no-op).
+    assert r2["reassigned"] == 0
+    assert r2["aliases"] == 0
+    assert await _scalar(config, "SELECT COUNT(*) FROM tracks") == snapshot

--- a/packages/kalinka-plugin-localfiles/tests/test_schema_library_file.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_schema_library_file.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Tests for the Phase-0 evidence schema (library_file + track_evidence):
+
+  1. A fresh DB has both tables with the expected columns.
+  2. Re-running init_db over a legacy DB backfills library_file from the
+     existing tracks (path-derived id becomes the initial file_id).
+  3. The backfill is idempotent — a second init_db adds no rows and
+     leaves an existing library_file row untouched.
+"""
+
+import aiosqlite
+import pytest
+
+from kalinka_plugin_localfiles.db_schema import init_db
+
+LIBRARY_FILE_COLS = {
+    "file_id",
+    "current_path",
+    "size_bytes",
+    "modified_at",
+    "device_id",
+    "inode",
+    "content_hash",
+    "first_indexed",
+}
+TRACK_EVIDENCE_COLS = {
+    "track_id",
+    "raw_tags",
+    "stream_info",
+    "art_phash",
+    "cue_sheet",
+    "fingerprint",
+    "fp_computed_at",
+    "import_batch",
+    "updated_at",
+}
+
+
+async def _cols(conn, table):
+    cur = await conn.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cur.fetchall()}
+
+
+@pytest.mark.asyncio
+async def test_fresh_db_has_evidence_tables(tmp_path):
+    db_path = str(tmp_path / "fresh.db")
+    await init_db(db_path)
+    async with aiosqlite.connect(db_path) as conn:
+        assert await _cols(conn, "library_file") == LIBRARY_FILE_COLS
+        assert await _cols(conn, "track_evidence") == TRACK_EVIDENCE_COLS
+        cur = await conn.execute("SELECT COUNT(*) FROM library_file")
+        assert (await cur.fetchone())[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_backfill_from_existing_tracks(tmp_path):
+    db_path = str(tmp_path / "legacy.db")
+    # A legacy DB predating library_file: just the tracks columns the
+    # backfill reads.
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute(
+            """
+            CREATE TABLE tracks (
+                id TEXT PRIMARY KEY, title TEXT NOT NULL,
+                file_path TEXT NOT NULL, format TEXT NOT NULL,
+                file_size BIGINT, modified_time INTEGER, last_updated INTEGER
+            )
+            """
+        )
+        await conn.executemany(
+            "INSERT INTO tracks (id, title, file_path, format, file_size, "
+            "modified_time, last_updated) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("track_aaa", "A", "/m/a.flac", "audio/flac", 111, 1000, 1710000000),
+                ("track_bbb", "B", "/m/b.flac", "audio/flac", 222, 2000, 1710000001),
+            ],
+        )
+        await conn.commit()
+
+    await init_db(db_path)
+
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        cur = await conn.execute("SELECT * FROM library_file ORDER BY file_id")
+        rows = [dict(r) for r in await cur.fetchall()]
+    assert len(rows) == 2
+    a = rows[0]
+    assert a["file_id"] == "track_aaa"          # path-hash id becomes file_id
+    assert a["current_path"] == "/m/a.flac"
+    assert a["size_bytes"] == 111
+    assert a["modified_at"] == 1000
+    assert a["first_indexed"] == 1710000000     # last_updated is best-effort
+    assert a["device_id"] is None               # filled on next scan
+    assert a["inode"] is None
+
+
+@pytest.mark.asyncio
+async def test_backfill_idempotent(tmp_path):
+    db_path = str(tmp_path / "legacy.db")
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute(
+            """
+            CREATE TABLE tracks (
+                id TEXT PRIMARY KEY, title TEXT NOT NULL,
+                file_path TEXT NOT NULL, format TEXT NOT NULL,
+                file_size BIGINT, modified_time INTEGER, last_updated INTEGER
+            )
+            """
+        )
+        await conn.execute(
+            "INSERT INTO tracks (id, title, file_path, format, file_size, "
+            "modified_time, last_updated) VALUES "
+            "('track_aaa', 'A', '/m/a.flac', 'audio/flac', 111, 1000, 1710000000)"
+        )
+        await conn.commit()
+
+    await init_db(db_path)
+    # A later scan sets device/inode; a second init_db must not clobber it
+    # or duplicate the row.
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute(
+            "UPDATE library_file SET device_id = '64512', inode = '999' "
+            "WHERE file_id = 'track_aaa'"
+        )
+        await conn.commit()
+
+    await init_db(db_path)
+
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        cur = await conn.execute("SELECT * FROM library_file")
+        rows = [dict(r) for r in await cur.fetchall()]
+    assert len(rows) == 1
+    assert rows[0]["device_id"] == "64512"      # preserved, not reset
+    assert rows[0]["inode"] == "999"

--- a/packages/kalinka-plugin-localfiles/tests/test_title_normalize.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_title_normalize.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Tests for normalize_album_title (Phase 2, 2h) — deterministic cleanup of
+folder/tag-derived album titles. Cases drawn from a real library's
+path-artifact titles, plus protective cases for titles that must NOT change.
+"""
+
+import pytest
+
+from kalinka_plugin_localfiles.clustering.classify import normalize_album_title
+
+
+@pytest.mark.parametrize("raw,clean", [
+    # Real path-artifact titles from the assessed library:
+    ("1993. Jean Michel Jarre - Chronology (Sony 88875129492, Russia)",
+     "Jean Michel Jarre - Chronology"),
+    ("1982 - Roxy Music - Avalon (EG, EGHP 50, UK, 24-192)",
+     "Roxy Music - Avalon"),
+    ("1976. Jean Michel Jarre - Oxygene (Sony-BMG 88843089342, Russia)",
+     "Jean Michel Jarre - Oxygene"),
+    ("{uaoa}Ellington, Mingus, Roach - Money Jungle",
+     "Ellington, Mingus, Roach - Money Jungle"),
+    ("Playlist - Urban - 500604904 --- Jamendo - MP3",
+     "Playlist - Urban"),
+])
+def test_strips_junk(raw, clean):
+    assert normalize_album_title(raw) == clean
+
+
+@pytest.mark.parametrize("title", [
+    "Abbey Road",
+    "The Wall",
+    "Blade Runner (Soundtrack)",          # descriptive paren kept
+    "OK Computer (Remastered)",           # descriptive paren kept
+    "Live at Wembley (Live)",
+    "Greatest Hits Vol. 2",               # volume kept (not a catalog paren)
+    "The Best Of Michael Jackson (Disk 2)",  # disc marker left to disc logic
+    "Discovery (2001)",                   # bare year in paren kept
+    "1984",                               # a title that *is* a year
+])
+def test_leaves_real_titles_untouched(title):
+    assert normalize_album_title(title) == title
+
+
+def test_empty_and_none_safe():
+    assert normalize_album_title("") == ""
+    assert normalize_album_title("(Sony 12345678)") == "(Sony 12345678)"  # all junk -> keep original
+    # Idempotent.
+    once = normalize_album_title("1993. Foo - Bar (Sony 88875129492, Russia)")
+    assert normalize_album_title(once) == once

--- a/packages/kalinka-plugin-localfiles/tests/test_track_move_continuity.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_track_move_continuity.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+A renamed or moved file keeps its identity: same track id, same
+first_indexed, evidence and enrichment intact — the paths are re-pointed via
+(device, inode) detection instead of delete-plus-create. A copy (old file
+still present) mints a new identity.
+"""
+
+import os
+
+import aiosqlite
+import numpy as np
+import pytest
+import pytest_asyncio
+import soundfile as sf
+from mutagen.flac import FLAC
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.indexer.indexer import FileIndexer
+from kalinka_plugin_localfiles.indexer.indexer_db import AsyncIndexerDb
+
+
+@pytest_asyncio.fixture
+async def indexer(tmp_path):
+    music = tmp_path / "music"
+    music.mkdir()
+    config = LocalFilesConfig(
+        music_folders=[str(music)],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+        quiescence_seconds=0,
+    )
+    await init_db(config.db_path)
+    return FileIndexer(config, AsyncIndexerDb(config)), music, config
+
+
+def _flac(path, **tags):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(path), np.zeros(2205, dtype="float32"), 44100, format="FLAC")
+    a = FLAC(str(path))
+    for k, v in tags.items():
+        a[k] = v
+    a.save()
+
+
+async def _row(config, sql, params=()):
+    async with aiosqlite.connect(config.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        row = await (await conn.execute(sql, params)).fetchone()
+        return dict(row) if row else None
+
+
+async def _enrich(config, track_id):
+    async with aiosqlite.connect(config.db_path) as conn:
+        await conn.execute(
+            "UPDATE tracks SET mbid='rec-1', enriched=1 WHERE id=?", (track_id,)
+        )
+        await conn.execute(
+            "UPDATE track_evidence SET fingerprint='FP' WHERE track_id=?",
+            (track_id,),
+        )
+        await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_rename_keeps_identity(indexer):
+    fi, music, config = indexer
+    old = music / "Album" / "old name.flac"
+    _flac(old, title="T", artist="A", album="X")
+    track_id = (await fi.process_file(str(old)))["tracks"]
+    await _enrich(config, track_id)
+    lf = await _row(config, "SELECT * FROM library_file WHERE file_id=?", (track_id,))
+    first_indexed = lf["first_indexed"]
+
+    new = music / "Album" / "new name.flac"
+    os.rename(old, new)
+    result = await fi.process_file(str(new))
+    assert result is None  # unchanged content: paths re-pointed, then skipped
+
+    t = await _row(config, "SELECT * FROM tracks WHERE id=?", (track_id,))
+    assert t is not None
+    assert t["file_path"] == str(new)
+    assert t["mbid"] == "rec-1"                 # enrichment intact
+    lf = await _row(config, "SELECT * FROM library_file WHERE file_id=?", (track_id,))
+    assert lf["current_path"] == str(new)
+    assert lf["first_indexed"] == first_indexed  # not re-minted
+    ev = await _row(config, "SELECT * FROM track_evidence WHERE track_id=?", (track_id,))
+    assert ev["fingerprint"] == "FP"             # evidence intact
+    n = await _row(config, "SELECT COUNT(*) c FROM tracks")
+    assert n["c"] == 1                           # no duplicate row
+
+
+@pytest.mark.asyncio
+async def test_move_across_folders_keeps_identity(indexer):
+    fi, music, config = indexer
+    old = music / "Old Folder" / "01 song.flac"
+    _flac(old, title="T", artist="A", album="X")
+    track_id = (await fi.process_file(str(old)))["tracks"]
+
+    new = music / "New Folder" / "01 song.flac"
+    new.parent.mkdir(parents=True)
+    os.rename(old, new)
+    await fi.process_file(str(new))
+
+    t = await _row(config, "SELECT * FROM tracks WHERE id=?", (track_id,))
+    assert t["file_path"] == str(new)            # same id, new location
+
+
+@pytest.mark.asyncio
+async def test_copy_mints_new_identity(indexer):
+    fi, music, config = indexer
+    a = music / "Album" / "song.flac"
+    _flac(a, title="T", artist="A", album="X")
+    id_a = (await fi.process_file(str(a)))["tracks"]
+
+    b = music / "Album" / "song copy.flac"
+    import shutil
+
+    shutil.copy2(a, b)  # old path still exists -> not a move
+    id_b = (await fi.process_file(str(b)))["tracks"]
+
+    assert id_b != id_a
+    n = await _row(config, "SELECT COUNT(*) c FROM tracks")
+    assert n["c"] == 2

--- a/packages/kalinka-plugin-localfiles/tests/test_track_number_from_filename.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_track_number_from_filename.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+The indexer parses a leading "NN." track number from the filename when the
+file has no track-number tag, so an album sorts correctly at scan time (not
+only after the enricher's filesystem fallback runs). Regression for albums
+whose tracks otherwise sorted lexicographically (1, 10, 2, 3, ...).
+"""
+
+import aiosqlite
+import numpy as np
+import pytest
+import pytest_asyncio
+import soundfile as sf
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.indexer.indexer import FileIndexer
+from kalinka_plugin_localfiles.indexer.indexer_db import AsyncIndexerDb
+from kalinka_plugin_localfiles.utils.name_utils import parse_leading_track_number
+
+
+def test_parse_leading_track_number():
+    assert parse_leading_track_number("1. Итальянец (L'Italiano)") == 1
+    assert parse_leading_track_number("10. Женщина (Donna)") == 10
+    assert parse_leading_track_number("03 - Soli") == 3
+    assert parse_leading_track_number("07_ Innamorati") == 7
+    assert parse_leading_track_number("Untitled") is None
+    assert parse_leading_track_number("No Number Here") is None
+
+
+@pytest_asyncio.fixture
+async def indexer(tmp_path):
+    music = tmp_path / "music"
+    music.mkdir()
+    config = LocalFilesConfig(
+        music_folders=[str(music)],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+        quiescence_seconds=0,
+    )
+    await init_db(config.db_path)
+    return FileIndexer(config, AsyncIndexerDb(config)), music, config
+
+
+@pytest.mark.asyncio
+async def test_indexer_orders_by_filename_number_without_tags(indexer):
+    fi, music, config = indexer
+    folder = music / "Toto Cutugno - 1985"
+    # Ten untagged FLACs named "N. Title" (no track-number tag).
+    for n in [1, 2, 3, 10]:
+        p = folder / f"{n}. Song {n}.flac"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(str(p), np.zeros(2205, dtype="float32"), 44100, format="FLAC")
+        await fi.process_file(str(p))
+
+    async with aiosqlite.connect(config.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        cur = await conn.execute(
+            "SELECT track_number, file_path FROM tracks "
+            "ORDER BY COALESCE(disc_number,1), track_number, title"
+        )
+        order = [r["track_number"] for r in await cur.fetchall()]
+    # Sorted numerically (1,2,3,10), not lexicographically (1,10,2,3).
+    assert order == [1, 2, 3, 10]

--- a/packages/kalinka-plugin-localfiles/tests/test_track_number_from_filename.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_track_number_from_filename.py
@@ -37,6 +37,15 @@ def test_parse_no_space_dot_prefix():
     assert parse_leading_track_number("2001.A Space Odyssey") is None
 
 
+def test_year_prefix_not_eaten_in_spaced_forms():
+    # The spaced patterns are capped at three digits, so a 4-digit year is
+    # never a track number — while 100+ tracks on big sets still parse.
+    assert parse_leading_track_number("1985. Some Song") is None
+    assert parse_leading_track_number("1985- Some Song") is None
+    assert parse_leading_track_number("1985_ Some Song") is None
+    assert parse_leading_track_number("100. Title") == 100
+
+
 @pytest_asyncio.fixture
 async def indexer(tmp_path):
     music = tmp_path / "music"

--- a/packages/kalinka-plugin-localfiles/tests/test_track_number_from_filename.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_track_number_from_filename.py
@@ -28,6 +28,15 @@ def test_parse_leading_track_number():
     assert parse_leading_track_number("No Number Here") is None
 
 
+def test_parse_no_space_dot_prefix():
+    # "N.Title" with no space after the dot (common in ripped folders).
+    assert parse_leading_track_number("1.Кончится лето") == 1
+    assert parse_leading_track_number("12.Track") == 12
+    # A year prefix must never be eaten as a track number (>2 digits).
+    assert parse_leading_track_number("1985.Some Song") is None
+    assert parse_leading_track_number("2001.A Space Odyssey") is None
+
+
 @pytest_asyncio.fixture
 async def indexer(tmp_path):
     music = tmp_path / "music"


### PR DESCRIPTION
## Summary

First two phases of the local-library enrichment redesign: stop destroying evidence at index time (Phase 0), then group albums folder-first from multiple signals instead of one album tag per track (Phase 1) — plus early Phase-2 title cleanup and track-ordering fixes. 20 commits, each self-contained and green.

### Phase 0 — evidence capture (never lose data again)
- `library_file`: stable per-file identity (path becomes a mutable attribute; `first_indexed` written once, so Recently Added stops churning on rescans).
- `track_evidence`: verbatim raw tags (incl. albumartist/compilation, which the display tables never carried), stream info, embedded-art perceptual hash, persisted chromaprints.
- Re-indexing a changed file is now a **surgical UPDATE**: mbid, embeddings and mood survive a retag (previously nulled by `INSERT OR REPLACE` — on an 8k test library that protects ~3.4k MB matches and ~5.8k CLAP embeddings).

### Phase 1 — folder-first clustering (on by default)
One folder is one album unless compelling evidence says otherwise. Tag-only variance merges; distinct artwork keeps real releases apart; V/A folders become Various-Artists compilations; generic dumps stay loose; disc-sibling folders fuse into one multi-disc album. Album ids are stable across re-runs (overlap reattach + alias table), and album membership is single-owner: AcoustID can no longer create albums or move tracks (the "one fingerprint match fragments a coherent rip" bug).

Simulated with the shipped planner on an 8k-track library: 54 split folders → 20 (all legitimately multi-release), 58 tag-variant merges (e.g. one folder that had fractured into 14 "albums" → 4 real ones), 1,265 of 2,071 `unknown_album` tracks recovered into 55 compilations, loose dumps correctly left alone.

### Fixes riding along
- Track numbers parse from filenames at index time (`"1. Title"`, `"1.Title"` no-space variant), so untagged rips sort correctly instead of 1, 10, 2, 3…
- Title cleanup: disc suffixes on multi-disc sets, and a normalizer for folder junk (`"1993. Artist - Album (Sony 88875129492, Russia)"` → `"Artist - Album"`); validated on a real library — cleans 10/71 titles, zero false positives.
- FilesystemFallback `ENRICHER_VERSION` bump: previously-FAILED rows retry once on upgrade and pick up the new parsing.
- Dead config fields removed (`dimensions`, `weight_clap_similarity`, `weight_popularity`, `fallback_coverage_threshold`); persisted configs still validate (`extra=ignore`).

## Behavior changes
- Folder-first clustering **on by default** (no installed base to gate; the old V/A-only pass remains behind the flag).
- AcoustID no longer assigns/creates albums even with the flag off — album membership belongs to clustering.
- One-time enrichment retry sweep on first start after upgrade (rate-limited).

## Test plan
- 391 plugin tests green (56 new across schema/evidence/signals/engine/planner/merge/identity/applier/normalizer); server suite green (388, playqueue deselected as the known pre-existing flake).
- Validated live on a real library: grouping assessed correct (folder splits healed, compilations formed, untagged rips titled), `assess-enrichment` run before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)