### PR TITLE
Enrichment redesign, Phase 2 foundations: single-writer librarian + claims/resolution schema

### DIFF
--- a/docs/enrichment-clustering-redesign.md
+++ b/docs/enrichment-clustering-redesign.md
@@ -1,0 +1,1380 @@
+# Enrichment & album-grouping redesign — design proposal
+
+Status: **proposal / brainstorm** — no code yet.
+Scope: `kalinka-plugin-localfiles` (indexer, enricher, browse layer), with minor
+server-side UI implications in the review-workflow section.
+
+All file references are to
+`packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/`.
+Empirical numbers come from the 2026-06-16 assessment of a real tester library
+(1608 artists · 696 albums · 7991 tracks — `tmp/enrichment_assess/`).
+
+---
+
+## 1. Diagnosis: why the current pipeline splits coherent albums
+
+### 1.1 Album identity is an eager, brittle hash
+
+An album *is* its ID, and the ID is computed per-track at index time:
+
+```
+album_id = md5( album_folder(file_path) + "\0" + normalize_for_id(album_tag) )
+```
+
+(`utils/id_generator.py:31-48`, called from `indexer/indexer.py:469-471`.)
+
+Grouping is therefore a **pure function of two fragile inputs** evaluated
+independently for every file, with no group-level view:
+
+- **Any variance in the album tag inside one folder mints a new album.**
+  "Everybody Hertz" vs "Air - Everybody Hertz" → two albums. The tester DB has
+  45 folders split this way; the worst (`/music/Air`) fractured into 14
+  "albums", several of which are single-track shards named after stray tags
+  (`MTV Hits '99`, `Playground Love`) or even a filename
+  (`Le solei est prs de moi.mp3`).
+- **A missing album tag doesn't fall back to the folder** — it falls into the
+  single library-wide `unknown_album` sentinel (`id_generator.py:41-44`). A
+  fully untagged vinyl rip in a clean `Some Album/` folder produces *no* album
+  at all, pooled with every other untagged track in the library.
+- **The same tag in two folders → two albums** (the folder half of the key).
+  This is deliberate (16-bit vs 24-bit sibling rips), but it also means
+  `Album/CD1`-style layouts survive only because of one regex
+  (`_DISC_SUBDIR_RE`, `utils/name_utils.py:38`); `Friends Of The Random
+  Summer CD1/CD2/CD3` as *tag suffixes* (not subdirs) → 3 albums.
+
+### 1.2 The pipeline decides once, then mutates blindly
+
+The conceptual flow is `scan → tag-read → per-entity enrichment → done`, and
+each stage commits irreversibly:
+
+- The indexer's `INSERT OR REPLACE` (`indexer/indexer_db.py:155`) rewrites the
+  whole track row on any mtime change, discarding enricher-written fields
+  (mbid, embeddings, mood) and re-deriving grouping from scratch. Raw tags are
+  **not persisted** — only the cleaned display strings survive, and
+  `albumartist`/TPE2 and the compilation flag are never read at all
+  (`indexer.py:549-667`).
+- `albums.artist_id` is **first-writer-wins**: whichever track happens to be
+  processed first anchors the album's artist (`indexer.py:479`), and later
+  tracks never correct it.
+- AcoustID enrichment can silently *move a single track to a different (or
+  brand-new) album row* (`acoustid_plugin.py:718`, `_create_or_get_album`
+  `:518-566`) based on one fingerprint match, with no view of the 11 sibling
+  tracks that stayed behind — exactly the "uncertain external metadata
+  fragments a coherent local album" failure. It also unconditionally
+  overwrites the track title (`acoustid_plugin.py:680`).
+- Enrichment success is defined by **required fields**, not by confidence:
+  a track without an `mbid` ends `FAILED` even if its metadata is complete
+  (`enricher.py:32-41`), and `FAILED` is terminal until the enrichment
+  fingerprint changes. There is no notion of "locally coherent album with no
+  external identity" — that state is unrepresentable.
+
+### 1.3 Nothing records uncertainty, so nothing can be reconsidered
+
+The schema has `match_score`/`match_similarity` (with per-source,
+incomparable semantics — MB ext:score vs AcoustID confidence×100 vs an
+in-release composite that can exceed 100) and a 3-state `enriched` flag.
+There is no per-field provenance, no record of conflicting candidate values,
+no grouping confidence, and no user-correction store (the only user lever is
+a full purge-and-rescan, `module_setup.py:158-167`). Once a wrong decision is
+written, the evidence that could have contradicted it is gone.
+
+### 1.4 What already works and must be preserved
+
+The system is not naive; three pieces are genuinely good and should survive
+the redesign as *rules inside a better framework*:
+
+- The **V/A folder coalesce pass** (`indexer.py:703-856`): folder-level
+  reasoning with thresholds (≥4 distinct artists, ≥0.5 uniqueness), a
+  generic-dump denylist, parent-artist remix anchoring. This is exactly the
+  shape of reasoning the whole pipeline needs — it's just bolted on for one
+  special case.
+- **Album-before-track enrichment coupling**: MB matches the album release
+  first, then constrains track lookup to that release's tracklist
+  (`musicbrainz_plugin.py:568-649`), and AcoustID gives +1000 to recordings
+  on the local album's release. This *is* album-level external matching; it
+  just lacks a way to say "no release fits, keep the local grouping".
+- **Ambiguity margins** ("holding as orphan rather than committing",
+  `musicbrainz_plugin.py:471-482`): the codebase already prefers abstaining
+  to guessing. The redesign generalizes that stance to grouping itself.
+
+---
+
+## 2. Alternative clustering architectures
+
+Five candidates, evaluated against: no labeled training data exists; libraries
+run 10³–10⁵ tracks on modest hardware; results must be stable across rescans;
+the user must be able to understand *why* a grouping happened.
+
+### A. Layered deterministic rules with confidence (folder-first)
+
+Invert the current precedence: **the folder is the unit of grouping**; tags
+vote on how many albums a folder contains rather than each distinct tag
+minting one. A per-folder pass runs split/merge rules (track-number sequence
+analysis, artwork groups, tag consensus) and emits clusters with a confidence
+score and a provenance trail.
+
+- **Pros:** deterministic, debuggable, idempotent, O(files); directly fixes
+  every observed failure class (45 folder splits, untagged rips, V/A);
+  generalizes the existing V/A pass instead of replacing it.
+- **Cons:** hand-set thresholds; cross-folder merges need separate rules;
+  confidence numbers are ordinal, not calibrated probabilities.
+
+### B. Pairwise scoring → graph clustering (weighted edges, connected components / correlation clustering)
+
+Score `P(same album)` for track pairs within a blocking scope, build a graph,
+cut it. Correlation clustering (maximize agreement with edge signs) or simple
+thresholded connected components.
+
+- **Pros:** principled handling of conflicting evidence; negative edges
+  (disjoint track sequences, different artwork) naturally force splits;
+  extensible — a new signal is just a new edge term.
+- **Cons:** pairwise is O(n²) per block (fine within folders, dangerous
+  globally); correlation clustering is NP-hard in general (needs greedy/pivot
+  approximations); connected components are fragile — one spurious strong
+  edge merges two albums transitively; results can be unstable under small
+  score perturbations, which is poison for rescan stability.
+
+### C. Learned pairwise classifier (logistic regression / GBT) + constrained clustering
+
+Same graph as B, but edge weights come from a trained model over the signal
+vector; user corrections become labels over time.
+
+- **Pros:** weights calibrated from data instead of intuition; logistic
+  regression stays inspectable.
+- **Cons:** **there is no training data today** and won't be until a
+  correction UI ships and accumulates months of labels; a model trained on
+  one user's library overfits their tagging habits; adds a model artifact to
+  ship/version for marginal gain — the within-folder decision space is small
+  enough that rules cover it.
+
+### D. Probabilistic graphical model / full entity-resolution framework
+
+Joint inference over track→cluster and cluster→release assignments
+(e.g. a factor graph, Dedupe-style fellegi-sunter EM).
+
+- **Pros:** the theoretically "right" formulation; uncertainty is native.
+- **Cons:** massive complexity for a self-hosted music server; inference cost
+  and non-determinism; near-impossible to debug ("why did my album split?" →
+  "the posterior moved"); rejected outright.
+
+### E. Density clustering on audio embeddings (DBSCAN/HDBSCAN over CLAP)
+
+Rejected for membership decisions. This project has **measured** that CLAP
+distances are not a usable relevance signal even for search ranking; albums
+routinely span acoustic styles (intros, interludes, a ballad on a metal
+record) while two albums by one artist are acoustically closer than tracks
+within a compilation. Embeddings stay in search, out of grouping (see §8).
+
+### Verdict
+
+**A, essentially alone.** Folders are already natural clusters; the job is
+not to build clusters from track pairs but to decide, per folder, whether
+convincing evidence forces a split — and >95 % of folders never present any.
+B survives only as a vocabulary: the *signal table* (§5.2) defines what
+counts as evidence and how strongly, and in the rare ambiguous folder those
+signals are summed per candidate partition as a tiebreak. No graph is built,
+no correlation clustering or connected components run — that formalism is
+heavier than the problem, and its instability under small perturbations is
+exactly what rescan stability cannot afford. C is a later calibration layer
+over the same signals if/when user-correction labels accumulate — the
+architecture should make swapping hand weights for learned weights a config
+change, not a rewrite. D and E are rejected.
+
+---
+
+## 3. Recommended architecture
+
+```
+                       files on disk
+                            │ scan / inotify
+                            ▼
+        ┌──────────────────────────────────────────┐
+        │ EVIDENCE COLLECTION (indexer, extended)   │
+        │  raw tags (incl. albumartist, compilation,│
+        │  all values verbatim) · stream info ·      │
+        │  artwork hash · cue sheets · mtimes        │
+        │  → track_evidence rows (current snapshot,  │
+        │    upserted in place, never dropped)       │
+        └────────────────┬─────────────────────────┘
+                         ▼  per dirty folder
+        ┌──────────────────────────────────────────┐
+        │ CLUSTERING PASS (new, deterministic)      │
+        │  folder = block → partition rules →       │
+        │  album clusters + confidence + provenance │
+        │  cross-folder merge rules (disc suffixes, │
+        │  cue/sibling patterns)                    │
+        └────────────────┬─────────────────────────┘
+                         ▼
+        ┌──────────────────────────────────────────┐
+        │ METADATA RESOLUTION                       │
+        │  claims (tag consensus, folder name,      │
+        │  external, user) → resolved fields on     │
+        │  albums/tracks (browse tables unchanged)  │
+        └────────────────┬─────────────────────────┘
+                         ▼
+        ┌──────────────────────────────────────────┐
+        │ ENRICHMENT (existing plugins, retargeted) │
+        │  album-level external match → release     │
+        │  candidates (claims, not overwrites)      │
+        │  track-level within matched release       │
+        │  AcoustID = last-resort track id only     │
+        └────────────────┬─────────────────────────┘
+                         ▼
+          reconciler re-runs RESOLUTION (and, with
+          hysteresis, CLUSTERING) for affected folders;
+          low-confidence cases → review queue
+```
+
+Principles:
+
+1. **Local grouping is primary.** A cluster exists because the files
+   physically cohere; external identity is an *annotation* on it, never its
+   source of existence. A cluster with zero release candidates is a fully
+   valid, "enriched" album.
+2. **Splitting requires positive evidence; tag variance alone is never
+   enough.** The default for one folder is one album.
+3. **Evidence is durable; decisions are derived and re-derivable.**
+   `track_evidence` is a *current snapshot* per file, updated in place — a
+   changed tag supersedes the old observation (no versioned history; the
+   resolver only ever reasons over what is currently true on disk). What is
+   never destroyed is the row itself and everything derived from it:
+   rescan re-reads evidence, not conclusions.
+4. **Membership changes only in the clustering pass** (with hysteresis), never
+   as a side effect of an enrichment plugin.
+5. **User corrections are pinned claims** — the top tier (§7) that resolution
+   can never override and rescans never destroy.
+6. **Entity-centric, pipeline-scheduled.** The durable model is a set of
+   *entities* — track, album cluster, artist, recording, release candidate —
+   each owning its raw evidence, inferred properties, external identities, and
+   relationships (this is what the tables in §4 already are). The
+   scan→cluster→resolve→enrich→reconcile flow is not a data model; it is the
+   *scheduler* that decides which entity to (re)compute when. The ordering is
+   real (artists can't be reconciled before albums are grouped; tracklists
+   can't be aligned before a cluster exists) but subordinate — every plugin's
+   job is "contribute evidence to an entity", never "run stage N".
+
+### 3.1 Process topology: merge indexer + enricher, keep the ML processes
+
+The current four-process model (indexer/enricher/searcher/embedder over
+shared SQLite/WAL, `module_setup.py`) is kept for the ML half and collapsed
+for the metadata half:
+
+- **Librarian** (merged indexer + enricher, one asyncio process): scan,
+  cluster, resolve, enrich — the *sole writer* of tracks/albums/artists,
+  claims, clusters, and release candidates. The staged pipeline survives as
+  phases inside this process, not as process boundaries.
+- **Embedder** unchanged: ~600 MB CLAP model, heavy CPU, load/unload
+  lifecycle — process isolation genuinely pays here.
+- **Searcher** unchanged: serves live queries, read-mostly, owns its
+  vec/FTS domain.
+
+Rationale: the enricher is a serial, rate-limited I/O loop (1 req/s MB,
+`limit=1` fetches) that needs neither a core nor memory isolation, while the
+redesign's scan→cluster→resolve→enrich→re-cluster loop is one state machine
+per folder. Split across two processes it requires either two copies of the
+reconciler rule engine (guaranteed drift — exactly the existing V/A
+duplication between `orphan_va_folder_tracks` and the fallback plugin's
+`_track_is_in_va_folder`) or a queue-RPC dance with folder locking. A single
+writer makes the core invariant — membership changes only in the clustering
+pass — enforceable by construction, and erases the current check-then-insert
+race class between indexer and enricher (no cross-process transactions
+exist). Merge prerequisites: move the sync `musicbrainzngs` calls to
+`asyncio.to_thread` so a slow lookup can't stall scanning (`fpcalc` is
+already a subprocess); keep the enrichment-fingerprint retry and one-shot
+config machinery as-is. Cost accepted: enricher crash isolation (already
+optional in the health rollup); gained: one fewer interpreter on Pi-class
+hosts and one fewer nudge-queue hop (indexer→enricher becomes an in-process
+call; the searcher nudge remains).
+
+To be precise about what is load-bearing here: the *requirement* is the
+**single-writer invariant** — exactly one process mutates entities. The
+merge is the cheapest implementation of it for this codebase; the
+alternative (scanner/provider workers sending evidence messages to a
+sole-writer librarian) preserves more crash isolation at the cost of a
+message protocol and is the documented fallback if the merge proves painful
+in practice. What is *not* acceptable is the status quo of two peer writers.
+
+### 3.2 Architecture at a glance
+
+The whole target system: evidence in, a single-writer librarian that clusters
+→ resolves → enriches → reconciles, durable entities beside the resolved
+browse view, and the two ML processes reading that view. Evidence sources and
+the review loop feed claims; nothing but the librarian writes entities.
+
+```mermaid
+flowchart TB
+    disk[(Files on disk<br/>mp3 · flac)]
+
+    subgraph LIB[Librarian process — sole entity writer]
+      direction TB
+      scan[scan / inotify] --> evc[evidence collection<br/>raw tags · stream info<br/>art phash · chromaprint]
+      evc --> clust[clustering pass<br/>folder-first partition<br/>+ V/A + disc-sibling merge]
+      clust --> resl[resolution<br/>claims → resolved view<br/>+ title normalize]
+      enr[enrichment plugins<br/>as claim emitters] --> resl
+      inf[library-wide inference<br/>artist · temporal] --> resl
+      resl -->|grouping field changed| recon[reconciler]
+      recon -. hysteresis .-> clust
+    end
+
+    disk --> scan
+
+    subgraph SRC[Evidence sources]
+      direction LR
+      tagc[tag consensus]
+      fname[filename parse]
+      aid[AcoustID rescue]
+      mbz[MusicBrainz]
+      art[Deezer / Wikidata art]
+    end
+    SRC --> enr
+    mbz --> rc
+
+    subgraph DATA[Durable entities · SQLite/WAL]
+      direction LR
+      lf[(library_file)]
+      te[(track_evidence)]
+      ac[(album_cluster)]
+      mc[(metadata_claims)]
+      ro[(resolved_origin)]
+      rc[(release_candidates)]
+      er[(entity_relation)]
+      mcn[(membership_constraint)]
+      view[(albums · artists · tracks<br/>resolved view)]
+    end
+    scan --> lf
+    evc --> te
+    clust --> ac
+    resl --> mc
+    resl --> ro
+    resl --> view
+    inf --> er
+
+    view --> browse[browse / playback API]
+    view --> emb[embedder process<br/>CLAP audio + text]
+    view --> srch[searcher process<br/>FTS + KNN]
+
+    recon --> rq[review queue<br/>needs_review]
+    rq --> usr[user decisions]
+    usr -->|pinned claims| mc
+    usr -->|membership pins| mcn
+    usr -->|confirmed links| er
+    mcn -. hard constraints .-> clust
+```
+
+Reading it: the **librarian** is the only box that writes the entity tables;
+**evidence sources** (local + external) contribute *claims*, never direct
+writes; **resolution** materializes the `albums/artists/tracks` view the rest
+of the app already consumes; the **reconciler** re-runs clustering under
+hysteresis when a grouping-relevant field changes; and **user decisions** from
+the review queue land as pinned claims / membership constraints / confirmed
+relations that the pipeline treats as hard, durable evidence. The embedder and
+searcher stay separate processes reading the resolved view.
+
+---
+
+## 4. Data model
+
+Design constraint: the browse layer (`localfiles.py`, `input_module_db.py`)
+and the server API consume `albums`/`artists`/`tracks` as they are. Keep those
+tables as the **resolved view**; add evidence/claims tables beside them. An
+album row *is* the materialization of a local album cluster.
+
+```sql
+-- Stable file identity, independent of path. THE fix for the path-derived
+-- track_id problem: identity is minted once; a rename/move updates
+-- current_path and nothing else. Move detection on rescan uses, in order:
+-- inotify file_moved events, (device_id, inode), content_hash/fingerprint
+-- corroboration, then size+mtime as weak evidence — falling back to
+-- new-file only when nothing matches. tracks.id becomes this file_id
+-- (old path-hash ids migrate once via entity_id_alias).
+CREATE TABLE library_file (
+    file_id        TEXT PRIMARY KEY,          -- opaque, minted once
+    current_path   TEXT NOT NULL UNIQUE,
+    size_bytes     INTEGER NOT NULL,
+    modified_at    INTEGER,
+    device_id      TEXT,                      -- st_dev; helps move detection
+    inode          TEXT,                      -- st_ino; not sole identity
+                                              -- (NAS/FUSE lie), corroborating
+    content_hash   TEXT,                      -- lazy; computed on demand
+    first_indexed  INTEGER NOT NULL           -- never rewritten
+);
+
+-- Verbatim per-file evidence. CURRENT SNAPSHOT semantics: upserted in place
+-- when the file changes (old observations are superseded, not versioned);
+-- the row survives rescans and is dropped only when the file is gone.
+CREATE TABLE track_evidence (
+    track_id       TEXT PRIMARY KEY,          -- = library_file.file_id = tracks.id
+    raw_tags       TEXT NOT NULL,             -- JSON: every tag verbatim, incl.
+                                              -- albumartist, compilation, date,
+                                              -- disc/track totals, sort names
+    stream_info    TEXT NOT NULL,             -- JSON: sample_rate, bit_depth,
+                                              -- channels, codec, encoder string
+    art_phash      TEXT,                      -- perceptual hash of embedded art
+    cue_sheet      TEXT,                      -- path of owning .cue, if any
+    fingerprint    TEXT,                      -- chromaprint, once computed
+    fp_computed_at INTEGER,
+    fs_created     INTEGER,                   -- (path/size/mtime/first_indexed
+                                              -- live on library_file)
+    import_batch   TEXT                       -- scan-session id
+);
+
+-- One row per local album cluster ≙ one albums row (albums.id = cluster id).
+-- Cluster↔folder is many-to-many (one folder can hold two albums; one
+-- multi-disc album can span sibling folders), so the folders a cluster
+-- occupies are DERIVED from member tracks' paths, not stored here;
+-- primary_folder is display/blocking convenience only.
+CREATE TABLE album_cluster (
+    album_id        TEXT PRIMARY KEY REFERENCES albums(id),
+    primary_folder  TEXT NOT NULL,            -- dominant folder (most members)
+    grouping_conf   REAL NOT NULL,            -- 0..1
+    grouping_basis  TEXT NOT NULL,            -- JSON provenance: which rules
+                                              -- fired, scores, outliers
+    kind            TEXT,                     -- album|compilation|multi_disc|
+                                              -- singles_pool|unknown
+    generation      INTEGER DEFAULT 0,        -- bumped on re-cluster (hysteresis)
+    needs_review    INTEGER DEFAULT 0,
+    review_reason   TEXT
+);
+
+-- Field-level claims. SPARSE, with a precise storage policy: ALWAYS stored
+-- are (a) winning non-local claims (external/inference values can expire or
+-- be rejected, so their full claim must be invalidatable), (b) all pinned
+-- claims, (c) all conflicts. NOT stored: uncontested purely-local values —
+-- those resolve straight into the entity row and are re-derivable from
+-- track_evidence; resolved_origin (below) still records their provenance.
+CREATE TABLE metadata_claims (
+    entity_type TEXT NOT NULL,                -- album|track|artist
+    entity_id   TEXT NOT NULL,
+    field       TEXT NOT NULL,                -- album_title, year, artist, ...
+    value       TEXT NOT NULL,
+    source      TEXT NOT NULL,                -- tag_consensus|folder_name|
+                                              -- library_inference|
+                                              -- musicbrainz:<mbid>|acoustid|
+                                              -- deezer|filesystem|user
+    tier        TEXT NOT NULL,                -- pinned|verified|observed|
+                                              -- inferred|guessed (see §7)
+    created_at  INTEGER,
+    PRIMARY KEY (entity_type, entity_id, field, source)
+);
+
+-- External identity candidates for a cluster (0..n, ranked, never exclusive).
+CREATE TABLE release_candidates (
+    album_id     TEXT NOT NULL REFERENCES albums(id),
+    provider     TEXT NOT NULL,               -- musicbrainz|qobuz|deezer
+    release_id   TEXT NOT NULL,               -- release mbid / catalogue id
+    rg_id        TEXT,                        -- release-group mbid
+    score        REAL NOT NULL,
+    coverage     REAL NOT NULL,               -- fraction of member tracks the
+                                              -- release explains
+    track_map    TEXT,                        -- JSON: track_id → (disc,pos,rec_mbid)
+    status       TEXT DEFAULT 'candidate',    -- candidate|accepted|rejected
+    fetched_at   INTEGER,
+    PRIMARY KEY (album_id, provider, release_id)
+);
+
+-- Per-track recording identity (from AcoustID / MB), separate from grouping.
+CREATE TABLE recording_identity (
+    track_id  TEXT NOT NULL,
+    provider  TEXT NOT NULL,
+    rec_id    TEXT NOT NULL,
+    score     REAL NOT NULL,
+    PRIMARY KEY (track_id, provider, rec_id)
+);
+
+-- Provenance for EVERY resolved field, including uncontested ones — this is
+-- what keeps sparse claims compatible with re-derivability: claims record
+-- only conflicts, but the winner's origin is always known, so the resolver
+-- can tell whether a value must be recomputed when its source's evidence
+-- changes or a provider is disabled. evidence_ref points at the specific
+-- backing object (a release_candidates key, a track_evidence field) so an
+-- expired/rejected candidate can invalidate exactly the values it produced.
+CREATE TABLE resolved_origin (
+    entity_type  TEXT NOT NULL,
+    entity_id    TEXT NOT NULL,
+    field        TEXT NOT NULL,
+    source       TEXT NOT NULL,
+    tier         TEXT NOT NULL,
+    evidence_ref TEXT,                        -- e.g. "release:musicbrainz:0d7f…"
+    resolved_at  INTEGER,
+    PRIMARY KEY (entity_type, entity_id, field)
+);
+
+-- Membership is a RELATIONSHIP, not a metadata field — user grouping
+-- decisions need their own durable store, not a prose promise. The
+-- reconciler treats these as hard constraints (the constrained-clustering
+-- element); they survive rescans via stable file/cluster identity.
+CREATE TABLE membership_constraint (
+    id               TEXT PRIMARY KEY,
+    kind             TEXT NOT NULL,           -- include|exclude|
+                                              -- keep_together|keep_separate
+    track_id         TEXT NOT NULL,
+    album_id         TEXT,                    -- for include/exclude
+    related_track_id TEXT,                    -- for keep_together/_separate
+    created_at       INTEGER NOT NULL
+);
+
+-- Semantic links between entities — the propagation channels §6.5 depends
+-- on. Distinct from entity_id_alias (which only redirects replaced local
+-- ids): a relation asserts a fact ABOUT two live entities.
+CREATE TABLE entity_relation (
+    source_type TEXT NOT NULL,
+    source_id   TEXT NOT NULL,
+    relation    TEXT NOT NULL,                -- same_identity|
+                                              -- possible_same_identity|
+                                              -- variant_of|release_group_member|
+                                              -- related_artist|
+                                              -- duplicate_recording|
+                                              -- alternate_master
+    target_type TEXT NOT NULL,
+    target_id   TEXT NOT NULL,
+    status      TEXT NOT NULL,                -- candidate|verified|rejected|pinned
+    source      TEXT NOT NULL,                -- what asserted it
+    created_at  INTEGER NOT NULL,
+    PRIMARY KEY (source_type, source_id, relation, target_type, target_id)
+);
+
+-- Old ids live on as aliases after splits/merges/id-migration, so artwork
+-- caches, playlists, and client bookmarks keep resolving. Chains are
+-- FLATTENED on write (merge of B into C rewrites A→B to A→C): resolution
+-- is always a single hop, never recursive.
+CREATE TABLE entity_id_alias (
+    old_id      TEXT PRIMARY KEY,
+    current_id  TEXT NOT NULL,
+    entity_type TEXT NOT NULL
+);
+```
+
+Changes to existing tables are minimal: `tracks`'s `album_id` now points at a
+cluster-backed album row; `albums.match_score/similarity` are superseded by
+`release_candidates.score` but kept for compatibility during migration. The
+destructive `INSERT OR REPLACE` on rescan is replaced by
+UPDATE-of-changed-columns so resolved/enriched fields survive
+(`indexer_db.py:155`).
+
+**Origin / era / language columns — one field, one meaning.** The field
+semantics of §6.5 (inference must never launder one field into another) only
+hold if the schema keeps the concepts in *separate* columns. Most exist; a
+few are added so "Italian 80s" can resolve on
+`artist_origin_country` + `original_release_year` without a release country
+or a lyric language leaking in:
+
+| concept | column | status |
+|---|---|---|
+| artist origin country | `artists.country` | ✅ exists |
+| artist area | `artists.area` | ✅ exists |
+| release / catalogue year | `albums.year` | ✅ exists (pin meaning to *release* year) |
+| original release year | `albums.original_year` | ✅ exists |
+| release language | `albums.language` | ✅ exists |
+| **release country** | `albums.country` | ➕ add |
+| **recording year** (track can predate the release) | `tracks.recording_year` | ➕ add |
+| **track language** (a track can differ from the release) | `tracks.language` | ➕ add |
+
+The added columns are nullable, best-effort, and never in `*_REQUIRED_FIELDS`
+(a missing value never fails enrichment) — matching how `country`/`area`/
+`original_year` were already introduced (`db_schema.py:317-336`). They are
+populated as resolved values from claims like anything else (external match,
+tag, or `library_inference`), so the raw tags in `track_evidence` remain the
+source and each resolved value carries a `resolved_origin`.
+
+**Stable cluster IDs.** The current title-dependent hash means resolving a
+better title would change the album's identity — unacceptable (playlists
+reference album context, artwork files are keyed by id). New scheme: the
+cluster id is **minted once and persisted** (an opaque random id; nothing
+derivable from mutable metadata), with explicit lifecycle semantics:
+
+- *Re-cluster:* one-to-one maximum-overlap matching between old and new
+  partitions (each old id assigned to at most one new cluster, deterministic
+  tie-breaking) — never the same old id to two new partitions.
+- *Split:* the child with the largest member overlap keeps the original id;
+  the others get fresh ids.
+- *Merge:* the dominant (largest, then oldest) cluster's id survives;
+  absorbed ids become rows in `entity_id_alias` so old references keep
+  resolving.
+- Title changes never touch identity.
+
+*Track identity:* solved the same way, not by migration heuristics.
+`track_id` is currently path-derived (`id_generator.py:51-53`), so a folder
+rename destroys track identity — and with it membership-overlap evidence
+and any pins. Rather than patching that with move-detection bolted onto a
+path hash, `library_file` makes file identity first-class: `tracks.id`
+becomes the once-minted `file_id`, `current_path` is just a mutable
+attribute, and a rename is an UPDATE. Move detection (inotify events,
+device/inode, content-hash/fingerprint corroboration, size+mtime as weak
+evidence) only decides *whether* an appearing path is an existing file —
+no single method is trusted alone, and a miss degrades to new-file, never
+to corrupted identity. Old path-hash ids migrate once through
+`entity_id_alias`. Pins that die on a folder rename would poison user
+trust in the whole review workflow; this closes that hole structurally.
+
+**Claims example** (the shape requested in the brief):
+
+```json
+{ "entity": "album_3f2a...", "field": "album_title", "claims": [
+    {"value": "Everybody Hertz", "source": "tag_consensus",  "tier": "observed"},
+    {"value": "Air",             "source": "folder_name",    "tier": "inferred"},
+    {"value": "Everybody Hertz", "source": "musicbrainz:0d7f…", "tier": "inferred"}
+]}
+```
+
+Resolution writes `albums.title = "Everybody Hertz"` (observed tag
+consensus beats both inferred claims; the fuzzy MB match agreeing with it
+is corroboration, not the winner) and records the winner in
+`resolved_origin`; the losing claims remain queryable as the conflict
+record. Had all sources agreed locally with no external claim, no claim
+rows would exist at all (storage policy above) — only the `resolved_origin`
+row.
+
+---
+
+## 5. Clustering: blocking, pairwise signals, album-level rules
+
+### 5.1 Blocking — who is ever compared with whom
+
+Whole-library pairwise comparison is banned. Candidate scopes, in order:
+
+1. **Folder** (primary block; after disc-subdir collapse). Covers ~all of the
+   observed failures. Within-folder n is typically 8–30; worst realistic case
+   a few hundred (the `/music` dump) — and since reasoning is per candidate
+   subgroup (tag buckets, sequence runs, art groups), not per track pair,
+   even that case stays cheap.
+2. **Sibling folders under one parent**, compared *cluster-to-cluster* (not
+   track-to-track): merge candidates when normalized titles differ only by a
+   disc/volume suffix, or a cue sheet spans them, or tag consensus titles
+   match exactly.
+3. **Same normalized (albumartist, album-title) bucket across the library** —
+   only to *flag* possible duplicates/variants for the review queue, never to
+   auto-merge (the folder half of identity intentionally separates quality
+   variants).
+
+Complexity: O(tracks) for subgroup formation (each track is bucketed once by
+tag/art/sequence) plus a handful of subgroup-pair comparisons in the rare
+ambiguous folder — a bounded quadratic fallback that almost never triggers,
+not the default cost. For 100k tracks / ~10k folders a full pass is
+effectively one linear sweep, and the pass is incremental (dirty folders
+only) after the first run.
+
+### 5.2 Membership signals
+
+The evidence vocabulary for "do these belong to the same local album". These
+signals are **not** evaluated for every track pair: the folder pass first
+forms candidate subgroups (tag buckets, track-number sequence runs, art
+groups — §5.3), and only when a split is *plausible* are the signals summed
+**between the candidate subgroups** as a tiebreak. A 12-track folder with one
+tag consensus and one art group evaluates nothing at all. Hand-set integer
+weights, stored in one table in code, logged per decision (the
+`grouping_basis` JSON).
+
+Positive:
+
+| signal | weight | notes |
+|---|---|---|
+| same folder | +4 | the prior; this is why folder is the block |
+| same cue sheet | +6 | near-decisive |
+| identical/near art phash | +3 | hamming ≤ threshold on embedded art |
+| compatible track numbers (no collision, plausible joint sequence) | +2 | |
+| same normalized album tag | +2 | supporting, **not** required |
+| same albumartist tag / compilation flag agreement | +2 | newly read |
+| same codec + sample rate + bit depth + encoder string | +1 | one rip session |
+| fs timestamps within one write session | +1 | rip batches |
+| same import batch | +1 | |
+
+Negative:
+
+| signal | weight | notes |
+|---|---|---|
+| track-number collision (both claim #4) with different titles | −3 | strongest split evidence when systematic |
+| disjoint disc numbers with own 1..n sequences *and* differing tags | −2 | multi-disc handled at album level first |
+| clearly different art phash groups | −3 | |
+| different albumartist (both explicit, both non-V/A) | −2 | |
+| different album tags **and** both tags each cover a complete plausible sequence | −3 | the "two albums in one folder" case |
+| gross stream mismatch (44.1/16 vs 96/24) aligned with a tag split | −1 | tie-breaker only — deluxe editions legitimately mix |
+
+Deliberately excluded: CLAP/audio-embedding distance (measured unreliable,
+§8); title string similarity between *track* titles (irrelevant to
+membership); year alone (remaster tags lie).
+
+**Hand weights vs learned model:** hand weights, for now. The decision space
+is small, the signals are few and interpretable, there is zero labeled data,
+and every mis-weighting shows up as an explainable rule firing in
+`grouping_basis`. The signal vector is exactly what a logistic regression
+would consume, so when the review UI has produced a few thousand
+accept/split/merge labels, fitting weights (per-signal coefficients, same
+structure) is a drop-in replacement — schedule that as the *last* phase, not
+the first.
+
+### 5.3 Album-level rules (the actual split/merge decisions)
+
+The group decisions are rule-shaped and ordered; §5.2's signal sum breaks
+ties between candidate partitions when a rule fires ambiguously:
+
+**One folder stays one album unless** at least one of:
+
+- **Duplicate-sequence rule:** members partition into ≥2 subsets that *each*
+  form a plausible 1..n track sequence (≥60 % of a contiguous range, ≥4
+  tracks), and the subsets are separated by at least one strong negative
+  signal (distinct tag consensus, distinct art groups, disc-number
+  partition). → split. Covers "24 tracks = Album A + Album A (remaster)".
+- **Multi-signal identity rule (no sequences needed):** members partition
+  into ≥2 substantial subgroups (each ≥ max(3, 25 % of folder)) that differ
+  on **at least two independent** strong identity signals — coherent album
+  tag, art group, explicit albumartist — even when track numbers are absent
+  or unusable. Covers two untagged-number albums dumped in one folder. One
+  differing signal alone (tags only) is never sufficient — that is the
+  original over-splitting bug.
+- **V/A dissolution rule:** the existing thresholds (≥4 distinct artists,
+  uniqueness ≥0.5, generic-dump denylist) — kept as-is, now emitting a
+  `kind='compilation'` or `kind='singles_pool'` cluster with provenance
+  instead of ad-hoc repointing.
+- **User pin.**
+
+**Outlier absorption (never split for these):** a minority tag subset that
+does *not* form its own sequence — e.g. 12 tracks: 9 × "Album X", 2 × empty,
+1 × "Album Y" where the Album-Y track holds track #7 of the X sequence — stays
+in the cluster; the deviant tags become losing claims and a per-track
+`conflict` record ("embedded album tag likely wrong"). Threshold: subset
+< max(2, 25 % of folder) *and* no independent sequence *and* no distinct art.
+
+**Merge rules (cross-folder / cross-cluster):**
+
+- disc-suffix siblings: normalized titles equal after stripping
+  `(CD|Disc|Vol)\s*\d+`, disc numbers/sequences complementary, **and**
+  album-artist evidence compatible (or artwork matches, or a cue sheet
+  spans them) → merge into one `multi_disc` cluster (fixes the Mum
+  CD1/CD2/CD3 split). Title + complementary sequences alone is not enough —
+  `Greatest Hits CD1`/`CD2` by two different artists must not fuse.
+- cue sheet spanning folders → merge.
+- a folder's tracks tag-match a sibling cluster's consensus exactly and track
+  ranges are complementary (a "bonus disc" folder) → merge proposal to the
+  review queue (auto-merge only when art also matches).
+
+**Title resolution for the cluster** (claims, §4): tag consensus (weighted by
+share of members) > folder name (cleaned) > external candidate title. An
+untagged folder rip thus gets its folder name as the album title with modest
+confidence — today it gets `unknown_album`.
+
+**Title normalization** (a claim transform applied before resolution, needed
+whichever source wins): folder- and tag-derived titles leak junk that must be
+stripped for a clean display value — measured on a real 526-track library,
+title quality (not grouping) was the dominant remaining defect. The
+normalizer removes, in order that preserves the real name:
+
+- a trailing disc/volume marker *only when the cluster is genuinely multi-disc*
+  (members' titles differ only by that suffix) — a standalone `… Vol. 2` keeps
+  its name (already shipped in Phase 1's planner);
+- a leading `YYYY.` / `YYYY -` year prefix (`1993. Jean Michel Jarre - …`);
+- a trailing catalog/pressing parenthetical (`(Sony 88875129492, Russia)`,
+  `(EG, EGHP 50, UK, 24-192)`);
+- format / quality tokens (`MP3`, `FLAC`, `WEB`, `24-192`, `Hi-Res`);
+- a leading artist prefix via `strip_artist_prefix` — **only when the
+  remainder is a substantive title**. Measured on the tester DB, blind
+  stripping degenerates: "Crystal Castles (II)" -> "(II)", "Mogwai EP" ->
+  "EP". The guard: keep the original unless the remainder has a real word
+  beyond a bare parenthetical / edition token ("EP", "(Limited Edition)");
+- stray bracket tags (`{uaoa}…`).
+
+Each rule is deterministic and reversible-in-review; the raw tag/folder value
+stays in the claim so a normalization mistake is auditable and undoable. The
+`assess-enrichment` skill's `path_artifact_titles` detector is the evaluation
+signal — it should trend to ~0 as the normalizer lands. This is **not** a new
+title *source*, only a cleanup of the winning claim, so it never invents a
+title, and it never overrides an external (verified) release title that is
+already clean.
+
+**Album artist resolution:** albumartist tag consensus > single common track
+artist > V/A sentinel (compilation rule) > parent-folder artist (remix rule,
+kept from `_parent_artist_for_folder`). First-writer-wins dies.
+
+---
+
+## 6. Enrichment redesign
+
+### 6.1 From linear per-entity passes to evidence rounds
+
+The plugin chain (`enricher.py:70-108`) survives, but plugins stop writing
+entity fields directly; they emit **claims** and **candidates**. The
+per-entity `limit=1` loop becomes a per-*cluster* work queue:
+
+```
+for each cluster needing enrichment:
+    1. resolve local claims first (tag consensus, folder, filesystem parse)
+    2. album-level external match (MB release search: artist+title,
+       track count, duration sum, tracklist alignment)  → release_candidates
+    3. per-track pass constrained to the accepted candidate's tracklist
+       (existing _lookup_track_in_release, musicbrainz_plugin.py:568-649)
+    4. AcoustID only as a last-resort identifier for tracks whose artist
+       or title is still completely unknown after all local sources
+       (tags, filename parse, folder context) → title/artist/recording-id
+       claims for that track and nothing else
+    5. resolution pass; if a claim changes a grouping-relevant field,
+       mark folder dirty for the reconciler
+```
+
+`FilesystemFallbackPlugin`'s parsing moves into step 1 as a claim source
+(its conservative "only fill unknowns" guards become confidence levels
+instead of write guards). Deezer/Wikidata/procedural artwork remain cover/
+image providers, unchanged in spirit.
+
+**"Enriched" is redefined.** A cluster is *done* when local resolution is
+complete and external matching has been attempted — a bootleg with zero
+external identity is `ENRICHED (local-only)`, not `FAILED`. The required-field
+lists (`enricher.py:32-41`) shrink to genuinely required local fields; `mbid`
+and `image_url` move from "required" to "desired". This deletes failure mode
+"correct MB match without a cover ⇒ FAILED forever".
+
+### 6.2 Album-level external matching
+
+Track-level lookup remains, but the primary MB interaction becomes: search
+releases by resolved artist + title; score candidates by the existing stage
+A/B machinery (`ext:score`, string similarity, `track_count_bonus`,
+`album_duration_bonus`) **plus tracklist alignment** — a **monotonic
+sequence alignment** (Needleman-Wunsch-style dynamic programming, n ≤ 30) of
+the local track order against the release track order, with
+title-similarity + duration costs, gap penalties for missing/bonus tracks,
+and reduced penalties at disc boundaries. Order-preserving alignment, not
+optimal assignment: Hungarian matching would happily map local track 9 to
+release position 2 on a title coincidence, which sequence monotonicity
+forbids; albums have an inherent order and absent tracks should behave like
+gaps, not free permutations. Store the top ≤3 as `release_candidates` with
+`coverage` = fraction of members explained.
+
+Decision policy:
+
+- coverage ≥ 0.9, score above threshold, margin ok → `accepted`; resolved
+  metadata (original year, genre, disc/track numbers via `track_map`) flows
+  in as *inferred*-tier claims under the §7 field policy — a fuzzy
+  acceptance fills gaps and attaches canonical identity but never displaces
+  locally observed title/artist; only a direct identifier or user
+  confirmation upgrades it to *verified*. Unmatched members **stay in the
+  cluster** flagged `bonus/unmatched` — a partial match never ejects tracks.
+- 0.5 ≤ coverage < 0.9 → keep as `candidate`, surface in review if the
+  cluster is otherwise confident ("external release explains 9 of 12
+  tracks").
+- Two candidates within the ambiguity margin but same release group →
+  accept the release group, leave edition unresolved (extends the existing
+  `_same_release_group` carve-out, `musicbrainz_plugin.py:471-482`).
+- Conflicting release groups → hold, record both, review-queue only if the
+  user has that view open; local grouping is unaffected either way.
+
+**When to skip external lookup entirely:** cluster kind `singles_pool`;
+clusters whose resolved title matched the generic-dump denylist; clusters the
+user pinned as local-only; re-lookups gated by a negative-result cache with
+TTL (weeks) plus the existing fingerprint-versioning for logic changes.
+This cuts MB traffic markedly — today every track fires a global
+`search_recordings` fallback even when the album context already failed.
+
+### 6.3 AcoustID narrowed to identity rescue
+
+AcoustID's only job is answering "what track is this?" when local evidence
+cannot. **Rescue mode** is defined as: after all local sources are
+exhausted — tags, filename parse, folder context — the track's **artist or
+title is still completely absent**. The archetype is a generically named
+file (`track01.mp3`, `AUD_0043.mp3`) in a dump folder, but a tagged-yet-
+titleless file whose filename parse yields nothing also qualifies. For
+those tracks it emits title/artist claims and a `recording_identity` row —
+and that is all. It is **not** an album-detection signal: it does not vote
+on release candidates, does not contribute to clustering, and its current
+powers to create albums, move tracks, and unconditionally overwrite titles
+(`acoustid_plugin.py:680`, `:695-718`) are removed. A track that has both
+an artist and a title from any local source is never fingerprint-looked-up
+— this differs from today's gating (fires whenever artist OR *album* is
+unknown, `acoustid_plugin.py:602-615`): a missing album no longer triggers
+AcoustID, because album identity is the cluster's job.
+
+Two operations the current plugin conflates are kept separate: **local
+chromaprint generation** (fpcalc, no network) and **remote AcoustID
+lookup**. Rescue mode gates the *lookup*. Chromaprint generation is
+independently useful — duplicate detection, move-tracking (§4), linking
+local recordings to accepted releases — and may run as an opt-in background
+backfill on any track without triggering a single web request. Fingerprints,
+once computed, are persisted in `track_evidence` (today they're recomputed
+per attempt — wasteful at 30 s `fpcalc` timeouts).
+
+### 6.4 Oscillation prevention
+
+Membership oscillation is structurally impossible in steady state because
+enrichment cannot move tracks. The remaining loop —
+claims → reconciler → re-cluster → new claims — is damped by:
+
+1. **Hysteresis:** re-clustering a folder only *applies* a new partition if
+   its group score beats the incumbent's by a fixed margin (say 15 %);
+   ties keep the incumbent. Incumbency is explicit (`generation`,
+   `grouping_basis` stores the incumbent score).
+2. **Monotone claim classes:** external claims may refine resolution but
+   grouping-relevant *structural* evidence (sequences, art, cue, folder) is
+   local-only, so a provider flip-flop can't re-partition anything.
+3. **Pinned claims** freeze both membership and fields.
+4. **Generation cap:** a folder re-clustered > N times per scan cycle goes to
+   the review queue instead of churning.
+
+Reconciliation triggers: new/changed/removed files in a folder (already
+detected via mtime/inotify), a user correction, an accepted release
+candidate that implies disc/track renumbering, an enricher claim on a
+grouping field. Provider metadata arriving for *one track* never triggers
+re-clustering by itself.
+
+### 6.5 Library-wide inference & entity reconciliation
+
+The folder is the right scope for *grouping*, but the wrong scope for
+*metadata*: the library as a whole already knows things no single folder
+does, and no external lookup can beat evidence you already own. A
+reconciliation pass runs after album resolution, upward through the entity
+graph (tracks → albums → artists) and propagates back down, emitting claims
+with source `library_inference`:
+
+- **Artist propagation.** Origin country is *artist-entity* evidence, so
+  the operation is artist-to-artist: several local artist rows are verified
+  as one identity (a `same_identity` relation in `entity_relation`), some
+  carry `artist_origin_country = Italy`, the others inherit it as an
+  inferred claim — likewise area, sort name, and genre distribution. What
+  albums contribute is the *identity evidence* (shared MBIDs, shared
+  release credits), never the origin value itself. In the tester DB 21.8 %
+  of artists lack an MBID while many share identity with already-enriched
+  rows; this pass closes such gaps for free and gives every *future* import
+  a head start.
+- **Field semantics — propagate only semantically identical fields.** The
+  model keeps distinct fields distinct: `artist_origin_country` ≠
+  `release_country` (an Italian release can be by a British artist);
+  `original_release_year` ≠ `release_year` ≠ recording year (a 2011
+  remaster contains a 1982 recording — the schema's existing
+  `year`/`original_year` split, now enforced in inference too);
+  `track_language` ≠ artist nationality (singing in Italian doesn't make
+  you Italian). A query like "Italian 80s" needs `artist_origin_country` +
+  `original_release_year`, and inference must never launder one field into
+  another to fake coverage.
+- **Temporal inference.** Within a resolved cluster: 11 tracks tagged 1982
+  and one untagged → year claim for the straggler; disc 1 dated, disc 2 not
+  → propagate across the `multi_disc` cluster (same-field only, per above).
+  Same pattern for genre and language at album scope. Purely local
+  arithmetic, zero requests.
+- **Identity guard — propagate only across *verified* identity.** Inference
+  flows through an entity link, never through a name. Sufficient for
+  automatic propagation: same provider ID (MBID), a user-confirmed
+  identity, or a `same_identity` relation already at `verified`/`pinned`
+  status in `entity_relation`. **Exact-name match
+  is never sufficient on its own** — two sparse artists sharing "John
+  Williams" have no conflicting evidence precisely *because* nothing is
+  known about them; absence of contradiction is not identity. A bare name
+  match produces an identity *candidate* (a review-queue link, same
+  machinery as §6.5 dedup links), and only its confirmation — by a user, or
+  by multiple independent fields subsequently agreeing with no strong
+  contradiction — upgrades it to a propagation channel. When in doubt,
+  abstain — the standing rule.
+- **Duplicate detection as *links*, not merges.** The same
+  candidate+margin pattern used for releases applies to three more entity
+  pairs, each producing review cards rather than automatic merges:
+  - *artists*: "Miles Davis" / "Miles Davis Quintet" — related but
+    **distinct** entities; a detected relation is surfaced, never collapsed;
+  - *albums*: "Kind Of Blue" / "Kind Of Blue (Remastered)" — two local
+    clusters, one release group; linking them (shared `rg_id`) is exactly
+    the local-vs-canonical separation, and the §5.1 cross-library bucket
+    already flags these. Only trivial case-folding variants
+    ("Kind of Blue") auto-normalize;
+  - *recordings*: "Take Five" / "Take Five (2003 Remaster)" — linked via
+    `recording_identity` when fingerprints or an accepted release prove it,
+    labeled duplicate-variant for the dedupe view.
+- **Scheduling.** The pass is incremental like everything else: an artist is
+  re-reconciled when one of its albums resolves or a user pins a field. It
+  emits ordinary claims, so provenance, pins, and the oscillation damping
+  of §6.4 apply unchanged.
+
+This also rebalances the provider hierarchy: external services become one
+evidence source among several — and for most fields not the strongest one.
+The effective per-field precedence (folder/tags/library above external for
+titles and grouping; library-inference or external leading for
+country/area/original-year) is deliberately *per-field*, not a global
+ratio — a single global weighting would be wrong for half the fields.
+
+---
+
+## 7. Confidence and provenance model
+
+Replace the three incomparable score families with **five ordinal tiers**,
+not a pervasive 0..1 float — most fields never have competing values, and a
+scale of hand-tuned decimals (0.63 vs 0.71) is precision the system cannot
+back up and behavior-changing knobs nobody can verify:
+
+| tier | meaning | sources |
+|---|---|---|
+| **pinned** | user said so; never overridden, never expired | user pin |
+| **verified** | confirmed through a *direct identifier*, not similarity | user-confirmed link; a release MBID already present in the tags; barcode/catalog number + compatible tracklist; ISRC/recording-ID coverage; cue sheet |
+| **observed** | directly read from the files, taken at face value | unanimous tag consensus, folder facts (structure, disc subdirs) |
+| **inferred** | derived from evidence with a real chance of being wrong | majority tag consensus, folder-name titles, library inference (§6.5), rescue-mode AcoustID, **fuzzy-accepted external matches** (title/duration/alignment scoring, however high the score) |
+| **guessed** | last-resort fallback | filename parse, fuzzy cover-only matches |
+
+Two boundaries here carry the weight. *Verified/observed:* unanimous tags
+are **one** observation repeated n times, not n independent ones — a whole
+folder tagged wrong by a single tagging session is unanimous and wrong; a
+direct-identifier match may correct even unanimous tags, which a merged
+"known" tier could not express. *Verified/inferred:* an external match
+accepted through fuzzy scoring — title similarity, durations, tracklist
+alignment, margin — is still **inference**, however high the coverage; it
+can pick the wrong edition or a structurally similar release. Placing it at
+inferred means a fuzzy MusicBrainz result can never silently outrank a
+unanimous embedded album title (observed > inferred) merely because it
+crossed an internal threshold. The accompanying field policy: a
+fuzzy-accepted match may fill `original_release_year`, attach canonical
+release identity, and normalize obvious formatting — it does **not**
+replace the locally observed display title or artist unless the match is
+upgraded to verified by a direct identifier or user confirmation.
+
+Resolution: higher tier wins; *within* a tier, a fixed per-field source
+precedence decides (e.g. for `album_title`: tag consensus > folder name >
+external; for `country`: external > library inference). Numeric scores exist
+only **inside** a source's own accept/reject decision (MB match scoring,
+coverage thresholds, §5.2 partition tiebreaks) — they are how a claim *earns*
+a tier, and they stay out of cross-source comparison entirely. A
+tier-and-source change is observable and explainable; a 0.05 float delta is
+neither. Stability rule: the currently-resolved value keeps winning against
+an equal-tier rival (incumbency), so display never churns.
+
+`grouping_conf` on clusters keeps its 0..1 form but with the same discipline:
+it is derived from which rules fired and the margin over the best alternative
+partition, serialized into `grouping_basis`, so "why is this one album?" is
+answerable from the DB with no re-computation.
+
+Calibration is Phase-5 work and gets simpler with tiers — but it is checked
+per **source × field**, not per tier in aggregate: a tier is an operational
+category, not a statistically homogeneous population. Embedded album titles
+may hit 99 % while embedded compilation flags or years sit far lower;
+`tag_consensus × album_title` and `tag_consensus × original_year` are
+separate rows in the reliability report. The bar: verified/observed cells
+≥ ~99 %, inferred cells ≥ ~90 %; a cell that underperforms demotes that
+source *for that field* — one discrete decision instead of re-tuning a
+table of decimals.
+
+---
+
+## 8. Audio-based evidence — what is and isn't worth it
+
+Grounded in what the project has already measured (CLAP distance is not a
+reliable relevance signal even for search):
+
+| signal | verdict | use |
+|---|---|---|
+| chromaprint fingerprint identity | **yes** | exact/near-duplicate detection; recording identity; "same track appears twice in folder" → strong split/dedupe evidence. Already computed; just persist it. |
+| container/stream info (sample rate, bit depth, channels, codec, encoder string) | **yes** | free from mutagen stream info; one rip session is homogeneous; cheap positive/negative signal (§5.2) |
+| ReplayGain tags / loudness | **weak yes** | already read when present; album-gain agreement is mild positive evidence; do not compute loudness ourselves in v1 |
+| leading/trailing silence, splice continuity across track boundaries | **defer** | genuinely indicative for vinyl/cassette side rips (track N end flows into N+1 start), but requires decoding every file; O(library) DSP on modest hardware for a signal folder-membership already covers. Revisit only if real-world folders defeat the structural rules. |
+| CLAP / acoustic embeddings for membership | **no** | measured unreliable; albums are acoustically heterogeneous by design |
+| vinyl surface-noise / mastering similarity, encoder forensics | **no** | research-grade, low marginal value over stream info + timestamps |
+| different-master detection (same recording, different mastering) | **partial** | fingerprint match + differing stream info/duration ≈ different edition; label as duplicate-variant for review, don't auto-act |
+
+Net: v1 uses only signals that are free at scan time plus the fingerprints
+the enricher already computes. No new DSP.
+
+**Forward marker — `track_semantic_profile`.** The rejection above is about
+*grouping*, not about audio understanding generally. The pieces of a
+per-track semantic profile already exist scattered across the schema (CLAP
+embedding, mood valence/arousal, and formerly predicted tags); naming them
+as one entity — mood, energy, instrumentation, danceability, era estimate,
+computed once per track and versioned like embeddings — is where search,
+recommendations, playlist generation, and duplicate detection will draw
+from as lightweight audio models improve. It plugs into the entity model of
+§3 as another evidence-owning entity; it is out of scope for this proposal
+and deliberately kept out of every grouping decision.
+
+---
+
+## 9. User interaction
+
+Two surfaces, deliberately asymmetric:
+
+- **Normal UI:** nothing changes except correctness. At most a subtle badge
+  on albums with `needs_review` (behind a setting, default off). Kalinka is a
+  player, not a tag editor.
+- **Library-maintenance view** (new, low-priority screen or even server web
+  UI first): a review queue fed by `needs_review` clusters and unresolved
+  conflicts, each item a one-decision card:
+  - "These 11 tracks look like one album — confirm?" [keep / split]
+  - "This folder may contain two albums" [keep one / split as proposed]
+  - "Track 7's album tag disagrees with the album" [use cluster value / keep tag]
+  - "MusicBrainz suggests 'X (2011 Remaster)' for this rip (explains 10/12
+    tracks)" [adopt external structure / keep local grouping / reject match]
+  - merge proposals for sibling folders.
+
+Every decision writes a pinned claim (field decisions), a
+`membership_constraint` row (grouping decisions), or an `entity_relation`
+status change (identity/variant links) — all durable schema, §4, not
+prose. Pins survive rescans (keyed to file/cluster identity, both now
+stable, §4), are exported/imported with the library DB, and are excluded
+from every future automated overwrite path by construction (no tier outranks
+pinned; the reconciler treats pinned membership as hard constraints —
+this is the "constrained clustering" element, cheap because constraints are
+per-folder).
+
+Review volume expectation from the tester library: ~45 split-folders + ~14
+V/A coalesce candidates + ~9 mistag candidates ≈ 70 items for 8k tracks —
+a few screens once, then a trickle.
+
+---
+
+## 10. Performance, incrementality, storage
+
+- **Compute:** clustering is per-dirty-folder; a folder pass is tag
+  normalization + sequence analysis + ≤ n² integer scoring, microseconds to
+  milliseconds. Initial full pass over 100k tracks ≈ one library scan's cost;
+  art perceptual hashes (8-byte dHash on the already-decoded embedded image)
+  add negligible time at index.
+- **External I/O** unchanged in mechanism (serial, rate-limited: MB 1 req/s
+  via musicbrainzngs, AcoustID 3 req/s) but reduced in volume: one release
+  search per cluster instead of per-track global fallbacks, negative-result
+  caching, and skip rules for `singles_pool`. The sync musicbrainzngs calls
+  that today block only the standalone enricher loop must move to
+  `asyncio.to_thread` at the Phase-2 process merge (§3.1), since after the
+  merge they would otherwise stall scanning too — this is a merge
+  prerequisite, not an optional cleanup.
+- **Storage** (100k tracks): `track_evidence` raw-tag JSON ~0.5–1 KB/track
+  → ≤ 100 MB worst case, likely ~30 MB; fingerprints ~1–3 KB compressed
+  chromaprint/track → ~200 MB *only if persisted for all tracks* — persist
+  only when computed (AcoustID-eligible tracks), which today is the
+  unknown-artist/album subset; claims are a handful of short rows per entity
+  → tens of MB. All fine for SQLite/WAL on a Pi-class host; `vec_*` tables
+  already dwarf this.
+- **Rescan stability:** evidence upsert (no REPLACE), stable cluster ids with
+  overlap re-attachment, hysteresis everywhere. A rescan of an unchanged
+  library must be a **semantic no-op** — zero entity updates, zero
+  cluster-generation bumps, zero new claims/origins/aliases, identical
+  exported logical state — and that becomes an explicit test. (Not
+  byte-identical SQLite files: WAL checkpointing and page layout make raw
+  bytes meaningless as an invariant.)
+
+---
+
+## 11. Migration & staged implementation roadmap
+
+Each phase ships independently and improves behavior on its own. **Commit
+granularity: every phase is at least one self-contained commit, and the
+larger phases are broken into the ordered sub-commits listed below — each a
+green-tests, independently-revertable step, never one mega-commit per
+phase.** The rule of thumb: a schema/migration change, a
+mechanism-preserving refactor, and a behavior change are always separate
+commits, so a regression bisects to a small diff and any single step can be
+reverted without unwinding the rest of the phase.
+
+1. **Phase 0 — stop destroying evidence.** Read albumartist/TPE2 +
+   compilation flag + full raw tags; add `library_file` (stable file
+   identity + `first_indexed`) and `track_evidence` (raw tags, stream
+   info, art phash, import batch); replace track
+   `INSERT OR REPLACE` with surgical UPDATE; persist chromaprints when
+   computed. Preserve the original indexing timestamp: today a re-processed
+   file's REPLACE rewrites `last_updated`, so a tag edit or rescan makes old
+   tracks look newly added (the `recently_added` view and root "Recently
+   Added" section order by it) — `first_indexed` is written once on first
+   sight of the file and never touched again, and becomes both the
+   recency signal for browse and the import-batch grouping evidence for
+   clustering. No behavior change visible to users otherwise.
+   *(Small; pure indexer + schema.)*
+   Commits: (0a) `library_file` + `track_evidence` schema + migration
+   (stable file identity from day one — every later phase keys off it);
+   (0b) extend tag reading (albumartist/compilation/verbatim raw tags)
+   writing into evidence; (0c) replace `INSERT OR REPLACE` with surgical
+   UPDATE + `first_indexed` preservation; (0d) persist chromaprints + art
+   phash when computed.
+2. **Phase 1 — folder-first clustering.** Implement the per-folder partition
+   pass (split rules, outlier absorption, V/A pass folded in as rules),
+   stable cluster ids, folder-name fallback title for untagged folders.
+   This alone fixes: the 45 folder splits, the Air-folder shards, untagged
+   vinyl rips landing in `unknown_album`, first-writer-wins album artists.
+   Migration = one re-cluster pass over existing DBs (id re-attachment by
+   overlap keeps most album ids; artwork files keyed by kept ids survive).
+   *(The core phase; biggest and highest-value.)*
+   **The membership write guard ships in this phase, not Phase 2** — with
+   folder-first clustering live, an enrichment plugin that can still
+   reassign `tracks.album_id` would fragment the new clusters and violate
+   the §3 invariant during the gap between phases. Structurally: one
+   repository method owns `album_id` writes, callable only by the
+   cluster/reconciler path; AcoustID's album-create/track-move code is
+   disabled here (its full claim-emitter conversion still lands in
+   Phase 2).
+   Commits: (1a) `album_cluster` + `membership_constraint` schema +
+   stable-id lifecycle (mint/split/merge/alias, §4) + path-hash→file_id
+   migration — the constraint table ships now, internal-only, so the
+   reconciler is constraint-aware from its first run and Phase 4's UI
+   *reveals* an established model rather than introducing one;
+   (1b) membership signal scorer (§5.2) as a pure, unit-tested function;
+   (1c) folder-partition rules + outlier absorption (§5.3), behind a flag;
+   (1d) fold the existing V/A pass into the rule engine; (1e) cross-folder
+   disc-suffix merge; (1f) membership write guard + disable AcoustID
+   membership writes; (1g) enable + one-time re-cluster migration.
+3. **Phase 2 — claims & resolution.** The indexer/enricher process merge
+   (§3.1) lands here, at the start of the phase — converting plugins to
+   claim emitters and introducing the reconciler only makes sense with a
+   single writer. `metadata_claims`, resolution pass,
+   conflict records; enricher plugins converted to claim emitters; redefine
+   ENRICHED/local-only; drop mbid/image from required fields. AcoustID is
+   narrowed to rescue mode here (§6.3): gated to tracks whose artist or
+   title is still absent after all local sources, and stripped of
+   album_id/artist_id/title write powers.
+   Commits: (2a) move sync musicbrainzngs calls to `asyncio.to_thread`
+   (merge prerequisite, §10); (2b) merge enricher into the librarian process,
+   mechanism-preserving (queues→in-process calls, no behavior change);
+   (2c) `metadata_claims` + `resolved_origin` + `entity_relation` schema +
+   the origin/era/language columns (§4: `albums.country`,
+   `tracks.recording_year`, `tracks.language` — nullable, never required) +
+   resolution pass writing the resolved view (relations ship before the
+   inference that uses them, same schema-first rule as 1a);
+   (2d) convert each plugin to a claim emitter (one commit per plugin);
+   (2e) redefine ENRICHED/local-only + shrink required fields; (2f) narrow
+   AcoustID to rescue mode + strip its title overwrite (its membership
+   writes are already dead since 1f);
+   (2g) library-wide inference pass (§6.5): artist propagation + temporal
+   inference emitting `library_inference` claims — lands here because it is
+   pure claim machinery with no external dependencies, and it recovers
+   metadata *before* Phase 3 spends any MB requests on it;
+   (2h) title normalizer (§5.3): deterministic cleanup of the winning
+   title claim — strip year prefix, catalog/pressing parenthetical, format
+   tokens and stray bracket tags from folder/tag-derived titles. Measured as
+   the dominant remaining defect on a real library (11 path-artifact titles
+   / 71 albums); tracked by `assess-enrichment`'s `path_artifact_titles`.
+4. **Phase 3 — album-level external matching.** `release_candidates` with
+   tracklist alignment + coverage; per-track lookups constrained to accepted
+   candidates; skip/negative-cache policies. (Builds directly on existing
+   stage-A/B and in-release code.)
+   Commits: (3a) `release_candidates` schema; (3b) tracklist-alignment +
+   coverage scorer; (3c) accept/hold decision policy + claim flow;
+   (3d) skip rules + negative-result cache.
+5. **Phase 4 — review workflow.** `needs_review` queue endpoint, pinned
+   claims, membership constraints, relation confirmations, the
+   maintenance view (server/web first, Flutter later — frontend is the
+   sibling repo and needs its own pass).
+   Commits: (4a) pin write paths (pinned claims, `membership_constraint`,
+   `entity_relation` status changes — the schemas already exist from 1a/2c;
+   this wires user decisions into them); (4b) `needs_review` queue query +
+   server endpoint; (4c) duplicate-link detection (§6.5: artist/album/
+   recording variant links as review cards, never auto-merge);
+   (4d) maintenance-view UI (its own commits, sibling frontend repo) —
+   revealing the established model, not introducing it.
+6. **Phase 5 — calibration & the learned option.** Reliability-check
+   confidence tables against accumulated review outcomes; optionally fit
+   logistic weights for §5.2 from correction labels. Only if the data says
+   hand weights are miscalibrated.
+   Commits: (5a) reliability-diagram tooling in the assess skill;
+   (5b) confidence-table adjustments; (5c) optional learned-weights swap.
+
+Explicitly *not* planned: DSP-based side-rip continuity (deferred),
+embedding-based grouping (rejected), full PGM entity resolution (rejected).
+
+---
+
+## 12. Evaluation plan
+
+**Metrics** (computed by extending the existing `assess-enrichment` skill,
+which already measures folder splits and V/A candidates):
+
+- clustering quality against a labeled corpus, reported as two distinct
+  metric families plus raw counts: *pairwise* precision/recall/F1 (over
+  same-album track pairs) and *B³* precision/recall/F1 (per-track cluster
+  purity/completeness — they are different metrics and disagree
+  informatively on skewed cluster sizes), plus absolute counts of albums
+  wrongly split and wrongly merged;
+- % tracks in the correct local album; % clusters with correctly resolved
+  title/artist/year;
+- external-lookup economy: MB/AcoustID requests per 1k tracks, useless-lookup
+  fraction;
+- review load: items per 1k tracks, and precision of auto-decisions made
+  *without* review;
+- confidence calibration: reliability of `grouping_conf` and claim
+  confidences vs observed correctness;
+- **stability:** repeat-scan is a semantic no-op (zero entity/membership/
+  claim/origin/alias changes — logical state compared, not DB bytes);
+  correction persistence: 100 % of pins survive rescan + re-enrichment.
+
+**Test corpus** — a fixture library (synthesized files with real tag
+structures; audio content can be silence except fingerprint cases) covering:
+clean tagged albums; partially tagged; fully untagged folder rips (vinyl /
+cassette); multi-disc as subdirs and as tag suffixes; compilations (VA-
+prefixed and not); one folder with two complete albums; one folder with an
+album + strays; remaster duplicate-sequence folders; live/bootleg with no
+external identity; bonus-track editions vs the MB standard edition; mixed
+sample-rate deluxe; duplicate tracks across folders; the generic-dump
+folders (`music/`, `90s Mixes/`). Plus the anonymized tester-DB findings
+(45 splits, 64 V/A folders, 9 mistag candidates) as a regression list with
+expected outcomes. CI runs the fixture library through scan→cluster→resolve
+and diffs cluster assignments against golden JSON.
+
+---
+
+## 13. Worked examples
+
+**A. Custom vinyl rip, no tags.** `Some Album/01 - Track A.flac …` — folder
+block → one cluster (sequence 1..4, one art group or none, homogeneous
+stream info). Title claim: folder name (inferred tier). External: album search on
+"Some Album" finds nothing → 0 candidates, cluster is ENRICHED(local-only).
+*Today:* all four tracks drown in the global `unknown_album`.
+
+**B. One mistagged track.** 12-track folder, 9 × "Album X", 2 × blank,
+1 × "Album Y" at position 7. The Y-subset (1 track) forms no sequence →
+outlier absorption; one cluster, title resolves to "Album X" (majority
+consensus, inferred tier), track 7 gets a conflict record ("album tag likely
+wrong") and, in
+review, a one-tap fix. *Today:* three albums (X, Y, and the blanks in
+`unknown_album`).
+
+**C. Two albums in one folder.** 24 tracks, positions 1–12 twice, two art
+groups, two tag consensuses → duplicate-sequence rule: two clusters, both
+titled from their own consensus, medium confidence, review-flagged.
+*Today:* split happens only if the tags differ (right answer by accident) —
+but with identical tags ("Album X" + remaster tagged the same) it's one
+24-track album with colliding track numbers, unflagged.
+
+**D. Multi-disc release.** `Album/CD1, Album/CD2` — already collapsed by the
+disc-subdir regex → one `multi_disc` cluster (unchanged). New: `…CD1`,
+`…CD2`, `…CD3` as *sibling folders/tag suffixes* (the Mum case) → disc-suffix
+merge rule → one cluster, `disc_number` claims from the suffixes.
+*Today:* three albums.
+
+**E. Partial AcoustID.** 10-track rip in a named folder with parseable
+filenames: AcoustID never runs — every track gets an artist and title from
+local sources, and album identity comes from the cluster + album-level MB
+matching. AcoustID fires only in rescue mode (§6.3): a track still missing
+its artist or title after tags, filename parse, and folder context — where
+a confident match yields title/artist claims for that file alone, and a
+partial or ambiguous match yields nothing. Either way no album is created
+and no grouping changes. *Today:* AcoustID runs on any track with an
+unknown artist or album, and each matched track can be individually
+re-pointed to a newly minted album row — fragmentation by enrichment.
+
+**F. Conflicting MusicBrainz candidates.** Album search returns "X (1994)"
+and "X (2011 Remaster)", margin < 3.0, same release group → accept release
+group; year resolves from `original_year`; edition left open (both
+candidates stored). Different release groups → both stored as candidates,
+nothing accepted, optional review card. Either way membership is untouched.
+*Today:* the album is "held as orphan" (good) but the state is
+indistinguishable from never-tried, and track-level fallbacks still fire
+global searches.
+
+**G. Release absent everywhere** (radio rip, DJ set, bootleg). Cluster forms
+from folder + sequence; external search under threshold → negative-cached;
+kind may resolve to `album` or `compilation` from local evidence;
+ENRICHED(local-only), procedural artwork eligible. Never FAILED, never
+retried until the negative cache expires or the user asks. *Today:*
+permanently `FAILED (enriched=2)` with required-field semantics.
+
+---
+
+## 14. Summary of the critical stance
+
+- Deterministic, provenance-logged rules cover every observed failure; the
+  clustering problem inside a folder block is small enough that "ML vs
+  rules" is mostly moot — **rules win on debuggability and there is no
+  training data anyway**. The architecture keeps a clean seam (signal vector
+  → weights) so learning can be added as calibration, not as a rewrite.
+- The single most valuable change is conceptual, not algorithmic:
+  **folder-first grouping with split-on-evidence**, plus **separating local
+  cluster identity from canonical release identity** so that "no external
+  match" is a normal healthy state.
+- Complexity is spent only where ambiguity actually lives: no track-pair
+  graphs (folders are already clusters; signals arbitrate only between
+  candidate subgroups), **sparse claims** (rows exist only for genuine
+  conflicts and overrides), and **ordinal tiers instead of pervasive floats**
+  (numbers stay inside each source's own accept/reject decision).
+- The library is its own best metadata provider: **entity reconciliation**
+  (§6.5) propagates what 13 albums know to the 14th, infers years and
+  languages from siblings, and links — never merges — duplicate artists,
+  album variants, and recordings. External services are one evidence source
+  among several, and for most fields not the strongest.
+- Audio intelligence is deliberately minimal for grouping: persist the
+  fingerprints we already compute, read the stream info we already parse,
+  hash the art we already extract — and measure before adding any DSP. The
+  semantic-profile entity (§8) is the marked door for future audio models,
+  kept firmly outside grouping.

--- a/docs/what-is-kalinka.md
+++ b/docs/what-is-kalinka.md
@@ -1,0 +1,176 @@
+# What is Kalinka?
+
+Full disclosure up front: I build Kalinka. This is the write-up I wish I could link when someone asks "so what is it, and why not just use X?" — what the system actually is, how it's put together, and an honest map of where it beats the alternatives and where it clearly doesn't. Facts about the other products were checked in July 2026; if I've gotten something wrong about your favorite player, corrections are welcome.
+
+> Based on Kalinka v3.4, July 2026. Website: [kalinkaplayer.com](https://kalinkaplayer.com)
+
+## The short version
+
+Kalinka is an open-source music system for people who run their own audio hardware. You point it at a folder of music on a small Linux box — a Raspberry Pi 4 with a DAC hat is the reference setup — and it turns that folder into a properly organized, searchable library you control from a phone. There's no account, no cloud dependency and no subscription anywhere in the stack.
+
+It's two cooperating pieces of software:
+
+- **KalinkaPlayer** — a lightweight backend service for Linux (arm64/amd64). It owns the music library, the play queue and the audio output, and exposes a REST + WebSocket API. The performance-critical audio engine is written in C++ and talks to ALSA directly.
+- **Kalinka Music App** — a Flutter client for Android, Linux desktop and Web that discovers the server on your network automatically and acts as the remote control: browsing, search, queue, favorites, playlists and live server settings. An optional browser-based player can be installed on the server as well.
+
+Everything beyond the core ships as **plugins**: the local-files library (the most developed part by far), streaming sources ([Jamendo](https://www.jamendo.com)'s Creative-Commons catalog, and an experimental [Qobuz](https://www.qobuz.com) integration for subscribers), and device integrations such as Yamaha MusicCast volume/power control.
+
+The intended user is specific: DIY HiFi people who are comfortable with Linux and the command line, and who want a controllable, efficient audio backend rather than a sealed appliance. The server runs headless on hardware as small as a Raspberry Pi 3 or Zero 2 W (512 MB RAM) for playback and library duties; enabling AI search raises the bar to a Pi 4B with 4 GB. Only 64-bit OSes are supported. The server is licensed GPL-3.0-or-later; the app's source is Apache 2.0.
+
+## The interesting parts
+
+### The library fixes its own metadata
+
+Most self-hosted music servers read whatever tags your files happen to have and stop there. Kalinka starts from the opposite assumption: real-world collections are messy — inconsistent tags, cryptic folder names, missing artwork — and cleaning that up is the system's job, not yours.
+
+The indexer watches your music directories (with an upload-quiescence window, so half-copied files aren't picked up) and feeds an enrichment pipeline that first reads embedded tags and local file metadata such as filename, path, and technical parameters. If an AcoustID API key is configured, it computes a fingerprint to identify the recording. The resulting metadata is then filled out through **MusicBrainz**, **Wikidata**, and **Deezer**; when external sources still can't resolve a track, filesystem heuristics keep the library browsable. Artwork is extracted and cached, and artist/album/track relationships are modeled properly in a local SQLite database. Nothing is written back to your files — the originals are never touched.
+
+### Search by describing the music
+
+The genuinely unusual feature. **AI search** is an optional, fully local semantic search layer: a background embedder runs a CLAP audio–text model (ONNX, downloaded on first boot) over your tracks, so a query like *"dreamy ambient guitar"* or *"upbeat synth pop"* returns results ranked by what the music actually sounds like, blended with full-text and metadata signals.
+
+The part I care about is *where* it runs: on your own hardware, over your own files, with no cloud API, no API key and no per-query cost. That combination is rare — elsewhere the feature is either absent, welded to a cloud LLM behind a subscription (Volumio's Supersearch, Plexamp's Sonic Sage), or a separate add-on service that wants x86-class hardware (AudioMuse-AI). The trade-off is real, though: the model holds ~285 MB of resident RAM and the initial embedding pass is CPU-heavy, so the feature is opt-in — you can start on a 512 MB board and flip it on later after moving to something bigger.
+
+### The audio path
+
+Playback is a C++ audio graph with direct ALSA access — no PulseAudio or PipeWire in the middle — giving a bit-perfect path where your ALSA configuration permits. It plays FLAC (up to 192 kHz / 24-bit) and MP3, from local files or HTTP streams, with gapless transitions between consecutive tracks of the same format. The server idles comfortably on a Raspberry Pi; the machine's resources go to your library, not to the runtime.
+
+### One queue, many sources
+
+Sources are equal citizens in the play queue: local tracks, Jamendo streams and Qobuz titles can be queued back-to-back. Search fans out across sources and merges results with best-match ranking, so "play that song" doesn't require remembering which backend it lives in.
+
+### Everything else is a plugin
+
+The server core is small; sources and devices arrive through a plugin SDK with typed interfaces for input modules (browse / search / track resolution / favorites / playlists) and output devices. Plugins are ordinary Python packages discovered at runtime, each shipping as its own Debian package — and a cookiecutter template gets a new one compiling in minutes. Configuration is schema-driven and editable live from the app, with a curated "simple" tier plus an `about:config`-style search over everything else, and maintenance actions (rebuild library, restart server) are one tap away.
+
+## Architecture
+
+Kalinka is a hub-and-spokes design. The **core server** owns the API, play queue, playback state, configuration and the native audio engine. **Plugins** — connected through the SDK's typed interfaces — provide everything source- or device-specific. **Clients** are thin: the Flutter app and optional web player drive the server over REST, with WebSocket channels pushing live queue/device state back.
+
+```mermaid
+flowchart TD
+    subgraph CLIENTS["Clients"]
+        APP["Kalinka Music App<br/>(Flutter — Android, Linux desktop)"]
+        WEB["Browser player<br/>(optional kalinka-web bundle)"]
+    end
+
+    subgraph CORE["kalinka-server — core service (Python + C++)"]
+        API["REST + WebSocket API<br/>(FastAPI)"]
+        DISC["Service discovery<br/>(zeroconf / SSDP)"]
+        QUEUE["Play queue &amp; playback state"]
+        SEARCH["Search &amp; catalog aggregation<br/>(fuzzy · semantic · best-match merge · suggestions)"]
+        CONF["Config &amp; state manager<br/>(schema-driven, live-editable)"]
+        NATIVE["Native audio engine (C++)<br/>FLAC &amp; MP3 decode · gapless switching<br/>file &amp; HTTP inputs · direct ALSA output"]
+    end
+
+    subgraph SDK["Plugin SDK (kalinka-plugin-sdk)"]
+        IM["InputModule interface<br/>(browse · search · track URLs ·<br/>favorites · playlists)"]
+        OD["Output-device interface"]
+    end
+
+    subgraph PLUGINS["Plugins (independently installable packages)"]
+        LF["localfiles<br/>indexer · enricher ·<br/>CLAP embedder · searcher"]
+        JAM["jamendo<br/>Creative-Commons streaming"]
+        QOB["qobuz<br/>streaming (separate repo)"]
+        MC["musiccast<br/>Yamaha amp volume &amp; power"]
+    end
+
+    subgraph EXT["External services"]
+        META["AcoustID · MusicBrainz ·<br/>Deezer · Wikidata"]
+        JAPI["Jamendo API"]
+        QAPI["Qobuz API"]
+    end
+
+    FILES[("Music folders<br/>SQLite index + CLAP vectors")]
+    DAC["ALSA sound card / DAC"]
+    AMP["Yamaha MusicCast device"]
+
+    APP -->|"REST + WebSocket"| API
+    WEB --> API
+    DISC -.->|"auto-discovery"| APP
+
+    API --> QUEUE
+    API --> SEARCH
+    API --> CONF
+    QUEUE --> NATIVE
+    NATIVE --> DAC
+
+    SEARCH --> IM
+    QUEUE --> IM
+    IM --- LF
+    IM --- JAM
+    IM --- QOB
+    OD --- MC
+
+    LF --> FILES
+    LF -->|"enrichment lookups"| META
+    JAM --> JAPI
+    QOB --> QAPI
+    NATIVE -.->|"audio streams"| JAPI
+    NATIVE -.->|"audio streams"| QAPI
+    MC --> AMP
+```
+
+Deployment matches the DIY audience: everything builds into separate Debian packages (one for the server, one per plugin) for arm64 and amd64. A systemd unit bootstraps a private virtualenv at startup and picks up any plugin wheels it finds, so installing a plugin is `dpkg -i` plus an automatic restart. For development, a fakeroot mode runs the whole stack from a source checkout with no root and no systemd.
+
+## How it compares
+
+Obvious caveat for this section: I wrote the product being compared, so weigh accordingly — I've tried to keep the table to checkable facts. Details were verified in July 2026, and pricing in this space has moved a lot this year, so re-check before deciding.
+
+The self-hosted music space is crowded, but the products cluster into a few families, and each family solves a different problem well. Kalinka sits in an intersection that is currently empty: Volumio's hardware niche crossed with Roon's intelligence niche — a free, open-source, Pi-class headless player whose library brains (automatic enrichment, fully local natural-language search) the DIY options lack and the commercial options deliver from the cloud, for a subscription. What follows is where each family is stronger, and where Kalinka is.
+
+| Product | License / cost | Server on a Pi? | Metadata enrichment | AI / semantic search | Streaming services | Multi-room |
+|---|---|---|---|---|---|---|
+| **Kalinka** | GPL‑3 · free | Yes — Pi 3 / Zero 2 W; AI search: Pi 4, 4 GB | Automatic waterfall: AcoustID fingerprint → MusicBrainz → Deezer → Wikidata, filename fallback | **Local CLAP embeddings** — natural-language, offline, free | Jamendo (CC); Qobuz (experimental) | No — single zone |
+| Volumio | Open-core · free tier; Premium $8.49/mo or $79.99/yr | Yes (Pi-first) | Minimal (extra credits in Premium) | "Supersearch" — ChatGPT in the cloud, Premium-only | Tidal, Qobuz, HighResAudio — Premium | Premium (up to 6 zones) |
+| moOde | GPL‑3 · free | Yes (Pi-only) | None — tags as-is | None | None (Spotify Connect / AirPlay renderer only) | DIY |
+| Roon | Proprietary · $14.99/mo ($12.49 annual) or $829.99 lifetime | No — x86/NAS server; Pi as endpoint only | Best-in-class (cloud editorial + credits) | Valence cloud recommendations; no natural-language library search | Tidal, Qobuz, KKBOX | Yes (RAAT) |
+| Plexamp | Proprietary · free tier; Plex Pass $6.99/mo, $749.99 lifetime | Headless Pi client (Pass); server heavy for a Pi | Automatic (Plex music agent) | Sonic Analysis (local similarity) + Sonic Sage (cloud LLM) — Pass-gated | Tidal (paid add-on) | Casting only |
+| Navidrome | GPL‑3 · free | Yes | Deliberately minimal — respects your tags | None native (AudioMuse-AI add-on) | None | No |
+| Jellyfin + Finamp | GPL‑2 · free | Yes | Plugin-based (MusicBrainz/TheAudioDB), hit-or-miss | None native (AudioMuse-AI plugin) | None | No |
+| Lyrion (ex‑LMS) | GPL‑2 · free | Yes | Basic, plugin-based | None native (AudioMuse-AI integration) | Qobuz, Tidal, Spotify via plugins | Yes — classic strength |
+| MPD / Mopidy | GPL‑2 / Apache‑2 · free | Yes | None | None | Mopidy extensions (fragile) | DIY (Snapcast) |
+
+### Raspberry Pi audio distros: Volumio and moOde
+
+Volumio and moOde are Kalinka's closest neighbors: audiophile playback systems that turn a Pi into a network player. Both are more mature, support more formats and renderer scenarios (AirPlay, Spotify Connect, Bluetooth), and moOde in particular offers deep DSP options (CamillaDSP, parametric EQ). The differences are philosophical. Volumio has gone freemium: streaming logins, multi-room, even Bluetooth input and its ChatGPT-based "Supersearch" AI all live behind a subscription with a cloud account attached. moOde is free, GPL and cloud-free like Kalinka, but is a classic MPD-based design: it plays exactly what your tags say you have. Neither attempts metadata enrichment, and neither understands your library semantically — Volumio's AI search is cloud discovery via ChatGPT, not local analysis of your own files. Kalinka trades their format breadth and DSP depth for library intelligence: fingerprint-based identification, multi-source enrichment, and description-based search that runs on the same board.
+
+### Premium ecosystems: Roon, Plexamp, Audirvana
+
+Roon is the reference point for "music server with brains": superb editorial metadata, multi-room via RAAT, ML-driven recommendations (Valence — though search itself stays conventional). It is also closed-source, subscription-priced under Harman ownership, and its server won't run on a Pi at all — a Pi can only be an endpoint. Plexamp is the closest in spirit on the intelligence axis: Sonic Analysis runs ML over your files for similarity mixes, and Sonic Sage generates playlists from prompts via a cloud LLM. It gained a free tier in 2023, but the intelligence — and the headless Raspberry Pi player — sits behind a Plex Pass (whose lifetime price tripled to $749.99 in July 2026), on top of a closed, cloud-account-mandatory media server. Audirvana targets desktop audiophile playback on Mac and Windows rather than a headless library appliance. The trade against all three is straightforward: they offer polish, support, deeper streaming catalogs and (in Roon's case) real multi-room, none of which Kalinka matches; Kalinka implements the same core ideas — enrichment, audio-embedding search, bit-perfect playback — as open code on your own hardware, with no subscription and no cloud in the loop.
+
+### Self-hosted servers: Navidrome, Jellyfin, Lyrion
+
+Navidrome, Jellyfin (with Finamp) and Lyrion Music Server are excellent free servers, but they solve a different problem: serving your files to many clients, often over the internet, with multi-user support. Playback happens in the client; the server is a catalog and a transcoder. Kalinka inverts that: the server *is* the player, wired to a DAC, and the clients are remotes — the model HiFi streamers use. Navidrome and Jellyfin also index by what your tags say (Navidrome deliberately so; Jellyfin's enrichment plugins are hit-or-miss with curated libraries), and none of the three searches semantically out of the box — in that ecosystem those features arrive via AudioMuse-AI, the add-on covered below. Lyrion remains unbeatable for whole-house Squeezebox multi-room, which Kalinka doesn't attempt today.
+
+### Building blocks: MPD and Mopidy
+
+MPD (and Mopidy, its Python-extensible cousin) are daemons you assemble a system around: bring your own client, your own library discipline, your own glue. Kalinka occupies the layer above — closer to what you'd assemble *from* such parts, but delivered as an integrated product with a first-party app, an enrichment pipeline and an upgrade path, while remaining open and pluggable underneath.
+
+### The new wave: AudioMuse-AI and Music Assistant
+
+Two newer open-source projects work the same territory from different angles. **AudioMuse-AI** (AGPL) brings local sonic analysis, similarity queues and natural-language playlists to Navidrome, Jellyfin, Lyrion, Emby and Plex — the same local-music-AI idea Kalinka builds in, arrived at independently. The architectural difference: AudioMuse-AI is a separate analysis service bolted onto an existing server, happiest with a 4-core AVX2 CPU and 8 GB of RAM, while Kalinka builds embedding search into the player itself and runs it on the same Pi 4 that feeds your DAC — with fingerprint-based enrichment underneath, which AudioMuse-AI's host servers don't do. **Music Assistant** (Apache-2.0) solves the opposite problem: aggregating a dozen streaming providers into whole-home multi-room via its open Sendspin protocol, with LLM voice/chat control through Home Assistant. It's a hub for orchestrating many sources and rooms; Kalinka is a single high-quality endpoint that owns and understands its library.
+
+## What Kalinka doesn't do (yet)
+
+Kalinka is young — the README itself calls it experimental. The current edges:
+
+- **Formats**: FLAC and MP3 only today. Collections heavy in ALAC, Opus, WAV or DSD need conversion or another player.
+- **Multi-room**: one server drives one output. There is no synchronized whole-house playback.
+- **Streaming breadth**: Jamendo plus an experimental Qobuz plugin. No Tidal or Spotify; subscribers deep in those ecosystems are better served elsewhere.
+- **DSP**: no EQ or room-correction chain — the design goal is a clean bit-perfect path, not signal processing.
+- **Polish over breadth**: development effort concentrates on the local-library experience; other areas move slower.
+
+And by design, it asks for a DIY temperament: you install a Debian package on a Linux box and own the result. If you want a sealed appliance with support, that's what the commercial products are for.
+
+## Which one should you actually run?
+
+Problem-first:
+
+- **Whole-house synchronized audio** → Lyrion, Music Assistant, or Roon. Kalinka is single-zone.
+- **Maximum format support and DSP on a Pi, with tags you already keep clean** → moOde, or plain MPD.
+- **Deep Tidal/Qobuz integration with commercial polish and support** → Roon; Volumio Premium if it must live on a Pi.
+- **Serving your files to many users and devices over the internet** → Navidrome or Jellyfin, plus AudioMuse-AI if you want similarity queues and prompt playlists.
+- **A large, imperfectly tagged local collection, one good DAC, and the wish to browse and search it like a curated service — without a subscription or a cloud account** → this is the problem Kalinka is built around.
+
+That last combination — automatic enrichment, local semantic search and integrated bit-perfect playback on Raspberry-Pi-class hardware — is, as far as I know, not implemented by any other open-source project right now. If I've missed one, tell me; that's half the reason for writing this up.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
@@ -234,6 +234,71 @@ async def init_db(db_path: str) -> None:
             "ON entity_id_alias(current_id)"
         )
 
+        # Field-level claims (Phase 2c). SPARSE: only rows worth keeping are
+        # stored — winning non-local claims (external/inference values that can
+        # expire or be rejected), pinned claims, and conflicts. Uncontested
+        # purely-local values resolve straight into the entity row and are
+        # re-derivable from track_evidence, so they are not stored here; their
+        # provenance still lands in resolved_origin.
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS metadata_claims (
+                entity_type TEXT NOT NULL,
+                entity_id   TEXT NOT NULL,
+                field       TEXT NOT NULL,
+                value       TEXT NOT NULL,
+                source      TEXT NOT NULL,
+                tier        TEXT NOT NULL,
+                created_at  INTEGER,
+                PRIMARY KEY (entity_type, entity_id, field, source)
+            )
+            """
+        )
+
+        # Provenance for EVERY resolved field, including uncontested ones. This
+        # is what keeps sparse claims compatible with re-derivability: claims
+        # record only conflicts, but the winner's origin is always known, so the
+        # resolver can tell whether a value must be recomputed when its source's
+        # evidence changes or a provider is disabled.
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS resolved_origin (
+                entity_type  TEXT NOT NULL,
+                entity_id    TEXT NOT NULL,
+                field        TEXT NOT NULL,
+                source       TEXT NOT NULL,
+                tier         TEXT NOT NULL,
+                evidence_ref TEXT,
+                resolved_at  INTEGER,
+                PRIMARY KEY (entity_type, entity_id, field)
+            )
+            """
+        )
+
+        # Semantic links between two live entities (same_identity, variant_of,
+        # release_group_member, ...) — the propagation channels the library-wide
+        # inference pass depends on. Distinct from entity_id_alias, which only
+        # redirects a replaced id; a relation asserts a fact ABOUT two entities.
+        await cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS entity_relation (
+                source_type TEXT NOT NULL,
+                source_id   TEXT NOT NULL,
+                relation    TEXT NOT NULL,
+                target_type TEXT NOT NULL,
+                target_id   TEXT NOT NULL,
+                status      TEXT NOT NULL,
+                source      TEXT NOT NULL,
+                created_at  INTEGER NOT NULL,
+                PRIMARY KEY (source_type, source_id, relation, target_type, target_id)
+            )
+            """
+        )
+        await cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_entity_relation_target "
+            "ON entity_relation(target_type, target_id)"
+        )
+
         await cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS playlists (
@@ -400,6 +465,16 @@ async def init_db(db_path: str) -> None:
             if col not in track_cols:
                 await cursor.execute(f"ALTER TABLE tracks ADD COLUMN {col} REAL")
                 logger.info("Added tracks.%s column", col)
+        # Per-field origin/era columns (Phase 2c) — one column, one meaning, so
+        # inference can never launder a release fact into a recording fact.
+        # recording_year: a track can predate the release it appears on;
+        # language: a track can differ from the release's language.
+        if "recording_year" not in track_cols:
+            await cursor.execute("ALTER TABLE tracks ADD COLUMN recording_year INTEGER")
+            logger.info("Added tracks.recording_year column")
+        if "language" not in track_cols:
+            await cursor.execute("ALTER TABLE tracks ADD COLUMN language TEXT")
+            logger.info("Added tracks.language column")
 
         # Origin/era metadata (nationality + language + first-release year) so
         # queries like "italian 80s" resolve on structured facts instead of CLAP,
@@ -421,6 +496,11 @@ async def init_db(db_path: str) -> None:
         if "original_year" not in album_cols:
             await cursor.execute("ALTER TABLE albums ADD COLUMN original_year INTEGER")
             logger.info("Added albums.original_year column")
+        # Release country (Phase 2c) — distinct from artists.country (origin);
+        # a release can be issued in a different country than the artist's.
+        if "country" not in album_cols:
+            await cursor.execute("ALTER TABLE albums ADD COLUMN country TEXT")
+            logger.info("Added albums.country column")
         # Marks covers produced by the procedural artwork generator, so the
         # FAILED-row retry sweep can clear them and give real sources
         # another chance when the enrichment setup changes.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/__init__.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/__init__.py
@@ -1,1 +1,2 @@
-from .enricher import main
+# The enricher runs inside the librarian process (see librarian.py); its
+# public surface is MetadataEnricher and the start/stop worker helpers.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
@@ -5,12 +5,9 @@ import enum
 import importlib.util
 import json
 import logging
-import queue
-import signal
 from typing import Optional
 
 from ..config_model import LocalFilesConfig
-from ..worker_utils import set_proc_title
 
 from .musicbrainz_plugin import MusicBrainzPlugin
 from .acoustid_plugin import AcoustIdPlugin
@@ -40,9 +37,11 @@ TRACK_REQUIRED_FIELDS = [
     "track_number",
 ]
 
-# Global variables to manage enricher state
+# Global variables to manage enricher state. The enricher runs inside the
+# librarian process (Phase 2b); the indexer feeds it "enrich"/"stop" over an
+# in-process asyncio queue, and the searcher nudge stays cross-process.
 _enricher_task: Optional[asyncio.Task] = None
-_enricher_queue: Optional[multiprocessing.Queue] = None
+_enricher_queue: Optional[asyncio.Queue] = None
 _embedder_nudge_queue: Optional[multiprocessing.Queue] = None
 _shutdown_event = asyncio.Event()
 
@@ -463,10 +462,8 @@ async def _enricher_worker(config, db_manager: AsyncEnricherDb):
         try:
             # Check for commands with timeout
             try:
-                # Use run_in_executor to call the blocking get() in a non-blocking way
-                loop = asyncio.get_running_loop()
-                command = await loop.run_in_executor(
-                    None, lambda: _enricher_queue.get(block=True, timeout=30.0)
+                command = await asyncio.wait_for(
+                    _enricher_queue.get(), timeout=30.0
                 )
 
                 logger.debug("Received command from queue: %s", command)
@@ -484,7 +481,7 @@ async def _enricher_worker(config, db_manager: AsyncEnricherDb):
                         except Exception:
                             pass
 
-            except queue.Empty:
+            except asyncio.TimeoutError:
                 # No command in the timeout window; loop and wait again.
                 logger.debug("No enricher commands received; continuing to wait")
                 continue
@@ -529,7 +526,7 @@ async def stop_enricher() -> bool:
             if _enricher_queue is None:
                 logger.error("Enricher queue is not initialized; cannot send stop")
                 return False
-            _enricher_queue.put("stop")
+            _enricher_queue.put_nowait("stop")
 
             await asyncio.wait_for(_enricher_task, timeout=10.0)
             return True
@@ -551,64 +548,6 @@ async def stop_enricher() -> bool:
     return False
 
 
-async def async_main(config: LocalFilesConfig):
-    """Runs the main application logic asynchronously."""
-    global _enricher_task, _shutdown_event
-
-    db_manager = AsyncEnricherDb(config)
-
-    loop = asyncio.get_running_loop()
-
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, _shutdown_event.set)
-
-    _enricher_task = start_enricher(config, db_manager)
-
-    try:
-        await _shutdown_event.wait()
-    except asyncio.CancelledError:
-        logger.info("Server cancelled, shutting down...")
-    except Exception as e:
-        logger.exception(f"Error in main loop: {str(e)}")
-    finally:
-        logger.info("Main async runner initiating shutdown of tasks...")
-
-        if _enricher_task and not _enricher_task.done():
-            await stop_enricher()
-        else:
-            logger.info("Enricher task already finished.")
-
-        logger.info("All background tasks processed for shutdown.")
-
-
-def main(
-    config: LocalFilesConfig,
-    enricher_queue: multiprocessing.Queue,
-    logger_queue: multiprocessing.Queue,
-    embedder_nudge_queue: Optional[multiprocessing.Queue] = None,
-):
-    """Main entry point for the enricher daemon."""
-
-    set_proc_title("kal-enricher")
-
-    global _enricher_queue, _embedder_nudge_queue
-
-    _enricher_queue = enricher_queue
-    _embedder_nudge_queue = embedder_nudge_queue
-    try:
-        import logging.handlers
-
-        root = logging.getLogger()
-        for handler in root.handlers[:]:
-            root.removeHandler(handler)
-        # Set root logger level to DEBUG to allow all logs through to the queue
-        root.setLevel(logging.DEBUG)
-        root.addHandler(logging.handlers.QueueHandler(logger_queue))
-
-        asyncio.run(async_main(config))
-    except KeyboardInterrupt:
-        logger.info("KeyboardInterrupt received by asyncio.run. Exiting.")
-    except Exception as e:
-        logger.critical(f"Unhandled exception in asyncio.run: {e}", exc_info=True)
-    finally:
-        logger.info("Enricher daemon finished.")
+# Process orchestration lives in librarian.py, which runs this enricher's
+# worker loop and the indexer's in one event loop (Phase 2b). start_enricher /
+# stop_enricher above are its API.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
@@ -408,8 +408,13 @@ class MetadataEnricher:
             not is_fully_enriched
             and updated_track.get("enriched") != EnrichmentStatus.ENRICHED
         ):
-            logger.info(
-                f"Track {track['id']} failed enrichment - missing required fields"
+            missing = [f for f in TRACK_REQUIRED_FIELDS if not updated_track.get(f)]
+            # file_path identifies the track even when title/artist are missing
+            where = updated_track.get("file_path") or track["id"]
+            logger.debug(
+                "Track %s failed enrichment - missing: %s",
+                where,
+                ", ".join(missing),
             )
             updated_track["enriched"] = EnrichmentStatus.FAILED
             had_updates = True

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
@@ -42,7 +42,9 @@ TRACK_REQUIRED_FIELDS = [
 # in-process asyncio queue, and the searcher nudge stays cross-process.
 _enricher_task: Optional[asyncio.Task] = None
 _enricher_queue: Optional[asyncio.Queue] = None
-_embedder_nudge_queue: Optional[multiprocessing.Queue] = None
+# Nudges the searcher (a separate process) to re-tag once enrichment finishes;
+# the searcher in turn nudges the embedder. Stays a cross-process queue.
+_searcher_nudge_queue: Optional[multiprocessing.Queue] = None
 _shutdown_event = asyncio.Event()
 
 
@@ -475,9 +477,9 @@ async def _enricher_worker(config, db_manager: AsyncEnricherDb):
                 elif command == "enrich":
                     logger.debug("Manual enrichment triggered")
                     await enricher_instance.start()
-                    if _embedder_nudge_queue is not None:
+                    if _searcher_nudge_queue is not None:
                         try:
-                            _embedder_nudge_queue.put_nowait("nudge")
+                            _searcher_nudge_queue.put_nowait("nudge")
                         except Exception:
                             pass
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import musicbrainzngs
 import re
@@ -264,7 +265,8 @@ class MusicBrainzPlugin(EnricherPlugin):
             logger.debug(f"Enriching artist: {artist['name']}")
 
             # Use alias to improve search, and limit results for faster processing
-            result = musicbrainzngs.search_artists(
+            result = await asyncio.to_thread(
+                musicbrainzngs.search_artists,
                 artist["name"],
                 strict=True,  # Use strict search mode
                 limit=20,  # Limit results to top matches
@@ -392,7 +394,8 @@ class MusicBrainzPlugin(EnricherPlugin):
 
             logger.debug(f"Enriching album: {album['title']} by {album['artist_name']}")
 
-            result = musicbrainzngs.search_releases(
+            result = await asyncio.to_thread(
+                musicbrainzngs.search_releases,
                 album["title"],
                 artistname=album["artist_name"],
                 strict=True,
@@ -426,7 +429,8 @@ class MusicBrainzPlugin(EnricherPlugin):
             scored: List[Tuple[Dict, float, float, Dict]] = []
             for cand, base_score, similarity in shortlist[:3]:
                 try:
-                    details = musicbrainzngs.get_release_by_id(
+                    details = await asyncio.to_thread(
+                        musicbrainzngs.get_release_by_id,
                         cand["id"],
                         includes=["recordings", "artist-credits", "tags",
                                   "release-groups"],
@@ -552,8 +556,10 @@ class MusicBrainzPlugin(EnricherPlugin):
         if cached is not None:
             return cached
         try:
-            details = musicbrainzngs.get_release_by_id(
-                release_mbid, includes=["recordings"]
+            details = await asyncio.to_thread(
+                musicbrainzngs.get_release_by_id,
+                release_mbid,
+                includes=["recordings"],
             )
         except Exception as e:
             logger.debug(
@@ -713,7 +719,8 @@ class MusicBrainzPlugin(EnricherPlugin):
             )
 
             # ---- Path 2: fallback global recording search ----
-            result = musicbrainzngs.search_recordings(
+            result = await asyncio.to_thread(
+                musicbrainzngs.search_recordings,
                 track["title"],
                 artistname=track["artist_name"],
                 release=track["album_title"],

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/wikidata_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/wikidata_plugin.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -48,8 +49,10 @@ class WikidataPlugin(EnricherPlugin):
             # Get MusicBrainz artist with relations
             artist_mbid = artist["mbid"]
 
-            mb_result = musicbrainzngs.get_artist_by_id(
-                artist_mbid, includes=["url-rels"]
+            mb_result = await asyncio.to_thread(
+                musicbrainzngs.get_artist_by_id,
+                artist_mbid,
+                includes=["url-rels"],
             )
             mb_artist = mb_result["artist"]
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/__init__.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/__init__.py
@@ -1,2 +1,2 @@
-# Export main indexer functionality
-from .indexer import main
+# The indexer runs inside the librarian process (see librarian.py); its
+# public surface is the FileIndexer class and the start/stop worker helpers.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -8,7 +8,6 @@ import time
 import logging
 import asyncio
 import mimetypes
-import multiprocessing
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from pathlib import Path
@@ -34,7 +33,6 @@ from ..utils.name_utils import (
     parse_leading_track_number,
     path_within_roots,
 )
-from ..worker_utils import set_proc_title
 from .id_generator import (
     generate_artist_id,
     generate_album_id,
@@ -73,7 +71,10 @@ _indexer_queue: asyncio.Queue = asyncio.Queue()
 _file_watcher_task: Optional[asyncio.Task] = None
 _file_watcher_stop_event: asyncio.Event = asyncio.Event()
 _shutdown_event = asyncio.Event()
-_enricher_queue: Optional[multiprocessing.Queue] = None
+# In-process handoff to the enricher worker (both run in the librarian
+# process). Set by librarian.async_main; None only in unit tests that
+# exercise FileIndexer without a running enricher.
+_enricher_queue: Optional[asyncio.Queue] = None
 
 
 async def trigger_enricher_update(data):
@@ -85,13 +86,10 @@ async def trigger_enricher_update(data):
     logger.debug(f"Triggering enricher update with data: {data}")
 
     if _enricher_queue is None:
-        logger.error("Enricher queue is not initialized; cannot trigger update")
+        logger.debug("Enricher queue not initialized; skipping enrich trigger")
         return
 
-    loop = asyncio.get_running_loop()
-    await loop.run_in_executor(
-        None, lambda: _enricher_queue.put(data, block=True, timeout=30.0)
-    )
+    await _enricher_queue.put(data)
 
 
 def is_supported_audio_file(filename: str) -> bool:
@@ -1531,66 +1529,6 @@ def start_file_watcher(config: LocalFilesConfig) -> Optional[asyncio.Task]:
     return _file_watcher_task
 
 
-async def async_main(config: LocalFilesConfig):
-    """Runs the main application logic asynchronously."""
-    global _indexer_task, _file_watcher_task, _shutdown_event
-
-    db_manager = AsyncIndexerDb(config)
-
-    loop = asyncio.get_running_loop()
-
-    import signal
-
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, _shutdown_event.set)
-
-    _indexer_task = start_indexer(config, db_manager)
-    _file_watcher_task = start_file_watcher(config)
-
-    try:
-        await _shutdown_event.wait()
-    except asyncio.CancelledError:
-        logger.info("Server cancelled, shutting down...")
-    except Exception as e:
-        logger.exception(f"Error in main loop: {str(e)}")
-    finally:
-        logger.info("Main async runner initiating shutdown of tasks...")
-        if _file_watcher_task and not _file_watcher_task.done():
-            logger.info("Stopping file watcher task...")
-            await stop_file_watcher()
-        else:
-            logger.info("File watcher task was not running or already done.")
-
-        if _indexer_task and not _indexer_task.done():
-            logger.info("Stopping indexer task...")
-            await stop_indexer()
-        else:
-            logger.info("Indexer task was not running or already done.")
-
-        logger.info("All background tasks processed for shutdown.")
-
-
-def main(config: LocalFilesConfig, enricher_queue, logger_queue):
-    """Main entry point for the indexer daemon."""
-
-    set_proc_title("kal-indexer")
-
-    global _enricher_queue
-    _enricher_queue = enricher_queue
-    try:
-        import logging.handlers
-
-        root = logging.getLogger()
-        for handler in root.handlers[:]:
-            root.removeHandler(handler)
-        # Set root logger level to DEBUG to allow all logs through to the queue
-        root.setLevel(logging.DEBUG)
-        root.addHandler(logging.handlers.QueueHandler(logger_queue))
-
-        asyncio.run(async_main(config))
-    except KeyboardInterrupt:
-        logger.info("KeyboardInterrupt received by asyncio.run. Exiting.")
-    except Exception as e:
-        logger.critical(f"Unhandled exception in asyncio.run: {e}", exc_info=True)
-    finally:
-        logger.info("Indexer daemon finished.")
+# Process orchestration lives in librarian.py, which runs this indexer's
+# worker loops and the enricher's in one event loop (Phase 2b). The
+# start_indexer / start_file_watcher / stop_* helpers above are its API.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/librarian.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/librarian.py
@@ -60,7 +60,7 @@ async def async_main(
     enricher_task = None
     if enricher_enabled:
         enricher_mod._enricher_queue = enrich_queue
-        enricher_mod._embedder_nudge_queue = searcher_nudge_queue
+        enricher_mod._searcher_nudge_queue = searcher_nudge_queue
         enricher_mod._shutdown_event = shutdown_event
         enricher_task = enricher_mod.start_enricher(config, AsyncEnricherDb(config))
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/librarian.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/librarian.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Single-writer librarian process.
+
+Phase 2b of the enrichment redesign merges the indexer and the enricher into
+one process so exactly one writer touches the library DB. The two worker loops
+are unchanged — only the indexer→enricher "enrich"/"stop" handoff moves from a
+cross-process ``multiprocessing.Queue`` to an in-process ``asyncio.Queue``. The
+searcher still runs separately, so the nudge to it stays a multiprocessing
+queue.
+"""
+
+import asyncio
+import logging
+import logging.handlers
+import multiprocessing
+import signal
+from typing import Optional
+
+from .config_model import LocalFilesConfig
+from .worker_utils import set_proc_title
+from .indexer import indexer as indexer_mod
+from .indexer.indexer_db import AsyncIndexerDb
+from .enricher import enricher as enricher_mod
+from .enricher.enricher_db import AsyncEnricherDb
+
+logger = logging.getLogger("librarian")
+
+
+async def async_main(
+    config: LocalFilesConfig,
+    searcher_nudge_queue: Optional[multiprocessing.Queue] = None,
+):
+    """Run the indexer and enricher worker loops in one event loop."""
+    shutdown_event = asyncio.Event()
+    enricher_enabled = config.enricher.enabled
+
+    # The indexer emits "enrich" onto this queue after every scan; the
+    # enricher consumes it. In-process now, so no serialization or process
+    # hop — the whole point of the merge. When the enricher is disabled the
+    # queue is left unwired (None), so trigger_enricher_update no-ops instead
+    # of growing a queue nobody drains.
+    enrich_queue: Optional[asyncio.Queue] = (
+        asyncio.Queue() if enricher_enabled else None
+    )
+    indexer_mod._enricher_queue = enrich_queue
+
+    # Both worker loops set _shutdown_event on a "stop" command; point them
+    # at the librarian's event so either one flags the whole process.
+    indexer_mod._shutdown_event = shutdown_event
+
+    indexer_db = AsyncIndexerDb(config)
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, shutdown_event.set)
+
+    indexer_task = indexer_mod.start_indexer(config, indexer_db)
+    watcher_task = indexer_mod.start_file_watcher(config)
+
+    enricher_task = None
+    if enricher_enabled:
+        enricher_mod._enricher_queue = enrich_queue
+        enricher_mod._embedder_nudge_queue = searcher_nudge_queue
+        enricher_mod._shutdown_event = shutdown_event
+        enricher_task = enricher_mod.start_enricher(config, AsyncEnricherDb(config))
+
+    try:
+        await shutdown_event.wait()
+    except asyncio.CancelledError:
+        logger.info("Server cancelled, shutting down...")
+    except Exception as e:
+        logger.exception(f"Error in librarian main loop: {e}")
+    finally:
+        logger.info("Librarian initiating shutdown of workers...")
+        if watcher_task and not watcher_task.done():
+            await indexer_mod.stop_file_watcher()
+        if indexer_task and not indexer_task.done():
+            await indexer_mod.stop_indexer()
+        if enricher_task and not enricher_task.done():
+            await enricher_mod.stop_enricher()
+        logger.info("Librarian shutdown complete.")
+
+
+def main(
+    config: LocalFilesConfig,
+    logger_queue: multiprocessing.Queue,
+    searcher_nudge_queue: Optional[multiprocessing.Queue] = None,
+):
+    """Main entry point for the librarian daemon."""
+    set_proc_title("kal-librarian")
+
+    root = logging.getLogger()
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+    root.setLevel(logging.DEBUG)
+    root.addHandler(logging.handlers.QueueHandler(logger_queue))
+
+    try:
+        asyncio.run(async_main(config, searcher_nudge_queue))
+    except KeyboardInterrupt:
+        logger.info("KeyboardInterrupt received by asyncio.run. Exiting.")
+    except Exception as e:
+        logger.critical(f"Unhandled exception in asyncio.run: {e}", exc_info=True)
+    finally:
+        logger.info("Librarian daemon finished.")

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/module_setup.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/module_setup.py
@@ -21,8 +21,7 @@ from .db_schema import init_db
 from .input_module_db import LocalFilesInputModuleDb
 from .localfiles import LocalFilesInputModule
 from .optional_packages import OPTIONAL_PACKAGES
-from . import enricher
-from . import indexer
+from . import librarian
 from . import embedder
 from . import searcher
 
@@ -99,11 +98,11 @@ class KalinkaPluginLocalFiles(InputModulePlugin):
     }
 
     def __init__(self):
-        self._enricher_proc = None
-        self._indexer_proc = None
+        # The indexer and enricher share one "librarian" process (single DB
+        # writer); the searcher and embedder stay separate.
+        self._librarian_proc = None
         self._searcher_proc = None
         self._embedder_proc = None
-        self._enricher_queue = multiprocessing.Queue()
         self._searcher_nudge_queue = multiprocessing.Queue()
         self._embedder_nudge_queue = multiprocessing.Queue()
         self._logging_queue = multiprocessing.Queue()
@@ -197,25 +196,18 @@ class KalinkaPluginLocalFiles(InputModulePlugin):
         # any subprocess starts, so there is no lock contention.
         await init_db(config.db_path)
 
-        self._indexer_proc = multiprocessing.Process(
-            target=indexer.main,
-            args=(config, self._enricher_queue, self._logging_queue),
+        # Indexer + enricher run in one process, wired by an in-process queue.
+        # It nudges the searcher (not the embedder directly) when enrichment
+        # completes; the enricher leg only runs if config.enricher.enabled.
+        self._librarian_proc = multiprocessing.Process(
+            target=librarian.main,
+            args=(
+                config,
+                self._logging_queue,
+                self._searcher_nudge_queue,
+            ),
         )
-
-        self._indexer_proc.start()
-
-        if config.enricher.enabled:
-            # Enricher nudges the searcher (not the embedder directly)
-            self._enricher_proc = multiprocessing.Process(
-                target=enricher.main,
-                args=(
-                    config,
-                    self._enricher_queue,
-                    self._logging_queue,
-                    self._searcher_nudge_queue,
-                ),
-            )
-            self._enricher_proc.start()
+        self._librarian_proc.start()
 
         # The embedder process must run when:
         # 1. embedder.enabled — to compute CLAP audio/text embeddings, or
@@ -286,14 +278,18 @@ class KalinkaPluginLocalFiles(InputModulePlugin):
         """
         await asyncio.sleep(0.2)
 
-        # Indexer: always starts. Mark ERROR only if the Process failed to start.
+        # Indexer: always starts (as the librarian process). Mark ERROR only
+        # if that process failed to start.
+        librarian_alive = (
+            self._librarian_proc is not None and self._librarian_proc.is_alive()
+        )
         idx = self._subfeatures["indexer"]
-        if self._indexer_proc is not None and self._indexer_proc.is_alive():
+        if librarian_alive:
             idx.state = ModuleHealthState.READY
             idx.message = ""
         else:
             idx.state = ModuleHealthState.ERROR
-            idx.message = "Indexer subprocess failed to start."
+            idx.message = "Librarian subprocess failed to start."
 
         # Music folders: a missing or unreadable folder doesn't crash the
         # indexer — it just finds nothing — which makes it the most silent
@@ -325,9 +321,9 @@ class KalinkaPluginLocalFiles(InputModulePlugin):
         if not config.enricher.enabled:
             enr.state = ModuleHealthState.DISABLED
             enr.message = "Disabled in configuration."
-        elif self._enricher_proc is None or not self._enricher_proc.is_alive():
+        elif not librarian_alive:
             enr.state = ModuleHealthState.ERROR
-            enr.message = "Enricher subprocess failed to start."
+            enr.message = "Librarian subprocess failed to start."
         elif config.enricher.plugins.procedural_artwork.enabled and not _is_importable(
             "numpy"
         ):
@@ -540,8 +536,7 @@ class KalinkaPluginLocalFiles(InputModulePlugin):
     async def shutdown(self) -> None:
         logger.info("Shutting down localfiles input module")
 
-        self._shutdown_process(self._indexer_proc)
-        self._shutdown_process(self._enricher_proc)
+        self._shutdown_process(self._librarian_proc)
         self._shutdown_process(self._searcher_proc)
         self._shutdown_process(self._embedder_proc)
 
@@ -550,7 +545,6 @@ class KalinkaPluginLocalFiles(InputModulePlugin):
 
         # Ensure multiprocessing queues release their semaphores
         for q in (
-            self._enricher_queue,
             self._searcher_nudge_queue,
             self._embedder_nudge_queue,
             self._logging_queue,

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/__init__.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/__init__.py
@@ -1,0 +1,1 @@
+# Claims resolution: turn field-level claims into the resolved view.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/resolver.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/resolver.py
@@ -1,0 +1,145 @@
+"""Claims resolution (Phase 2c, §7).
+
+A field's resolved value is the winner of its claims: higher tier wins; within
+a tier a fixed per-field source precedence decides; a tie is broken in favour
+of the value currently resolved (incumbency), so display never churns.
+
+Numeric match scores never enter here — they are how a source *earns* a tier
+inside its own accept/reject decision and stay out of cross-source comparison.
+This module is a pure function over claims; the DB wiring lives in the caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+# Tier ordering (§7). pinned = user said so; guessed = last-resort fallback.
+TIER_RANK = {
+    "pinned": 5,
+    "verified": 4,
+    "observed": 3,
+    "inferred": 2,
+    "guessed": 1,
+}
+
+# Within-tier source precedence. Two profiles cover the fields we resolve:
+#   local_first  — display identity (titles, artist): tags read from the files
+#                  beat a folder name, which beats any external match. A fuzzy
+#                  external match is inferred and must never silently replace a
+#                  locally observed title/artist (§7 field policy).
+#   external_first — origin/era facts (country, year, language, genre): a
+#                  release/artist database is authoritative over local tags,
+#                  and library inference sits above raw tags for these.
+# `user` is always highest; filename/procedural are always last.
+_LOCAL_FIRST = (
+    "user",
+    "tag_consensus",
+    "folder_name",
+    "library_inference",
+    "musicbrainz",
+    "deezer",
+    "wikidata",
+    "acoustid",
+    "filename",
+    "procedural_artwork",
+)
+_EXTERNAL_FIRST = (
+    "user",
+    "musicbrainz",
+    "deezer",
+    "wikidata",
+    "library_inference",
+    "tag_consensus",
+    "folder_name",
+    "acoustid",
+    "filename",
+)
+
+_EXTERNAL_FIRST_FIELDS = frozenset(
+    {
+        "country",
+        "area",
+        "year",
+        "original_year",
+        "recording_year",
+        "language",
+        "genre",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Claim:
+    field: str
+    value: str
+    source: str  # e.g. "tag_consensus" or "musicbrainz:0d7f…"
+    tier: str
+    evidence_ref: Optional[str] = None
+
+
+def _source_base(source: str) -> str:
+    """Strip the id suffix: "musicbrainz:0d7f…" -> "musicbrainz"."""
+    return source.split(":", 1)[0]
+
+
+def _precedence(field: str) -> tuple:
+    return _EXTERNAL_FIRST if field in _EXTERNAL_FIRST_FIELDS else _LOCAL_FIRST
+
+
+def _source_rank(field: str, source: str) -> int:
+    """Higher rank = higher precedence. Unknown sources rank below all known
+    ones (but above nothing), so an unrecognised emitter never outranks a
+    known one merely by being unlisted."""
+    order = _precedence(field)
+    base = _source_base(source)
+    if base in order:
+        # Invert index so earlier-in-tuple = higher rank.
+        return len(order) - order.index(base)
+    return 0
+
+
+def _score(claim: Claim) -> tuple:
+    return (TIER_RANK.get(claim.tier, 0), _source_rank(claim.field, claim.source))
+
+
+def resolve_field(
+    claims: Iterable[Claim], current_value: Optional[str] = None
+) -> Optional[Claim]:
+    """Pick the winning claim for a single field.
+
+    `current_value` is the value already resolved (if any); it wins ties so a
+    display value only changes when a strictly better claim appears.
+    """
+    best: Optional[Claim] = None
+    best_score: Optional[tuple] = None
+    for claim in claims:
+        score = _score(claim)
+        if best is None or score > best_score:
+            best, best_score = claim, score
+        elif score == best_score:
+            # Tie: incumbency — keep whichever equals the current value.
+            if (
+                current_value is not None
+                and claim.value == current_value
+                and best.value != current_value
+            ):
+                best, best_score = claim, score
+    return best
+
+
+def resolve_entity(
+    claims: Iterable[Claim], current: Optional[dict] = None
+) -> List[Claim]:
+    """Resolve every field present in `claims`, returning one winning Claim per
+    field. `current` maps field -> currently-resolved value for incumbency."""
+    current = current or {}
+    by_field: dict[str, List[Claim]] = {}
+    for claim in claims:
+        by_field.setdefault(claim.field, []).append(claim)
+    winners = []
+    for field, field_claims in by_field.items():
+        winner = resolve_field(field_claims, current.get(field))
+        if winner is not None:
+            winners.append(winner)
+    return winners

--- a/packages/kalinka-plugin-localfiles/tests/test_librarian.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_librarian.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""The librarian (Phase 2b) runs the indexer and enricher worker loops in one
+process, wired by an in-process asyncio queue instead of a cross-process
+multiprocessing queue. These cover the handoff contract and that the
+orchestrator points both worker modules at the same queue object.
+"""
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+from kalinka_plugin_localfiles import librarian
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.indexer import indexer as indexer_mod
+from kalinka_plugin_localfiles.enricher import enricher as enricher_mod
+
+
+@pytest.mark.asyncio
+async def test_trigger_enricher_update_puts_on_shared_queue():
+    q: asyncio.Queue = asyncio.Queue()
+    indexer_mod._enricher_queue = q
+    try:
+        await indexer_mod.trigger_enricher_update("enrich")
+        assert q.get_nowait() == "enrich"
+    finally:
+        indexer_mod._enricher_queue = None
+
+
+@pytest.mark.asyncio
+async def test_trigger_enricher_update_noop_without_queue():
+    indexer_mod._enricher_queue = None
+    # No queue wired (e.g. a unit test exercising FileIndexer alone): the
+    # trigger is a silent no-op, not an error.
+    await indexer_mod.trigger_enricher_update("enrich")
+
+
+@pytest_asyncio.fixture
+async def config(tmp_path):
+    cfg = LocalFilesConfig(
+        music_folders=[str(tmp_path / "music")],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+    )
+    (tmp_path / "music").mkdir()
+    await init_db(cfg.db_path)
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_librarian_wires_one_queue_into_both_workers(config, monkeypatch):
+    # Don't run the real worker loops — just observe the wiring async_main does.
+    monkeypatch.setattr(indexer_mod, "start_indexer", lambda c, db: None)
+    monkeypatch.setattr(indexer_mod, "start_file_watcher", lambda c: None)
+    monkeypatch.setattr(enricher_mod, "start_enricher", lambda c, db: None)
+
+    task = asyncio.create_task(librarian.async_main(config, None))
+    try:
+        await asyncio.sleep(0.05)
+        assert isinstance(indexer_mod._enricher_queue, asyncio.Queue)
+        # Same object on both sides — the whole point of the merge.
+        assert indexer_mod._enricher_queue is enricher_mod._enricher_queue
+        assert indexer_mod._shutdown_event is enricher_mod._shutdown_event
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        indexer_mod._enricher_queue = None
+        enricher_mod._enricher_queue = None
+
+
+@pytest.mark.asyncio
+async def test_librarian_leaves_queue_unwired_when_enricher_disabled(
+    config, monkeypatch
+):
+    config.enricher.enabled = False
+    monkeypatch.setattr(indexer_mod, "start_indexer", lambda c, db: None)
+    monkeypatch.setattr(indexer_mod, "start_file_watcher", lambda c: None)
+
+    def _fail(*a, **k):  # enricher must not be started when disabled
+        raise AssertionError("enricher started while disabled")
+
+    monkeypatch.setattr(enricher_mod, "start_enricher", _fail)
+
+    task = asyncio.create_task(librarian.async_main(config, None))
+    try:
+        await asyncio.sleep(0.05)
+        # No drain side, so the indexer's enrich trigger must be a no-op.
+        assert indexer_mod._enricher_queue is None
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        indexer_mod._enricher_queue = None

--- a/packages/kalinka-plugin-localfiles/tests/test_resolver.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_resolver.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Claims resolution engine (Phase 2c, §7): higher tier wins; within a tier a
+per-field source precedence decides; ties favour the incumbent value.
+"""
+
+from kalinka_plugin_localfiles.resolution.resolver import (
+    Claim,
+    resolve_entity,
+    resolve_field,
+)
+
+
+def _c(value, source, tier, field="album_title"):
+    return Claim(field=field, value=value, source=source, tier=tier)
+
+
+def test_higher_tier_wins_regardless_of_source():
+    # Observed tag consensus beats an inferred external match — the canonical
+    # "fuzzy MusicBrainz can't outrank a unanimous embedded title" case.
+    claims = [
+        _c("Everybody Hertz", "tag_consensus", "observed"),
+        _c("Air", "folder_name", "inferred"),
+        _c("Everybody Hertz", "musicbrainz:0d7f", "inferred"),
+    ]
+    winner = resolve_field(claims)
+    assert winner.value == "Everybody Hertz"
+    assert winner.source == "tag_consensus"
+
+
+def test_verified_identifier_corrects_unanimous_tags():
+    # A direct-identifier (verified) match may correct even unanimous tags.
+    claims = [
+        _c("Wrong Title", "tag_consensus", "observed"),
+        _c("Right Title", "musicbrainz:abcd", "verified"),
+    ]
+    assert resolve_field(claims).value == "Right Title"
+
+
+def test_within_tier_field_precedence_local_first_for_title():
+    # Both inferred; for a title, folder_name outranks a fuzzy external match.
+    claims = [
+        _c("Folder Title", "folder_name", "inferred"),
+        _c("MB Title", "musicbrainz:xyz", "inferred"),
+    ]
+    assert resolve_field(claims).source == "folder_name"
+
+
+def test_within_tier_field_precedence_external_first_for_country():
+    # For origin/era fields the profile flips: external beats library inference.
+    claims = [
+        _c("IT", "library_inference", "inferred", field="country"),
+        _c("FR", "musicbrainz:xyz", "inferred", field="country"),
+    ]
+    assert resolve_field(claims).value == "FR"
+
+
+def test_incumbency_breaks_ties():
+    # Two equal-tier, equal-precedence rivals (same source base): the value
+    # already shown keeps winning so display doesn't churn.
+    claims = [
+        _c("A", "musicbrainz:1", "inferred", field="genre"),
+        _c("B", "musicbrainz:2", "inferred", field="genre"),
+    ]
+    assert resolve_field(claims, current_value="B").value == "B"
+    assert resolve_field(claims, current_value="A").value == "A"
+
+
+def test_pinned_beats_everything():
+    claims = [
+        _c("User Choice", "user", "pinned"),
+        _c("MB", "musicbrainz:abcd", "verified"),
+    ]
+    assert resolve_field(claims).source == "user"
+
+
+def test_unknown_source_does_not_outrank_known():
+    claims = [
+        _c("Known", "tag_consensus", "inferred"),
+        _c("Mystery", "some_new_plugin", "inferred"),
+    ]
+    assert resolve_field(claims).value == "Known"
+
+
+def test_empty_claims_resolve_to_none():
+    assert resolve_field([]) is None
+
+
+def test_resolve_entity_returns_one_winner_per_field():
+    claims = [
+        _c("Title A", "tag_consensus", "observed", field="album_title"),
+        _c("Title B", "folder_name", "inferred", field="album_title"),
+        _c("2001", "musicbrainz:z", "inferred", field="year"),
+    ]
+    winners = {w.field: w for w in resolve_entity(claims)}
+    assert winners["album_title"].value == "Title A"
+    assert winners["year"].value == "2001"

--- a/packages/kalinka-plugin-localfiles/tests/test_schema_claims.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_schema_claims.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Phase 2c schema: the claims/resolution tables and the per-field origin/era
+columns exist after init_db, including the migration path on a legacy DB that
+predates them.
+"""
+
+import aiosqlite
+import pytest
+
+from kalinka_plugin_localfiles.db_schema import init_db
+
+
+async def _cols(conn, table):
+    cur = await conn.execute(f"PRAGMA table_info({table})")
+    return {r[1] for r in await cur.fetchall()}
+
+
+async def _tables(conn):
+    cur = await conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    return {r[0] for r in await cur.fetchall()}
+
+
+@pytest.mark.asyncio
+async def test_claims_tables_and_columns_created(tmp_path):
+    db = str(tmp_path / "localfiles.db")
+    await init_db(db)
+    async with aiosqlite.connect(db) as conn:
+        tables = await _tables(conn)
+        assert {"metadata_claims", "resolved_origin", "entity_relation"} <= tables
+        assert "recording_year" in await _cols(conn, "tracks")
+        assert "language" in await _cols(conn, "tracks")
+        assert "country" in await _cols(conn, "albums")
+
+
+@pytest.mark.asyncio
+async def test_init_db_is_idempotent(tmp_path):
+    # Running init_db twice must not fail (the ALTER-TABLE migrations skip
+    # columns that already exist) and must leave the 2c columns in place.
+    db = str(tmp_path / "localfiles.db")
+    await init_db(db)
+    await init_db(db)
+    async with aiosqlite.connect(db) as conn:
+        assert "recording_year" in await _cols(conn, "tracks")
+        assert "language" in await _cols(conn, "tracks")
+        assert "country" in await _cols(conn, "albums")
+
+
+@pytest.mark.asyncio
+async def test_metadata_claims_primary_key_is_per_source(tmp_path):
+    db = str(tmp_path / "localfiles.db")
+    await init_db(db)
+    async with aiosqlite.connect(db) as conn:
+        # Two sources for the same field coexist (a conflict record).
+        await conn.execute(
+            "INSERT INTO metadata_claims VALUES (?,?,?,?,?,?,?)",
+            ("album", "a1", "album_title", "X", "tag_consensus", "observed", 0),
+        )
+        await conn.execute(
+            "INSERT INTO metadata_claims VALUES (?,?,?,?,?,?,?)",
+            ("album", "a1", "album_title", "Y", "folder_name", "inferred", 0),
+        )
+        await conn.commit()
+        cur = await conn.execute(
+            "SELECT COUNT(*) FROM metadata_claims WHERE entity_id='a1'"
+        )
+        assert (await cur.fetchone())[0] == 2


### PR DESCRIPTION
Builds on #92 (Phases 0–1). This is the low-risk **foundation** slice of Phase 2 — the process merge and the claims/resolution schema — landed ahead of the live-path rewrites (plugin→emitter conversion, ENRICHED redefinition, AcoustID rescue mode, library inference), which are their own phase and want live validation of the merge first.

## 2a — run blocking MusicBrainz calls off the event loop
Every synchronous `musicbrainzngs.*` network call inside an `async` enrich method now runs via `asyncio.to_thread`. On its own a small hygiene fix; as a prerequisite it's the thing that makes 2b safe — once the indexer and enricher share one loop, a blocking MB request would otherwise freeze indexing too. Call signatures and the module-level monkeypatch points are preserved, so match-scoring tests are unchanged.

## 2b — merge indexer + enricher into one "librarian" process
`librarian.py` runs both worker loops in a single event loop, so **exactly one process writes the library DB** (the single-writer goal from the design). Mechanism-preserving: the indexer→enricher `"enrich"`/`"stop"` handoff that used to cross a `multiprocessing.Queue` is now an in-process `asyncio.Queue`; the loops themselves are untouched. The searcher stays a separate process, so its post-enrichment nudge remains a multiprocessing queue.

- `indexer`/`enricher` drop their own `main()`/`async_main()`; orchestration lives in the librarian.
- `module_setup` starts one librarian process instead of two, and both the indexer and enricher sub-feature health now key off it.
- When the enricher is disabled the queue is left unwired, so the indexer's post-scan trigger no-ops instead of growing a queue nobody drains.

## 2c — claims/resolution schema + resolver engine (schema-first)
Same schema-before-use rule as 1a. Adds `metadata_claims` (sparse: winning non-local claims, pins, conflicts), `resolved_origin` (provenance for every resolved field), `entity_relation` (semantic links for later inference), and the per-field origin/era columns `albums.country` / `tracks.recording_year` / `tracks.language` (nullable, never required — one column per concept so inference can't launder a release fact into a recording fact).

The `resolution/resolver.py` engine is a pure function: higher tier wins; within a tier a per-field source precedence decides (local-first for display identity, external-first for origin/era); ties favour the incumbent value so display never churns. Match scores stay inside each source's own accept/reject decision and never enter cross-source comparison. **Not yet wired into the live write path** — that's the emitter migration (2d/2e).

## Tests
417 passing (was 413 on main + the 4 new suites here: resolver, claims schema, librarian wiring, plus the existing suite unchanged).

## Not in this PR (next phase)
2d plugins→claim emitters · 2e ENRICHED/required-fields redefinition · 2f AcoustID rescue-mode gating + title-overwrite strip · 2g library-wide inference. These rewrite the enrichment write path and should land after the process merge here is validated live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)