### PR TITLE
enricher: make the failed-track log useful and quiet

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
@@ -407,8 +407,13 @@ class MetadataEnricher:
             not is_fully_enriched
             and updated_track.get("enriched") != EnrichmentStatus.ENRICHED
         ):
-            logger.info(
-                f"Track {track['id']} failed enrichment - missing required fields"
+            missing = [f for f in TRACK_REQUIRED_FIELDS if not updated_track.get(f)]
+            # file_path identifies the track even when title/artist are missing
+            where = updated_track.get("file_path") or track["id"]
+            logger.debug(
+                "Track %s failed enrichment - missing: %s",
+                where,
+                ", ".join(missing),
             )
             updated_track["enriched"] = EnrichmentStatus.FAILED
             had_updates = True


### PR DESCRIPTION
The enricher logs a line per failed track. It was **INFO** and carried only the opaque track id — no way to tell which track or what was missing:

```
INFO enricher: Track track_c3caec5b65184870 failed enrichment - missing required fields
```

Now it logs the **file path** (which identifies the track even when title/artist are the very fields that are missing) and the **exact list of missing required fields**, at **DEBUG** — matching the artist/album failure logs, which were already debug:

```
DEBUG enricher: Track /music/…/01.Come Together.flac failed enrichment - missing: mbid, track_number
```

Small, self-contained. Pulled out of the Phase 2 foundations PR (#93) so it can land on its own without waiting on that larger change; #93 still contains the same commit, which resolves cleanly on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)