### PR TITLE
enricher: fix untagged-rip album titles and mid-filename track numbers

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
@@ -20,6 +20,7 @@ from .classify import (
     compilation_title,
     is_va_folder,
     normalize_album_title,
+    strip_artist_prefix,
     strip_disc_suffix,
 )
 from .engine import partition_folder
@@ -140,6 +141,11 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
         )
         for t, e in rows
     }
+    name_by_id = {
+        t.get("artist_id"): t.get("artist_name")
+        for t, _ in rows
+        if t.get("artist_id") and t.get("artist_name")
+    }
 
     result = partition_folder(features)
     clusters: List[ClusterPlan] = []
@@ -191,6 +197,12 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
             title = strip_disc_suffix(title)
             kind = "multi_disc"
         title = normalize_album_title(title)
+        # Drop a leading "Artist - " a folder name leaves on the album title
+        # ("The Beatles - Abbey Road" -> "Abbey Road"). Guarded against
+        # eponymous albums by strip_artist_prefix.
+        anchor_name = name_by_id.get(anchor)
+        if anchor_name:
+            title = strip_artist_prefix(title, anchor_name)
 
         clusters.append(
             ClusterPlan(ids, kind, title, anchor, dict(result.basis),

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
@@ -138,7 +138,8 @@ class FilesystemFallbackPlugin(EnricherPlugin):
         return track_number, clean_title, artist_name
 
     def _strip_leading_number(self, text: str) -> tuple[Optional[int], str]:
-        """Split a leading "NN." track number off, if present."""
+        """Split a leading track number off, if present, using the shared
+        TRACK_NUMBER_PREFIX_PATTERNS ("NN ", "NN.", "NN- ", "NN_ ", "NN.Title")."""
         for pattern in self.track_number_patterns:
             match = pattern.match(text)
             if match:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/filesystem_fallback_plugin.py
@@ -99,20 +99,8 @@ class FilesystemFallbackPlugin(EnricherPlugin):
         Returns:
             Tuple of (track_number, clean_title, artist_name)
         """
-        track_number = None
-        clean_title = filename
         artist_name = None
-
-        # First, try to extract track number if present
-        for pattern in self.track_number_patterns:
-            match = pattern.match(filename)
-            if match:
-                try:
-                    track_number = int(match.group(1))
-                    clean_title = filename[match.end() :].strip()
-                    break
-                except (ValueError, IndexError):
-                    continue
+        track_number, clean_title = self._strip_leading_number(filename)
 
         # Try to split the clean title into "artist - track" format
         # Handle various dash variants: -, –, —, and with/without spaces
@@ -142,7 +130,23 @@ class FilesystemFallbackPlugin(EnricherPlugin):
                         clean_title = potential_title
                         break
 
+        # A track number can sit after the "Artist - " prefix
+        # ("Artist - 01.Title"); retry on the post-split title.
+        if track_number is None:
+            track_number, clean_title = self._strip_leading_number(clean_title)
+
         return track_number, clean_title, artist_name
+
+    def _strip_leading_number(self, text: str) -> tuple[Optional[int], str]:
+        """Split a leading "NN." track number off, if present."""
+        for pattern in self.track_number_patterns:
+            match = pattern.match(text)
+            if match:
+                try:
+                    return int(match.group(1)), text[match.end() :].strip()
+                except (ValueError, IndexError):
+                    continue
+        return None, text
 
     def _parse_album_folder(self, album_folder: str) -> tuple[str, Optional[str]]:
         """

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/indexer/indexer_db.py
@@ -328,9 +328,11 @@ class AsyncIndexerDb:
             conn.row_factory = aiosqlite.Row
             cur = await conn.execute(
                 """
-                SELECT t.*, e.raw_tags, e.stream_info, e.art_phash,
+                SELECT t.*, ar.name AS artist_name,
+                       e.raw_tags, e.stream_info, e.art_phash,
                        e.cue_sheet, e.cue_tracks, e.import_batch
                 FROM tracks t
+                LEFT JOIN artists ar ON ar.id = t.artist_id
                 LEFT JOIN track_evidence e ON e.track_id = t.id
                 """
             )

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
@@ -39,9 +39,10 @@ def _ev(album=None, albumartist=None, compilation=None, art=None,
     }
 
 
-def _track(tid, artist_id="artist_a", track_number=1, disc_number=None):
+def _track(tid, artist_id="artist_a", track_number=1, disc_number=None,
+           artist_name=None):
     return {"id": tid, "artist_id": artist_id, "track_number": track_number,
-            "disc_number": disc_number}
+            "disc_number": disc_number, "artist_name": artist_name}
 
 
 def test_build_features_reads_albumartist_and_disc_suffix():
@@ -72,6 +73,29 @@ def test_plan_untagged_folder_gets_folder_name_title():
     assert c.kind == "album"
     assert c.title == "Some Album"        # folder name, not unknown_album
     assert len(c.track_ids) == 5
+
+
+def test_plan_strips_artist_prefix_from_folder_title():
+    # Untagged rip in "The Beatles - Abbey Road": the folder-derived album
+    # title keeps only "Abbey Road" once the artist prefix is stripped.
+    rows = [
+        (_track(f"t{i}", artist_id="beatles", track_number=i,
+                artist_name="The Beatles"), _ev())
+        for i in range(1, 6)
+    ]
+    plan = plan_folder("/music/The Beatles - Abbey Road", rows)
+    assert plan.clusters[0].title == "Abbey Road"
+
+
+def test_plan_keeps_eponymous_album_title():
+    # An album actually named after the artist isn't stripped to empty.
+    rows = [
+        (_track(f"t{i}", artist_id="metallica", track_number=i,
+                artist_name="Metallica"), _ev())
+        for i in range(1, 6)
+    ]
+    plan = plan_folder("/music/Metallica", rows)
+    assert plan.clusters[0].title == "Metallica"
 
 
 def test_plan_coherent_album_uses_tag_title():

--- a/packages/kalinka-plugin-localfiles/tests/test_filesystem_fallback.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_filesystem_fallback.py
@@ -156,3 +156,24 @@ class TestNoSpaceDotPrefix:
         updates = result["updates"]
         assert updates["title"] == "Кончится лето"   # prefix stripped
         assert updates["track_number"] == 1
+
+
+class TestTrackNumberAfterArtistPrefix:
+    """A track number after the "Artist - " prefix ("Artist - 01.Title")
+    is still parsed — the number sits mid-filename, not at the start."""
+
+    def test_number_after_artist_prefix(self, plugin):
+        num, title, artist = plugin._extract_track_number_and_title(
+            "THE BEATLES - 01.Come Together (Lennon-McCartney)"
+        )
+        assert num == 1
+        assert title == "Come Together (Lennon-McCartney)"
+        assert artist == "THE BEATLES"
+
+    def test_no_false_number_when_title_has_no_prefix(self, plugin):
+        num, title, artist = plugin._extract_track_number_and_title(
+            "Pink Floyd - Time"
+        )
+        assert num is None
+        assert title == "Time"
+        assert artist == "Pink Floyd"


### PR DESCRIPTION
Route A of the metadata-quality fixes — the deterministic parser wins for untagged rips, targeting the remaining Beatles-style breakage (folder `The Beatles - Abbey Road`, files `THE BEATLES - 01.Come Together (Lennon-McCartney).flac`, no tags, no cue).

## 1. Track number after the `Artist - ` prefix
`Artist - 01.Title` filenames kept the `01.` in the title and left `track_number` null, because the leading-number parse only ran at the very start of the filename (which begins with the artist). Now, after splitting off the `Artist - ` prefix, the parse retries on the remaining title. Extracted into a `_strip_leading_number` helper.

`THE BEATLES - 01.Come Together (Lennon-McCartney)` → number `1`, title `Come Together (Lennon-McCartney)`, artist `THE BEATLES`.

## 2. Strip the artist prefix from a folder-derived album title
An untagged rip took the whole folder name as the album title (`The Beatles - Abbey Road`). When the cluster's anchor artist is known, a leading `Artist - ` is dropped via the existing word-boundary-safe `strip_artist_prefix` — which guards eponymous albums (a `Metallica` album by Metallica stays `Metallica`). Clustering now joins the artist name into its query.

`The Beatles - Abbey Road` → `Abbey Road`.

## Not here: artist casing (`THE BEATLES` → `The Beatles`)
Deliberately deferred. A deterministic de-shout rule can't tell `THE BEATLES` (fix) from `MF DOOM` / `DJ SHADOW` / `RUN DMC` (intentional uppercase — must not touch) without a dictionary. The false-positive-free fix is the MusicBrainz canonical name, which route B's resolution will provide.

## Tests
433 passing (4 new). Covers the after-prefix number parse, the no-false-positive case, the album-prefix strip, and the eponymous-album guard.

## Deploy note
These apply at index/enrich time, so existing rows need a **library rebuild** to pick them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)