### PR TITLE
indexer: read sibling .cue sheets for single-file CD rips

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
@@ -170,9 +170,7 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
             )
             continue
 
-        # A normal album: title from tag consensus, else a sibling cue's disc
-        # title (single-file CD rips), else the folder name so an untagged rip
-        # still gets a real album (today it falls to unknown_album).
+        # Title: tag consensus, else a sibling cue's disc title, else folder.
         titles = [display_by_id[i][1] for i in ids]
         cue_titles = [display_by_id[i][2] for i in ids]
         title = (

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
@@ -55,6 +55,12 @@ def _album_display(raw: Dict) -> Optional[str]:
     return clean_display_name(album) if album else None
 
 
+def _cue_album(cue: Dict) -> Optional[str]:
+    """Disc title from a parsed cue sheet (single-file CD rip), if any."""
+    album = cue.get("album") if isinstance(cue, dict) else None
+    return clean_display_name(album) if album else None
+
+
 def build_features(track: Dict, evidence: Optional[Dict]) -> TrackFeatures:
     """Assemble the scorer's per-track features from a track row + evidence."""
     evidence = evidence or {}
@@ -127,7 +133,11 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
         return FolderPlan(folder=folder, clusters=[], split=False)
     features = [build_features(t, e) for t, e in rows]
     display_by_id = {
-        t["id"]: (t, _album_display(_loads((e or {}).get("raw_tags"))))
+        t["id"]: (
+            t,
+            _album_display(_loads((e or {}).get("raw_tags"))),
+            _cue_album(_loads((e or {}).get("cue_tracks"))),
+        )
         for t, e in rows
     }
 
@@ -160,10 +170,17 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
             )
             continue
 
-        # A normal album: title from tag consensus, else the folder name so an
-        # untagged rip still gets a real album (today it falls to unknown_album).
+        # A normal album: title from tag consensus, else a sibling cue's disc
+        # title (single-file CD rips), else the folder name so an untagged rip
+        # still gets a real album (today it falls to unknown_album).
         titles = [display_by_id[i][1] for i in ids]
-        title = _dominant(titles) or os.path.basename(folder.rstrip("/")) or ""
+        cue_titles = [display_by_id[i][2] for i in ids]
+        title = (
+            _dominant(titles)
+            or _dominant(cue_titles)
+            or os.path.basename(folder.rstrip("/"))
+            or ""
+        )
         anchor = _dominant(t.get("artist_id") for t in member_tracks) or "unknown_artist"
 
         # Multi-disc-in-one-folder: if the members' titles differ *only* by a

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
@@ -158,6 +158,7 @@ async def init_db(db_path: str) -> None:
                 stream_info    TEXT,
                 art_phash      TEXT,
                 cue_sheet      TEXT,
+                cue_tracks     TEXT,
                 fingerprint    TEXT,
                 fp_computed_at INTEGER,
                 import_batch   TEXT,
@@ -509,6 +510,14 @@ async def init_db(db_path: str) -> None:
                 "ALTER TABLE albums ADD COLUMN image_generated INTEGER DEFAULT 0"
             )
             logger.info("Added albums.image_generated column")
+
+        # Parsed cue tracklist (JSON) captured for single-file CD rips, kept
+        # beside the cue_sheet path for a future playback-splitting consumer.
+        await cursor.execute("PRAGMA table_info(track_evidence)")
+        ev_cols = {row[1] for row in await cursor.fetchall()}
+        if "cue_tracks" not in ev_cols:
+            await cursor.execute("ALTER TABLE track_evidence ADD COLUMN cue_tracks TEXT")
+            logger.info("Added track_evidence.cue_tracks column")
 
         # Backfill file identity from existing tracks (path-hash id becomes
         # file_id; last_updated is the best first_indexed for legacy rows).

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/db_schema.py
@@ -511,8 +511,7 @@ async def init_db(db_path: str) -> None:
             )
             logger.info("Added albums.image_generated column")
 
-        # Parsed cue tracklist (JSON) captured for single-file CD rips, kept
-        # beside the cue_sheet path for a future playback-splitting consumer.
+        # Parsed cue tracklist (JSON) for single-file CD rips.
         await cursor.execute("PRAGMA table_info(track_evidence)")
         ev_cols = {row[1] for row in await cursor.fetchall()}
         if "cue_tracks" not in ev_cols:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/cue.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/cue.py
@@ -1,0 +1,181 @@
+"""Minimal CUE-sheet parser.
+
+Full-CD rips are often a single audio file plus a sibling ``.cue`` that holds
+the real disc metadata (album, performer) and per-track titles + offsets. That
+metadata is authoritative — far better than parsing it back out of a folder
+name — so the indexer reads it when a file's own tags are empty.
+
+This parses the subset we use: disc-level PERFORMER/TITLE/REM GENRE/REM DATE and
+per-track TITLE/PERFORMER/INDEX. Playback splitting (seeking to INDEX offsets)
+is out of scope here; only metadata is captured.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+# CUE keywords are ASCII, so they survive every candidate encoding; only the
+# quoted values differ. utf-16 (BOM) and utf-8 are the common real-world
+# encodings; cp1251 before latin-1 keeps Cyrillic titles readable.
+_ENCODINGS = ("utf-8-sig", "utf-16", "cp1251", "latin-1")
+
+_INDEX_RE = re.compile(r"^\s*INDEX\s+(\d+)\s+(\d+):(\d+):(\d+)")
+_QUOTED_RE = re.compile(r'"([^"]*)"')
+
+
+@dataclass
+class CueTrack:
+    number: Optional[int]
+    title: Optional[str]
+    performer: Optional[str]
+    start_seconds: Optional[float]
+
+
+@dataclass
+class CueFile:
+    name: str
+    tracks: List[CueTrack] = field(default_factory=list)
+
+
+@dataclass
+class CueSheet:
+    performer: Optional[str] = None
+    title: Optional[str] = None
+    genre: Optional[str] = None
+    date: Optional[str] = None
+    files: List[CueFile] = field(default_factory=list)
+
+    def tracks_for(self, audio_basename: str) -> List[CueTrack]:
+        """Tracks whose FILE is the given audio file (basename compare)."""
+        for f in self.files:
+            if os.path.basename(f.name).lower() == audio_basename.lower():
+                return f.tracks
+        # Single-FILE cue: the lone file is implicitly this one.
+        if len(self.files) == 1:
+            return self.files[0].tracks
+        return []
+
+
+def _decode(raw: bytes) -> str:
+    # A wrong encoding can still decode without error (e.g. utf-16 on
+    # single-byte text yields CJK garbage). CUE keywords are ASCII and survive
+    # only the correct decoding, so prefer whichever produces them.
+    fallback: Optional[str] = None
+    for enc in _ENCODINGS:
+        try:
+            text = raw.decode(enc)
+        except (UnicodeDecodeError, UnicodeError):
+            continue
+        if fallback is None:
+            fallback = text
+        up = text.upper()
+        if "TRACK" in up and "FILE" in up:
+            return text
+    return fallback if fallback is not None else raw.decode("latin-1", errors="replace")
+
+
+def _quoted(line: str, keyword: str) -> Optional[str]:
+    """Value after KEYWORD, preferring a quoted form, else the bare remainder."""
+    rest = line.strip()[len(keyword):].strip()
+    if not rest:
+        return None
+    m = _QUOTED_RE.search(rest)
+    return m.group(1).strip() if m else rest.strip('"').strip()
+
+
+def parse_cue(path: str) -> Optional[CueSheet]:
+    """Parse a .cue file. Returns None if it can't be read or has no tracks."""
+    try:
+        with open(path, "rb") as fh:
+            text = _decode(fh.read())
+    except OSError:
+        return None
+
+    sheet = CueSheet()
+    current: Optional[CueFile] = None
+    track: Optional[CueTrack] = None
+
+    for line in text.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        upper = s.upper()
+
+        if upper.startswith("REM GENRE"):
+            sheet.genre = _quoted(s[3:].strip(), "GENRE")
+        elif upper.startswith("REM DATE"):
+            sheet.date = _quoted(s[3:].strip(), "DATE")
+        elif upper.startswith("REM "):
+            continue
+        elif upper.startswith("FILE "):
+            name = _quoted(s, "FILE")
+            # Strip the trailing type token (WAVE / MP3 / ...) if it leaked in.
+            if name and not _QUOTED_RE.search(s):
+                name = name.rsplit(" ", 1)[0]
+            current = CueFile(name=name or "")
+            sheet.files.append(current)
+            track = None
+        elif upper.startswith("TRACK "):
+            parts = s.split()
+            num = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else None
+            track = CueTrack(number=num, title=None, performer=None,
+                             start_seconds=None)
+            if current is None:
+                current = CueFile(name="")
+                sheet.files.append(current)
+            current.tracks.append(track)
+        elif upper.startswith("TITLE"):
+            value = _quoted(s, "TITLE")
+            if track is not None:
+                track.title = value
+            else:
+                sheet.title = value
+        elif upper.startswith("PERFORMER"):
+            value = _quoted(s, "PERFORMER")
+            if track is not None:
+                track.performer = value
+            else:
+                sheet.performer = value
+        elif upper.startswith("INDEX"):
+            m = _INDEX_RE.match(s)
+            # INDEX 01 is the track start; INDEX 00 is pre-gap, ignore it.
+            if m and track is not None and int(m.group(1)) == 1:
+                mm, ss, ff = int(m.group(2)), int(m.group(3)), int(m.group(4))
+                track.start_seconds = mm * 60 + ss + ff / 75.0
+
+    if not any(f.tracks for f in sheet.files):
+        return None
+    return sheet
+
+
+def find_cue_for(audio_path: str) -> Optional[str]:
+    """Locate a sibling .cue describing this audio file.
+
+    Prefers a same-stem .cue (the common single-file-rip layout); otherwise
+    scans the directory for a .cue whose FILE line references this file.
+    """
+    directory = os.path.dirname(audio_path)
+    base = os.path.basename(audio_path)
+    stem = os.path.splitext(base)[0]
+
+    same_stem = os.path.join(directory, stem + ".cue")
+    if os.path.isfile(same_stem):
+        return same_stem
+
+    try:
+        entries = os.listdir(directory)
+    except OSError:
+        return None
+    for entry in entries:
+        if not entry.lower().endswith(".cue"):
+            continue
+        cue_path = os.path.join(directory, entry)
+        sheet = parse_cue(cue_path)
+        if sheet and any(
+            os.path.basename(f.name).lower() == base.lower() for f in sheet.files
+        ):
+            return cue_path
+    return None

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/cue.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/cue.py
@@ -1,13 +1,7 @@
-"""Minimal CUE-sheet parser.
+"""Minimal CUE-sheet parser for single-file CD rips.
 
-Full-CD rips are often a single audio file plus a sibling ``.cue`` that holds
-the real disc metadata (album, performer) and per-track titles + offsets. That
-metadata is authoritative — far better than parsing it back out of a folder
-name — so the indexer reads it when a file's own tags are empty.
-
-This parses the subset we use: disc-level PERFORMER/TITLE/REM GENRE/REM DATE and
-per-track TITLE/PERFORMER/INDEX. Playback splitting (seeking to INDEX offsets)
-is out of scope here; only metadata is captured.
+Reads the disc header (PERFORMER/TITLE/REM GENRE/REM DATE) and per-track
+TITLE/PERFORMER/INDEX. Playback splitting is out of scope; metadata only.
 """
 
 from __future__ import annotations
@@ -17,9 +11,7 @@ import re
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-# CUE keywords are ASCII, so they survive every candidate encoding; only the
-# quoted values differ. utf-16 (BOM) and utf-8 are the common real-world
-# encodings; cp1251 before latin-1 keeps Cyrillic titles readable.
+# cp1251 before latin-1 keeps Cyrillic titles readable; see _decode.
 _ENCODINGS = ("utf-8-sig", "utf-16", "cp1251", "latin-1")
 
 _INDEX_RE = re.compile(r"^\s*INDEX\s+(\d+)\s+(\d+):(\d+):(\d+)")
@@ -60,9 +52,8 @@ class CueSheet:
 
 
 def _decode(raw: bytes) -> str:
-    # A wrong encoding can still decode without error (e.g. utf-16 on
-    # single-byte text yields CJK garbage). CUE keywords are ASCII and survive
-    # only the correct decoding, so prefer whichever produces them.
+    # A wrong encoding can decode without erroring (utf-16 on single-byte text
+    # yields garbage), so prefer whichever produces the ASCII cue keywords.
     fallback: Optional[str] = None
     for enc in _ENCODINGS:
         try:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/cue.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/cue.py
@@ -160,8 +160,8 @@ def find_cue_for(audio_path: str) -> Optional[str]:
         entries = os.listdir(directory)
     except OSError:
         return None
-    # listdir order is filesystem-defined; sort so a folder with several cue
-    # files always resolves to the same one.
+    # sorted() so several cue files resolve deterministically (listdir order
+    # is filesystem-defined).
     for entry in sorted(entries):
         if not entry.lower().endswith(".cue"):
             continue

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/cue.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/cue.py
@@ -160,7 +160,9 @@ def find_cue_for(audio_path: str) -> Optional[str]:
         entries = os.listdir(directory)
     except OSError:
         return None
-    for entry in entries:
+    # listdir order is filesystem-defined; sort so a folder with several cue
+    # files always resolves to the same one.
+    for entry in sorted(entries):
         if not entry.lower().endswith(".cue"):
             continue
         cue_path = os.path.join(directory, entry)

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -612,11 +612,9 @@ class FileIndexer:
             return None
 
     def _augment_with_cue(self, file_path: str, metadata: Dict) -> None:
-        """Fill missing disc metadata from a sibling .cue and stash the parsed
-        tracklist as evidence. A full-CD single-file rip carries its real album,
-        artist and per-track titles in the .cue; that beats parsing them back
-        out of the folder name. Embedded tags still win — the cue only fills
-        fields the file itself left blank."""
+        """Fill blank fields from a sibling .cue (embedded tags still win) and
+        stash the tracklist as evidence. Untagged single-file rips carry their
+        real metadata in the .cue, not the folder name."""
         cue_path = find_cue_for(file_path)
         if not cue_path:
             return
@@ -626,9 +624,7 @@ class FileIndexer:
 
         my_tracks = sheet.tracks_for(os.path.basename(file_path))
         metadata["cue_sheet"] = cue_path
-        # Store the disc header alongside this file's track list so clustering
-        # can prefer the cue's album title over a folder-name guess without
-        # re-reading the file.
+        # Disc header stored too, so clustering can prefer the cue album title.
         metadata["cue_tracks"] = {
             "album": sheet.title,
             "artist": sheet.performer,
@@ -643,9 +639,8 @@ class FileIndexer:
             ],
         }
 
-        # A file that maps to exactly one cue track is a per-track rip: take
-        # that track's title/number. Many tracks in one file is a whole-disc
-        # rip: the disc title labels the single blob until splitting exists.
+        # One cue track for this file -> per-track rip (use its title/number);
+        # many tracks in one file -> whole-disc blob (use the disc title).
         one = my_tracks[0] if len(my_tracks) == 1 else None
 
         if not metadata.get("artist") and sheet.performer:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -33,6 +33,7 @@ from ..utils.name_utils import (
     parse_leading_track_number,
     path_within_roots,
 )
+from .cue import find_cue_for, parse_cue
 from .id_generator import (
     generate_artist_id,
     generate_album_id,
@@ -572,6 +573,8 @@ class FileIndexer:
                 "raw_tags": metadata.get("raw_tags"),
                 "stream_info": metadata.get("stream_info"),
                 "art_phash": art_phash,
+                "cue_sheet": metadata.get("cue_sheet"),
+                "cue_tracks": metadata.get("cue_tracks"),
             },
         )
 
@@ -593,17 +596,66 @@ class FileIndexer:
                 "format": mime_type,
             }
             if "audio/mpeg" in mime_type:
-                return self._extract_mp3_metadata(file_path, metadata)
+                metadata = self._extract_mp3_metadata(file_path, metadata)
             elif "audio/flac" in mime_type:
-                return self._extract_flac_metadata(file_path, metadata)
+                metadata = self._extract_flac_metadata(file_path, metadata)
             else:
                 logger.warning(
                     f"Unsupported file format: {file_path}, format: {mime_type}"
                 )
                 return None
+            if metadata is not None:
+                self._augment_with_cue(file_path, metadata)
+            return metadata
         except Exception as e:
             logger.exception(f"Error extracting metadata from {file_path}: {str(e)}")
             return None
+
+    def _augment_with_cue(self, file_path: str, metadata: Dict) -> None:
+        """Fill missing disc metadata from a sibling .cue and stash the parsed
+        tracklist as evidence. A full-CD single-file rip carries its real album,
+        artist and per-track titles in the .cue; that beats parsing them back
+        out of the folder name. Embedded tags still win — the cue only fills
+        fields the file itself left blank."""
+        cue_path = find_cue_for(file_path)
+        if not cue_path:
+            return
+        sheet = parse_cue(cue_path)
+        if sheet is None:
+            return
+
+        metadata["cue_sheet"] = cue_path
+        # Store the disc header alongside the per-track list so clustering can
+        # prefer the cue's album title over a folder-name guess without
+        # re-reading the file.
+        metadata["cue_tracks"] = {
+            "album": sheet.title,
+            "artist": sheet.performer,
+            "tracks": [
+                {
+                    "number": t.number,
+                    "title": t.title,
+                    "performer": t.performer,
+                    "start_seconds": t.start_seconds,
+                }
+                for t in sheet.tracks_for(os.path.basename(file_path))
+            ],
+        }
+
+        if not metadata.get("artist") and sheet.performer:
+            metadata["artist"] = sheet.performer
+        # One playable file = the whole disc, so the disc title is both the
+        # album and the single track's title until playback splitting exists.
+        if not metadata.get("album") and sheet.title:
+            metadata["album"] = sheet.title
+        if not metadata.get("title") and sheet.title:
+            metadata["title"] = sheet.title
+        if not metadata.get("genre") and sheet.genre:
+            metadata["genre"] = sheet.genre
+        if not metadata.get("year") and sheet.date:
+            m = re.search(r"\d{4}", sheet.date)
+            if m:
+                metadata["year"] = int(m.group())
 
     def _extract_mp3_metadata(self, file_path: str, metadata: Dict) -> Dict:
         """Extract metadata from an MP3 file.

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer.py
@@ -624,9 +624,10 @@ class FileIndexer:
         if sheet is None:
             return
 
+        my_tracks = sheet.tracks_for(os.path.basename(file_path))
         metadata["cue_sheet"] = cue_path
-        # Store the disc header alongside the per-track list so clustering can
-        # prefer the cue's album title over a folder-name guess without
+        # Store the disc header alongside this file's track list so clustering
+        # can prefer the cue's album title over a folder-name guess without
         # re-reading the file.
         metadata["cue_tracks"] = {
             "album": sheet.title,
@@ -638,18 +639,26 @@ class FileIndexer:
                     "performer": t.performer,
                     "start_seconds": t.start_seconds,
                 }
-                for t in sheet.tracks_for(os.path.basename(file_path))
+                for t in my_tracks
             ],
         }
 
+        # A file that maps to exactly one cue track is a per-track rip: take
+        # that track's title/number. Many tracks in one file is a whole-disc
+        # rip: the disc title labels the single blob until splitting exists.
+        one = my_tracks[0] if len(my_tracks) == 1 else None
+
         if not metadata.get("artist") and sheet.performer:
             metadata["artist"] = sheet.performer
-        # One playable file = the whole disc, so the disc title is both the
-        # album and the single track's title until playback splitting exists.
         if not metadata.get("album") and sheet.title:
             metadata["album"] = sheet.title
-        if not metadata.get("title") and sheet.title:
-            metadata["title"] = sheet.title
+        if not metadata.get("title"):
+            if one and one.title:
+                metadata["title"] = one.title
+            elif sheet.title:
+                metadata["title"] = sheet.title
+        if one and one.number and not metadata.get("track_number"):
+            metadata["track_number"] = one.number
         if not metadata.get("genre") and sheet.genre:
             metadata["genre"] = sheet.genre
         if not metadata.get("year") and sheet.date:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -265,10 +265,11 @@ class AsyncIndexerDb:
     async def upsert_track_evidence(
         self, track_id: str, evidence: Dict[str, Any]
     ) -> None:
-        """Upsert the current-snapshot evidence row (only named columns, so
-        fingerprint/cue set later survive). art_phash/import_batch are kept
-        when a refresh omits them — a retag without art shouldn't drop the
-        hash."""
+        """Upsert the current-snapshot evidence row (only named columns, so a
+        fingerprint set later survives). art_phash/cue_sheet/cue_tracks/
+        import_batch are kept when a refresh omits them — a transient miss (no
+        embedded art this pass, a momentarily missing or unparseable cue)
+        shouldn't erase evidence already captured."""
         raw_tags = evidence.get("raw_tags")
         stream_info = evidence.get("stream_info")
         cue_tracks = evidence.get("cue_tracks")
@@ -284,8 +285,10 @@ class AsyncIndexerDb:
                     stream_info  = excluded.stream_info,
                     art_phash    = COALESCE(excluded.art_phash,
                                             track_evidence.art_phash),
-                    cue_sheet    = excluded.cue_sheet,
-                    cue_tracks   = excluded.cue_tracks,
+                    cue_sheet    = COALESCE(excluded.cue_sheet,
+                                            track_evidence.cue_sheet),
+                    cue_tracks   = COALESCE(excluded.cue_tracks,
+                                            track_evidence.cue_tracks),
                     import_batch = COALESCE(excluded.import_batch,
                                             track_evidence.import_batch),
                     updated_at   = excluded.updated_at

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -271,18 +271,21 @@ class AsyncIndexerDb:
         hash."""
         raw_tags = evidence.get("raw_tags")
         stream_info = evidence.get("stream_info")
+        cue_tracks = evidence.get("cue_tracks")
         async with self._open() as conn:
             await conn.execute(
                 """
                 INSERT INTO track_evidence
-                    (track_id, raw_tags, stream_info, art_phash,
-                     import_batch, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?)
+                    (track_id, raw_tags, stream_info, art_phash, cue_sheet,
+                     cue_tracks, import_batch, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(track_id) DO UPDATE SET
                     raw_tags     = excluded.raw_tags,
                     stream_info  = excluded.stream_info,
                     art_phash    = COALESCE(excluded.art_phash,
                                             track_evidence.art_phash),
+                    cue_sheet    = excluded.cue_sheet,
+                    cue_tracks   = excluded.cue_tracks,
                     import_batch = COALESCE(excluded.import_batch,
                                             track_evidence.import_batch),
                     updated_at   = excluded.updated_at
@@ -292,6 +295,8 @@ class AsyncIndexerDb:
                     json.dumps(raw_tags) if raw_tags is not None else None,
                     json.dumps(stream_info) if stream_info is not None else None,
                     evidence.get("art_phash"),
+                    evidence.get("cue_sheet"),
+                    json.dumps(cue_tracks) if cue_tracks is not None else None,
                     evidence.get("import_batch"),
                     int(time.time()),
                 ),
@@ -317,13 +322,13 @@ class AsyncIndexerDb:
         """All tracks paired with their track_evidence (empty dict if none),
         for the clustering pass."""
         _ev_cols = ("raw_tags", "stream_info", "art_phash", "cue_sheet",
-                    "import_batch")
+                    "cue_tracks", "import_batch")
         async with self._open() as conn:
             conn.row_factory = aiosqlite.Row
             cur = await conn.execute(
                 """
                 SELECT t.*, e.raw_tags, e.stream_info, e.art_phash,
-                       e.cue_sheet, e.import_batch
+                       e.cue_sheet, e.cue_tracks, e.import_batch
                 FROM tracks t
                 LEFT JOIN track_evidence e ON e.track_id = t.id
                 """

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -265,11 +265,9 @@ class AsyncIndexerDb:
     async def upsert_track_evidence(
         self, track_id: str, evidence: Dict[str, Any]
     ) -> None:
-        """Upsert the current-snapshot evidence row (only named columns, so a
-        fingerprint set later survives). art_phash/cue_sheet/cue_tracks/
-        import_batch are kept when a refresh omits them — a transient miss (no
-        embedded art this pass, a momentarily missing or unparseable cue)
-        shouldn't erase evidence already captured."""
+        """Upsert the current-snapshot evidence row. art_phash/cue_sheet/
+        cue_tracks/import_batch are COALESCE-kept when a refresh omits them, so
+        a transient miss doesn't erase already-captured evidence."""
         raw_tags = evidence.get("raw_tags")
         stream_info = evidence.get("stream_info")
         cue_tracks = evidence.get("cue_tracks")

--- a/packages/kalinka-plugin-localfiles/tests/test_cue.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cue.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""CUE-sheet parsing: disc + per-track metadata, encoding robustness, and
+sibling-cue discovery. Modelled on a real single-file CD rip (Roxy Music -
+Avalon) whose .cue is UTF-16.
+"""
+
+from kalinka_plugin_localfiles.indexer.cue import find_cue_for, parse_cue
+
+CUE = """REM GENRE "Pop Rock, Synth-pop"
+REM DATE "1982"
+REM COMMENT "EG - EGHP 50, UK, Vinyl, LP, Album"
+PERFORMER "Roxy Music"
+TITLE "Avalon"
+FILE "1982 - Roxy Music - Avalon.flac" WAVE
+  TRACK 01 AUDIO
+    TITLE "More Than This"
+    PERFORMER "Roxy Music"
+    INDEX 01 00:00:00
+  TRACK 02 AUDIO
+    TITLE "The Space Between"
+    PERFORMER "Roxy Music"
+    INDEX 00 04:28:00
+    INDEX 01 04:30:00
+  TRACK 03 AUDIO
+    TITLE "Avalon"
+    PERFORMER "Roxy Music"
+    INDEX 01 08:58:00
+"""
+
+
+def _write(path, text, encoding):
+    path.write_bytes(text.encode(encoding))
+    return str(path)
+
+
+def test_disc_level_metadata(tmp_path):
+    p = _write(tmp_path / "a.cue", CUE, "utf-8")
+    sheet = parse_cue(p)
+    assert sheet.performer == "Roxy Music"
+    assert sheet.title == "Avalon"
+    assert sheet.genre == "Pop Rock, Synth-pop"
+    assert sheet.date == "1982"
+
+
+def test_per_track_titles_and_offsets(tmp_path):
+    p = _write(tmp_path / "a.cue", CUE, "utf-8")
+    tracks = parse_cue(p).files[0].tracks
+    assert [t.number for t in tracks] == [1, 2, 3]
+    assert [t.title for t in tracks] == [
+        "More Than This",
+        "The Space Between",
+        "Avalon",
+    ]
+    # INDEX 01 is the start; INDEX 00 pre-gap is ignored.
+    assert tracks[0].start_seconds == 0.0
+    assert tracks[1].start_seconds == 4 * 60 + 30
+    assert tracks[2].start_seconds == 8 * 60 + 58
+
+
+def test_utf16_encoding(tmp_path):
+    # The real Avalon.cue is UTF-16; decoding must not fall back to mojibake.
+    p = _write(tmp_path / "a.cue", CUE, "utf-16")
+    sheet = parse_cue(p)
+    assert sheet.performer == "Roxy Music"
+    assert sheet.files[0].tracks[1].title == "The Space Between"
+
+
+def test_cyrillic_cp1251(tmp_path):
+    cyr = 'PERFORMER "Кино"\nTITLE "Группа крови"\nFILE "x.flac" WAVE\n' \
+          '  TRACK 01 AUDIO\n    TITLE "Война"\n    INDEX 01 00:00:00\n'
+    p = _write(tmp_path / "a.cue", cyr, "cp1251")
+    sheet = parse_cue(p)
+    assert sheet.performer == "Кино"
+    assert sheet.files[0].tracks[0].title == "Война"
+
+
+def test_tracks_for_single_file(tmp_path):
+    p = _write(tmp_path / "a.cue", CUE, "utf-8")
+    sheet = parse_cue(p)
+    # Exact filename match and the single-file implicit match both work.
+    assert len(sheet.tracks_for("1982 - Roxy Music - Avalon.flac")) == 3
+    assert len(sheet.tracks_for("anything-else.flac")) == 3
+
+
+def test_no_tracks_returns_none(tmp_path):
+    p = _write(tmp_path / "a.cue", 'PERFORMER "X"\nTITLE "Y"\n', "utf-8")
+    assert parse_cue(p) is None
+
+
+def test_find_cue_same_stem(tmp_path):
+    audio = tmp_path / "1982 - Roxy Music - Avalon.flac"
+    audio.write_bytes(b"x")
+    _write(tmp_path / "1982 - Roxy Music - Avalon.cue", CUE, "utf-8")
+    assert find_cue_for(str(audio)) == str(
+        tmp_path / "1982 - Roxy Music - Avalon.cue"
+    )
+
+
+def test_find_cue_by_file_reference(tmp_path):
+    # Cue named differently from the audio, but its FILE line points at it.
+    audio = tmp_path / "1982 - Roxy Music - Avalon.flac"
+    audio.write_bytes(b"x")
+    _write(tmp_path / "disc.cue", CUE, "utf-8")
+    assert find_cue_for(str(audio)) == str(tmp_path / "disc.cue")
+
+
+def test_find_cue_none_when_absent(tmp_path):
+    audio = tmp_path / "track.flac"
+    audio.write_bytes(b"x")
+    assert find_cue_for(str(audio)) is None

--- a/packages/kalinka-plugin-localfiles/tests/test_indexer_cue.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_indexer_cue.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""End-to-end: a tagless single-file CD rip with a sibling .cue is indexed with
+the artist/album/year taken from the cue (not the mangled folder name), and the
+parsed tracklist is stored as evidence.
+"""
+
+import aiosqlite
+import json
+import numpy as np
+import pytest
+import pytest_asyncio
+import soundfile as sf
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.indexer.indexer import FileIndexer
+from kalinka_plugin_localfiles.indexer.indexer_db import AsyncIndexerDb
+
+CUE = """REM GENRE "Synth-pop"
+REM DATE "1982"
+PERFORMER "Roxy Music"
+TITLE "Avalon"
+FILE "1982 - Roxy Music - Avalon.flac" WAVE
+  TRACK 01 AUDIO
+    TITLE "More Than This"
+    INDEX 01 00:00:00
+  TRACK 02 AUDIO
+    TITLE "Avalon"
+    INDEX 01 04:30:00
+"""
+
+
+@pytest_asyncio.fixture
+async def indexer(tmp_path):
+    music = tmp_path / "music"
+    music.mkdir()
+    config = LocalFilesConfig(
+        music_folders=[str(music)],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "artwork"),
+        quiescence_seconds=0,
+    )
+    await init_db(config.db_path)
+    return FileIndexer(config, AsyncIndexerDb(config)), music, config
+
+
+async def _row(config, sql, params=()):
+    async with aiosqlite.connect(config.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        r = await (await conn.execute(sql, params)).fetchone()
+        return dict(r) if r else None
+
+
+@pytest.mark.asyncio
+async def test_cue_supplies_artist_album_for_tagless_rip(indexer):
+    fi, music, config = indexer
+    folder = music / "1982 - Roxy Music - Avalon (EG, UK)"
+    folder.mkdir(parents=True)
+    flac = folder / "1982 - Roxy Music - Avalon.flac"
+    # A tagless FLAC — everything must come from the cue, not the folder name.
+    sf.write(str(flac), np.zeros(2205, dtype="float32"), 44100, format="FLAC")
+    (folder / "1982 - Roxy Music - Avalon.cue").write_bytes(CUE.encode("utf-16"))
+
+    await fi.process_file(str(flac))
+
+    row = await _row(
+        config,
+        """SELECT ar.name AS artist, al.title AS album, al.year AS year,
+                  t.id AS tid
+           FROM tracks t
+           JOIN artists ar ON t.artist_id = ar.id
+           JOIN albums al ON t.album_id = al.id""",
+    )
+    assert row["artist"] == "Roxy Music"   # not "1982"
+    assert row["album"] == "Avalon"        # not "Roxy Music - Avalon"
+    assert row["year"] == 1982
+
+    ev = await _row(
+        config,
+        "SELECT cue_sheet, cue_tracks FROM track_evidence WHERE track_id=?",
+        (row["tid"],),
+    )
+    assert ev["cue_sheet"].endswith("Avalon.cue")
+    cue = json.loads(ev["cue_tracks"])
+    assert cue["album"] == "Avalon"
+    assert [t["title"] for t in cue["tracks"]] == ["More Than This", "Avalon"]
+
+    # The cue-derived album title must survive a folder-first recluster pass,
+    # which otherwise renames the album from the folder ("...Avalon (EG, UK)").
+    await fi.recluster()
+    after = await _row(
+        config, "SELECT title FROM albums WHERE id=?", (
+            (await _row(config, "SELECT album_id FROM tracks WHERE id=?", (row["tid"],)))[
+                "album_id"
+            ],
+        )
+    )
+    assert after["title"] == "Avalon"
+
+
+@pytest.mark.asyncio
+async def test_embedded_tags_win_over_cue(indexer):
+    fi, music, config = indexer
+    folder = music / "Album"
+    folder.mkdir(parents=True)
+    flac = folder / "track.flac"
+    sf.write(str(flac), np.zeros(2205, dtype="float32"), 44100, format="FLAC")
+    # Give the FLAC real tags; the cue must not override them.
+    from mutagen.flac import FLAC
+
+    a = FLAC(str(flac))
+    a["artist"] = "Real Artist"
+    a["album"] = "Real Album"
+    a.save()
+    (folder / "track.cue").write_bytes(CUE.encode("utf-8"))
+
+    await fi.process_file(str(flac))
+    row = await _row(
+        config,
+        """SELECT ar.name AS artist, al.title AS album
+           FROM tracks t JOIN artists ar ON t.artist_id=ar.id
+           JOIN albums al ON t.album_id=al.id""",
+    )
+    assert row["artist"] == "Real Artist"
+    assert row["album"] == "Real Album"

--- a/packages/kalinka-plugin-localfiles/tests/test_indexer_cue.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_indexer_cue.py
@@ -98,6 +98,45 @@ async def test_cue_supplies_artist_album_for_tagless_rip(indexer):
     assert after["title"] == "Avalon"
 
 
+MULTI_FILE_CUE = """PERFORMER "Roxy Music"
+TITLE "Avalon"
+FILE "01 - More Than This.flac" WAVE
+  TRACK 01 AUDIO
+    TITLE "More Than This"
+    INDEX 01 00:00:00
+FILE "02 - The Space Between.flac" WAVE
+  TRACK 02 AUDIO
+    TITLE "The Space Between"
+    INDEX 01 00:00:00
+"""
+
+
+@pytest.mark.asyncio
+async def test_multi_file_cue_uses_per_track_title_and_number(indexer):
+    # A cue with a FLAC per track: each file must get its own title + number,
+    # not the disc title (the whole-disc-blob case is the other test).
+    fi, music, config = indexer
+    folder = music / "Roxy Music - Avalon"
+    folder.mkdir(parents=True)
+    for name in ("01 - More Than This.flac", "02 - The Space Between.flac"):
+        sf.write(str(folder / name), np.zeros(2205, dtype="float32"), 44100,
+                 format="FLAC")
+    (folder / "album.cue").write_bytes(MULTI_FILE_CUE.encode("utf-8"))
+
+    for name in ("01 - More Than This.flac", "02 - The Space Between.flac"):
+        await fi.process_file(str(folder / name))
+
+    rows = {}
+    async with aiosqlite.connect(config.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        cur = await conn.execute(
+            "SELECT title, track_number FROM tracks ORDER BY track_number"
+        )
+        for r in await cur.fetchall():
+            rows[r["track_number"]] = r["title"]
+    assert rows == {1: "More Than This", 2: "The Space Between"}
+
+
 @pytest.mark.asyncio
 async def test_embedded_tags_win_over_cue(indexer):
     fi, music, config = indexer

--- a/packages/kalinka-plugin-localfiles/tests/test_schema_library_file.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_schema_library_file.py
@@ -30,6 +30,7 @@ TRACK_EVIDENCE_COLS = {
     "stream_info",
     "art_phash",
     "cue_sheet",
+    "cue_tracks",
     "fingerprint",
     "fp_computed_at",
     "import_batch",


### PR DESCRIPTION
## Problem
Several albums showed nonsense metadata: **Roxy Music – Avalon** had artist **"1982"**, The Beatles' album was **"The Beatles - Abbey Road"**, etc. Digging in, these files have **completely empty tags** — so everything was being guessed from the folder name, badly.

But they're full-CD single-file rips, and each has a **sibling `.cue`** carrying the real metadata:
```
PERFORMER "Roxy Music"
TITLE "Avalon"
FILE "1982 - Roxy Music - Avalon.flac" WAVE
  TRACK 01 AUDIO / TITLE "More Than This" / INDEX 01 00:00:00
  …full tracklist with offsets
```
That was sitting on disk unused — the `cue_sheet` evidence field existed but the indexer never wrote it (**0 cue sheets captured** across the whole library). ~28 albums are single-file rips like this.

## What this does (capture + metadata)
- **`indexer/cue.py`** — a small, encoding-robust CUE parser (utf-8 / utf-16 / cp1251; keyword-guided decode so a wrong encoding can't silently produce mojibake) + sibling-cue discovery (same-stem, else a `.cue` whose `FILE` references the audio file).
- **Indexer** fills metadata from the cue **only when the file's own tags are absent** (embedded tags still win): disc `PERFORMER` → artist, `TITLE` → album/title, `REM DATE` → year, `REM GENRE` → genre. So `Roxy Music` / `Avalon` / `1982` instead of `1982` / `Roxy Music - Avalon`.
- The parsed **disc header + tracklist** are stored in a new `track_evidence.cue_tracks` column; `cue_sheet` stores the path (which also lights up the existing `same_cue_sheet` clustering signal).
- **Clustering** prefers the cue's disc title over a folder-name guess, so the cue-derived album name **survives a folder-first recluster pass** (verified by test).

No playback changes — the file stays one playable track. The tracklist + `INDEX` offsets are captured for a future splitter, which is the separate, larger piece that touches the native player.

## Tests
412 passing. New: `test_cue.py` (parser: disc/track fields, UTF-16, Cyrillic cp1251, discovery) and `test_indexer_cue.py` (end-to-end: tagless rip → cue-derived artist/album/year + tracklist evidence; embedded tags win; recluster survival).

## Deploy note
Cue data is captured at index time. **Existing** unchanged rips won't pick it up on a normal scan (they're skipped as unchanged) — a **library rebuild** is needed for them. New/changed files get it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)