### PR TITLE
enricher: resolve artist display name through claims (Phase 2d slice 1)

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
@@ -8,6 +8,7 @@ import logging
 from typing import Optional
 
 from ..config_model import LocalFilesConfig
+from ..resolution.resolver import Claim, resolve_display_name
 
 from .musicbrainz_plugin import MusicBrainzPlugin
 from .acoustid_plugin import AcoustIdPlugin
@@ -232,6 +233,7 @@ class MetadataEnricher:
         logger.debug(
             f"Artist {artist.get('name', artist['id'])} missing fields - starting plugin enrichment"
         )
+        emitted_claims: list[dict] = []
         for plugin in self.plugins:
             if not plugin.can_enrich_artist():
                 continue
@@ -240,6 +242,8 @@ class MetadataEnricher:
                 f"Enriching artist {artist['name'] if 'name' in artist else artist['id']} with {plugin.__class__.__name__}"
             )
             result = await plugin.enrich_artist(updated_artist)
+            if result:
+                emitted_claims.extend(result.get("claims") or [])
             if result and "updates" in result:
                 # Apply updates to our working copy
                 updated_artist.update(result["updates"])
@@ -255,6 +259,11 @@ class MetadataEnricher:
                     updated_artist["enriched"] = EnrichmentStatus.ENRICHED
                     break  # No need to check further plugins
 
+        # Resolve the display name from claims: a matching external match
+        # supplies canonical casing without replacing a different local name.
+        if await self._resolve_artist_name(artist, updated_artist, emitted_claims):
+            had_updates = True
+
         # After all plugins, if still not fully enriched, mark as failed
         if (
             not is_fully_enriched
@@ -269,6 +278,41 @@ class MetadataEnricher:
         # Only update the database once at the end if we had any updates
         if had_updates:
             await self.db_manager.update_artist(artist["id"], updated_artist)
+
+    async def _resolve_artist_name(
+        self, artist: dict, updated_artist: dict, emitted_claims: list
+    ) -> bool:
+        """Resolve the artist display name from claims. Returns True if the name
+        changed. First field wired through the claims/resolution path (Phase
+        2d): an external match re-cases a matching local name but never replaces
+        a different one; provenance lands in resolved_origin."""
+        local_name = artist.get("name")
+        name_claims = [c for c in emitted_claims if c.get("field") == "name"]
+        if not local_name or not name_claims:
+            return False
+
+        entity_id = artist["id"]
+        external = []
+        for c in name_claims:
+            await self.db_manager.record_claim(
+                "artist", entity_id, "name", c["value"], c["source"], c["tier"]
+            )
+            external.append(
+                Claim("name", c["value"], c["source"], c["tier"])
+            )
+
+        winner = resolve_display_name(local_name, external)
+        await self.db_manager.record_resolved_origin(
+            "artist", entity_id, "name", winner.source, winner.tier
+        )
+        if winner.value != local_name:
+            updated_artist["name"] = winner.value
+            logger.debug(
+                "Artist name resolved: %r -> %r (%s)",
+                local_name, winner.value, winner.source,
+            )
+            return True
+        return False
 
     async def _process_albums(self) -> int:
         """Process non-enriched albums"""

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
@@ -287,23 +287,28 @@ class MetadataEnricher:
         2d): an external match re-cases a matching local name but never replaces
         a different one; provenance lands in resolved_origin."""
         local_name = artist.get("name")
-        name_claims = [c for c in emitted_claims if c.get("field") == "name"]
-        if not local_name or not name_claims:
+        if not local_name:
             return False
 
         entity_id = artist["id"]
         external = []
-        for c in name_claims:
+        for c in emitted_claims:
+            if c.get("field") != "name":
+                continue
             await self.db_manager.record_claim(
                 "artist", entity_id, "name", c["value"], c["source"], c["tier"]
             )
             external.append(
-                Claim("name", c["value"], c["source"], c["tier"])
+                Claim("name", c["value"], c["source"], c["tier"],
+                      c.get("evidence_ref"))
             )
 
+        # Record provenance for the resolved name even when the local value
+        # wins uncontested (resolved_origin covers every resolved field).
         winner = resolve_display_name(local_name, external)
         await self.db_manager.record_resolved_origin(
-            "artist", entity_id, "name", winner.source, winner.tier
+            "artist", entity_id, "name", winner.source, winner.tier,
+            winner.evidence_ref,
         )
         if winner.value != local_name:
             updated_artist["name"] = winner.value

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
@@ -478,6 +478,73 @@ class AsyncEnricherDb:
         """Update track information"""
         await self._update("tracks", track_id, data)
 
+    async def record_claim(
+        self,
+        entity_type: str,
+        entity_id: str,
+        field: str,
+        value: str,
+        source: str,
+        tier: str,
+    ) -> None:
+        """Record one field-level claim (upsert per entity/field/source)."""
+        async with self._open() as conn:
+            await conn.execute(
+                """
+                INSERT INTO metadata_claims
+                    (entity_type, entity_id, field, value, source, tier, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(entity_type, entity_id, field, source) DO UPDATE SET
+                    value = excluded.value,
+                    tier = excluded.tier,
+                    created_at = excluded.created_at
+                """,
+                (entity_type, entity_id, field, value, source, tier,
+                 int(time.time())),
+            )
+            await conn.commit()
+
+    async def get_claims(
+        self, entity_type: str, entity_id: str, field: str
+    ) -> List[Dict[str, Any]]:
+        """All claims for one entity field."""
+        async with self._open() as conn:
+            conn.row_factory = aiosqlite.Row
+            cur = await conn.execute(
+                "SELECT value, source, tier FROM metadata_claims "
+                "WHERE entity_type=? AND entity_id=? AND field=?",
+                (entity_type, entity_id, field),
+            )
+            return [dict(r) for r in await cur.fetchall()]
+
+    async def record_resolved_origin(
+        self,
+        entity_type: str,
+        entity_id: str,
+        field: str,
+        source: str,
+        tier: str,
+        evidence_ref: Optional[str] = None,
+    ) -> None:
+        """Record where a resolved field value came from (upsert per field)."""
+        async with self._open() as conn:
+            await conn.execute(
+                """
+                INSERT INTO resolved_origin
+                    (entity_type, entity_id, field, source, tier, evidence_ref,
+                     resolved_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(entity_type, entity_id, field) DO UPDATE SET
+                    source = excluded.source,
+                    tier = excluded.tier,
+                    evidence_ref = excluded.evidence_ref,
+                    resolved_at = excluded.resolved_at
+                """,
+                (entity_type, entity_id, field, source, tier, evidence_ref,
+                 int(time.time())),
+            )
+            await conn.commit()
+
     async def update_album_stats(self, album_id: str) -> None:
         """Update album statistics (track count and duration)"""
         async with self._open() as conn:

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
@@ -313,8 +313,21 @@ class MusicBrainzPlugin(EnricherPlugin):
             if area_name:
                 updates["area"] = area_name
 
-            # Return data for further enrichment if needed
-            return {"updates": updates, "mbid": artist_mbid}
+            # The canonical name is emitted as an inferred claim, not a direct
+            # update: resolution uses it to re-case a matching local name
+            # ("THE BEATLES" -> "The Beatles") but never to replace a
+            # different local name (a fuzzy match can misidentify the artist).
+            claims = []
+            canonical = best_match.get("name")
+            if canonical:
+                claims.append({
+                    "field": "name",
+                    "value": canonical,
+                    "source": f"musicbrainz:{artist_mbid}",
+                    "tier": "inferred",
+                })
+
+            return {"updates": updates, "mbid": artist_mbid, "claims": claims}
 
         except Exception as e:
             logger.error(f"Error enriching artist {artist['name']}: {str(e)}")

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/resolver.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/resolver.py
@@ -145,13 +145,15 @@ def resolve_display_name(local_value: str, external: Iterable[Claim]) -> Claim:
     local = Claim("name", local_value, "tag_consensus", "observed")
     external = list(external)
 
+    # Order-independent: pick by the resolver's (tier, source-precedence) score,
+    # not by input order, so multiple external claims resolve deterministically.
     strong = [c for c in external if TIER_RANK.get(c.tier, 0) >= TIER_RANK["verified"]]
     if strong:
-        return max(strong, key=lambda c: TIER_RANK.get(c.tier, 0))
+        return max(strong, key=_score)
 
-    for c in external:
-        if _norm(c.value) == _norm(local_value):
-            return c
+    matching = [c for c in external if _norm(c.value) == _norm(local_value)]
+    if matching:
+        return max(matching, key=_score)
     return local
 
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/resolver.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/resolver.py
@@ -128,6 +128,33 @@ def resolve_field(
     return best
 
 
+def _norm(s: str) -> str:
+    return " ".join((s or "").split()).casefold()
+
+
+def resolve_display_name(local_value: str, external: Iterable[Claim]) -> Claim:
+    """Resolve a display-identity field (artist/title) under the §7 rule that a
+    fuzzy external match may re-format but not replace it.
+
+    The locally observed value wins, except: a verified/pinned external (direct
+    identifier or user confirmation) replaces it outright; otherwise a same-
+    value external (equal up to case/whitespace) supplies the canonical surface
+    form ("THE BEATLES" -> "The Beatles"). An external with a genuinely
+    different value never wins.
+    """
+    local = Claim("name", local_value, "tag_consensus", "observed")
+    external = list(external)
+
+    strong = [c for c in external if TIER_RANK.get(c.tier, 0) >= TIER_RANK["verified"]]
+    if strong:
+        return max(strong, key=lambda c: TIER_RANK.get(c.tier, 0))
+
+    for c in external:
+        if _norm(c.value) == _norm(local_value):
+            return c
+    return local
+
+
 def resolve_entity(
     claims: Iterable[Claim], current: Optional[dict] = None
 ) -> List[Claim]:

--- a/packages/kalinka-plugin-localfiles/tests/test_enricher_claims_db.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_enricher_claims_db.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""AsyncEnricherDb claims persistence (Phase 2d): record_claim / get_claims /
+record_resolved_origin round-trip and upsert on the real schema.
+"""
+
+import pytest
+import pytest_asyncio
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.db_schema import init_db
+from kalinka_plugin_localfiles.enricher.enricher_db import AsyncEnricherDb
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    cfg = LocalFilesConfig(
+        music_folders=[str(tmp_path)],
+        db_path=str(tmp_path / "localfiles.db"),
+        artwork_path=str(tmp_path / "art"),
+    )
+    await init_db(cfg.db_path)
+    return AsyncEnricherDb(cfg)
+
+
+@pytest.mark.asyncio
+async def test_claim_roundtrip_and_upsert(db):
+    await db.record_claim("artist", "a1", "name", "The Beatles",
+                          "musicbrainz:m1", "inferred")
+    await db.record_claim("artist", "a1", "name", "THE BEATLES",
+                          "tag_consensus", "observed")
+    claims = await db.get_claims("artist", "a1", "name")
+    by_source = {c["source"]: c for c in claims}
+    assert by_source["musicbrainz:m1"]["value"] == "The Beatles"
+    assert by_source["tag_consensus"]["tier"] == "observed"
+
+    # Same (entity, field, source) upserts rather than duplicating.
+    await db.record_claim("artist", "a1", "name", "The Beatles!",
+                          "musicbrainz:m1", "verified")
+    claims = await db.get_claims("artist", "a1", "name")
+    assert len(claims) == 2
+    mb = next(c for c in claims if c["source"] == "musicbrainz:m1")
+    assert mb["value"] == "The Beatles!" and mb["tier"] == "verified"
+
+
+@pytest.mark.asyncio
+async def test_resolved_origin_upsert(db):
+    await db.record_resolved_origin("artist", "a1", "name",
+                                    "tag_consensus", "observed")
+    await db.record_resolved_origin("artist", "a1", "name",
+                                    "musicbrainz:m1", "inferred", "release:m1")
+    import aiosqlite
+
+    async with aiosqlite.connect(db.db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        cur = await conn.execute(
+            "SELECT * FROM resolved_origin WHERE entity_id='a1' AND field='name'"
+        )
+        rows = [dict(r) for r in await cur.fetchall()]
+    assert len(rows) == 1                       # one row per field
+    assert rows[0]["source"] == "musicbrainz:m1"
+    assert rows[0]["evidence_ref"] == "release:m1"

--- a/packages/kalinka-plugin-localfiles/tests/test_enricher_name_resolution.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_enricher_name_resolution.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Phase 2d, first slice: the enricher resolves the artist display name from
+claims. A MusicBrainz match re-cases a matching local name ("THE BEATLES" ->
+"The Beatles") but never replaces a genuinely different one, and the decision's
+provenance is recorded.
+"""
+
+import pytest
+
+from kalinka_plugin_localfiles.enricher.enricher import MetadataEnricher
+
+
+class FakeDb:
+    def __init__(self):
+        self.claims = []
+        self.origins = []
+
+    async def record_claim(self, et, eid, field, value, source, tier):
+        self.claims.append((et, eid, field, value, source, tier))
+
+    async def record_resolved_origin(self, et, eid, field, source, tier, ev=None):
+        self.origins.append((et, eid, field, source, tier))
+
+
+def _enricher():
+    # Skip __init__ (which builds the real plugin stack); we only exercise
+    # _resolve_artist_name against a fake db.
+    enr = MetadataEnricher.__new__(MetadataEnricher)
+    enr.db_manager = FakeDb()
+    return enr
+
+
+MB_CLAIM = {
+    "field": "name",
+    "value": "The Beatles",
+    "source": "musicbrainz:mbid-1",
+    "tier": "inferred",
+}
+
+
+@pytest.mark.asyncio
+async def test_recases_name_from_matching_mb_claim():
+    enr = _enricher()
+    artist = {"id": "a1", "name": "THE BEATLES"}
+    updated = dict(artist)
+    changed = await enr._resolve_artist_name(artist, updated, [MB_CLAIM])
+    assert changed is True
+    assert updated["name"] == "The Beatles"
+    # Claim persisted and origin recorded as the MB source.
+    assert enr.db_manager.claims[0][:4] == ("artist", "a1", "name", "The Beatles")
+    assert enr.db_manager.origins[0] == (
+        "artist", "a1", "name", "musicbrainz:mbid-1", "inferred",
+    )
+
+
+@pytest.mark.asyncio
+async def test_keeps_local_name_when_mb_differs():
+    enr = _enricher()
+    artist = {"id": "a1", "name": "The Beatles"}
+    updated = dict(artist)
+    diff = {**MB_CLAIM, "value": "The Beetles"}  # different artist
+    changed = await enr._resolve_artist_name(artist, updated, [diff])
+    assert changed is False
+    assert updated["name"] == "The Beatles"
+
+
+@pytest.mark.asyncio
+async def test_no_name_claim_is_noop():
+    enr = _enricher()
+    artist = {"id": "a1", "name": "THE BEATLES"}
+    updated = dict(artist)
+    changed = await enr._resolve_artist_name(artist, updated, [])
+    assert changed is False
+    assert updated["name"] == "THE BEATLES"
+    assert enr.db_manager.claims == []

--- a/packages/kalinka-plugin-localfiles/tests/test_enricher_name_resolution.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_enricher_name_resolution.py
@@ -65,7 +65,7 @@ async def test_keeps_local_name_when_mb_differs():
 
 
 @pytest.mark.asyncio
-async def test_no_name_claim_is_noop():
+async def test_no_name_claim_keeps_local_but_records_origin():
     enr = _enricher()
     artist = {"id": "a1", "name": "THE BEATLES"}
     updated = dict(artist)
@@ -73,3 +73,7 @@ async def test_no_name_claim_is_noop():
     assert changed is False
     assert updated["name"] == "THE BEATLES"
     assert enr.db_manager.claims == []
+    # Provenance is still recorded for the uncontested local value.
+    assert enr.db_manager.origins[0] == (
+        "artist", "a1", "name", "tag_consensus", "observed",
+    )

--- a/packages/kalinka-plugin-localfiles/tests/test_resolver.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_resolver.py
@@ -5,6 +5,7 @@ per-field source precedence decides; ties favour the incumbent value.
 
 from kalinka_plugin_localfiles.resolution.resolver import (
     Claim,
+    resolve_display_name,
     resolve_entity,
     resolve_field,
 )
@@ -94,3 +95,32 @@ def test_resolve_entity_returns_one_winner_per_field():
     winners = {w.field: w for w in resolve_entity(claims)}
     assert winners["album_title"].value == "Title A"
     assert winners["year"].value == "2001"
+
+
+# resolve_display_name: external re-formats but never replaces (§7)
+
+def _ext(value, tier, mbid="x"):
+    return Claim("name", value, f"musicbrainz:{mbid}", tier)
+
+
+def test_display_name_external_recases_matching_local():
+    w = resolve_display_name("THE BEATLES", [_ext("The Beatles", "inferred")])
+    assert w.value == "The Beatles"
+    assert w.source.startswith("musicbrainz:")
+
+
+def test_display_name_keeps_local_when_external_differs():
+    w = resolve_display_name("The Beatles", [_ext("The Beetles", "inferred")])
+    assert w.value == "The Beatles"
+    assert w.tier == "observed"
+
+
+def test_display_name_verified_replaces_outright():
+    w = resolve_display_name("beatles", [_ext("The Beatles", "verified")])
+    assert w.value == "The Beatles"
+
+
+def test_display_name_no_external_keeps_local():
+    w = resolve_display_name("THE BEATLES", [])
+    assert w.value == "THE BEATLES"
+    assert w.tier == "observed"

--- a/packages/kalinka-plugin-localfiles/tests/test_resolver.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_resolver.py
@@ -124,3 +124,12 @@ def test_display_name_no_external_keeps_local():
     w = resolve_display_name("THE BEATLES", [])
     assert w.value == "THE BEATLES"
     assert w.tier == "observed"
+
+
+def test_display_name_recase_is_order_independent():
+    # Two same-value externals in either order resolve to the same winner
+    # (by source precedence, not input order).
+    a = _ext("The Beatles", "inferred", mbid="1")
+    b = Claim("name", "The Beatles", "deezer:2", "inferred")
+    assert resolve_display_name("THE BEATLES", [a, b]).source == \
+        resolve_display_name("THE BEATLES", [b, a]).source


### PR DESCRIPTION
First vertical slice of route B / Phase 2d — wiring the `resolver` (shipped in #93) into the live enrichment write path, one field at a time. This slice does the **artist display name**, which also safely closes the casing gap deferred from #96.

## The rule (§7)
A fuzzy external match may **re-format** a value but not **replace** it. So:
- Locally observed name wins by default.
- A **verified/pinned** external (direct identifier / user confirmation) replaces it.
- An **inferred** external whose value matches the local one *up to case/whitespace* supplies the canonical surface form — `THE BEATLES` → `The Beatles`.
- A fuzzy match to a **different** artist (`The Beetles`) never replaces the local name.

This is why casing couldn't be a blind de-shout (`MF DOOM` must survive): the MB name only re-cases when it's demonstrably the same artist.

## Changes
- **MusicBrainz** emits its canonical artist name as an *inferred* claim (not a direct update).
- **`resolver.resolve_display_name`** implements the rule above.
- **`enricher._resolve_artist_name`** records claims, resolves, applies the winner, and writes `resolved_origin` provenance.
- **`enricher_db`** gains `record_claim` / `get_claims` / `record_resolved_origin` (first writers of `metadata_claims` / `resolved_origin`).

## Tests
438 passing. New: `resolve_display_name` cases (recase / keep-on-difference / verified-replace / no-external), the enricher `_resolve_artist_name` path, and a claims-DB round-trip + upsert.

## Scope
This is slice 1. Album title, year/country/genre, and retiring the plugins' direct writes in favour of resolved output are follow-up slices of 2d. Existing rows need a **library rebuild** to re-resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)