### PR TITLE
Enrichment redesign, Phase 2d slice 2: album title via claims

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
@@ -319,6 +319,44 @@ class MetadataEnricher:
             return True
         return False
 
+    async def _resolve_album_title(
+        self, album: dict, updated_album: dict, emitted_claims: list
+    ) -> bool:
+        """Resolve the album display title from claims. Returns True if the
+        title changed. Second field on the claims/resolution path (Phase 2d):
+        an external release match re-cases a matching local title but never
+        replaces a different one; provenance lands in resolved_origin."""
+        local_title = album.get("title")
+        if not local_title:
+            return False
+
+        entity_id = album["id"]
+        external = []
+        for c in emitted_claims:
+            if c.get("field") != "title":
+                continue
+            await self.db_manager.record_claim(
+                "album", entity_id, "title", c["value"], c["source"], c["tier"]
+            )
+            external.append(
+                Claim("title", c["value"], c["source"], c["tier"],
+                      c.get("evidence_ref"))
+            )
+
+        winner = resolve_display_name(local_title, external, field="title")
+        await self.db_manager.record_resolved_origin(
+            "album", entity_id, "title", winner.source, winner.tier,
+            winner.evidence_ref,
+        )
+        if winner.value != local_title:
+            updated_album["title"] = winner.value
+            logger.debug(
+                "Album title resolved: %r -> %r (%s)",
+                local_title, winner.value, winner.source,
+            )
+            return True
+        return False
+
     async def _process_albums(self) -> int:
         """Process non-enriched albums"""
         processed_albums = set()
@@ -352,6 +390,7 @@ class MetadataEnricher:
             )
             return
 
+        emitted_claims: list[dict] = []
         for plugin in self.plugins:
             if not plugin.can_enrich_album():
                 continue
@@ -360,6 +399,8 @@ class MetadataEnricher:
                 f"Enriching album {album['name'] if 'name' in album else album['id']} with {plugin.__class__.__name__}"
             )
             result = await plugin.enrich_album(updated_album)
+            if result:
+                emitted_claims.extend(result.get("claims") or [])
             if result and "updates" in result:
                 # Apply updates to our working copy
                 updated_album.update(result["updates"])
@@ -374,6 +415,11 @@ class MetadataEnricher:
                     logger.debug(f"Album {album['title']} now fully enriched")
                     updated_album["enriched"] = EnrichmentStatus.ENRICHED
                     break
+
+        # Resolve the display title from claims: a matching external match
+        # supplies canonical casing without replacing a different local title.
+        if await self._resolve_album_title(album, updated_album, emitted_claims):
+            had_updates = True
 
         # After all plugins, if still not fully enriched, mark as failed
         if (

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
@@ -548,7 +548,21 @@ class MusicBrainzPlugin(EnricherPlugin):
             # per album vs N calls per album of N tracks.
             self._release_cache[release_mbid] = mb_release_data
 
-            return {"updates": updates, "mbid": release_mbid}
+            # Title claim: an inferred canonicalization, resolved the same way
+            # as the artist name — it re-cases a matching local title but never
+            # replaces a different one (a fuzzy release match can misidentify
+            # the edition). Album titles are otherwise locally derived.
+            claims = []
+            canonical_title = mb_release_data.get("title") or best.get("title")
+            if canonical_title:
+                claims.append({
+                    "field": "title",
+                    "value": canonical_title,
+                    "source": f"musicbrainz:{release_mbid}",
+                    "tier": "inferred",
+                })
+
+            return {"updates": updates, "mbid": release_mbid, "claims": claims}
 
         except Exception as e:
             logger.error(f"Error enriching album {album['title']}: {str(e)}")

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/resolver.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/resolver.py
@@ -132,17 +132,24 @@ def _norm(s: str) -> str:
     return " ".join((s or "").split()).casefold()
 
 
-def resolve_display_name(local_value: str, external: Iterable[Claim]) -> Claim:
-    """Resolve a display-identity field (artist/title) under the §7 rule that a
-    fuzzy external match may re-format but not replace it.
+def resolve_display_name(
+    local_value: str, external: Iterable[Claim], field: str = "name"
+) -> Claim:
+    """Resolve a display-identity field (artist ``name`` / album ``title``)
+    under the §7 rule that a fuzzy external match may re-format but not replace
+    it.
 
     The locally observed value wins, except: a verified/pinned external (direct
     identifier or user confirmation) replaces it outright; otherwise a same-
     value external (equal up to case/whitespace) supplies the canonical surface
     form ("THE BEATLES" -> "The Beatles"). An external with a genuinely
     different value never wins.
+
+    ``field`` labels the synthesized local claim; both name and title resolve
+    under the same local-first precedence, so it is cosmetic, but keeping it
+    accurate makes the returned/recorded provenance correct per field.
     """
-    local = Claim("name", local_value, "tag_consensus", "observed")
+    local = Claim(field, local_value, "tag_consensus", "observed")
     external = list(external)
 
     # Order-independent: pick by the resolver's (tier, source-precedence) score,

--- a/packages/kalinka-plugin-localfiles/tests/test_enricher_title_resolution.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_enricher_title_resolution.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Phase 2d, second slice: the enricher resolves the album display title from
+claims. A MusicBrainz release match re-cases a matching local title ("ABBEY
+ROAD" -> "Abbey Road") but never replaces a genuinely different one, and the
+decision's provenance is recorded.
+"""
+
+import pytest
+
+from kalinka_plugin_localfiles.enricher.enricher import MetadataEnricher
+
+
+class FakeDb:
+    def __init__(self):
+        self.claims = []
+        self.origins = []
+
+    async def record_claim(self, et, eid, field, value, source, tier):
+        self.claims.append((et, eid, field, value, source, tier))
+
+    async def record_resolved_origin(self, et, eid, field, source, tier, ev=None):
+        self.origins.append((et, eid, field, source, tier))
+
+
+def _enricher():
+    # Skip __init__ (which builds the real plugin stack); we only exercise
+    # _resolve_album_title against a fake db.
+    enr = MetadataEnricher.__new__(MetadataEnricher)
+    enr.db_manager = FakeDb()
+    return enr
+
+
+MB_CLAIM = {
+    "field": "title",
+    "value": "Abbey Road",
+    "source": "musicbrainz:rel-1",
+    "tier": "inferred",
+}
+
+
+@pytest.mark.asyncio
+async def test_recases_title_from_matching_mb_claim():
+    enr = _enricher()
+    album = {"id": "al1", "title": "ABBEY ROAD"}
+    updated = dict(album)
+    changed = await enr._resolve_album_title(album, updated, [MB_CLAIM])
+    assert changed is True
+    assert updated["title"] == "Abbey Road"
+    assert enr.db_manager.claims[0][:4] == ("album", "al1", "title", "Abbey Road")
+    assert enr.db_manager.origins[0] == (
+        "album", "al1", "title", "musicbrainz:rel-1", "inferred",
+    )
+
+
+@pytest.mark.asyncio
+async def test_keeps_local_title_when_mb_differs():
+    enr = _enricher()
+    album = {"id": "al1", "title": "The Singles - The First Ten Years"}
+    updated = dict(album)
+    diff = {**MB_CLAIM, "value": "Gold: Greatest Hits"}  # different release
+    changed = await enr._resolve_album_title(album, updated, [diff])
+    assert changed is False
+    assert updated["title"] == "The Singles - The First Ten Years"
+
+
+@pytest.mark.asyncio
+async def test_no_title_claim_keeps_local_but_records_origin():
+    enr = _enricher()
+    album = {"id": "al1", "title": "Oxygène"}
+    updated = dict(album)
+    changed = await enr._resolve_album_title(album, updated, [])
+    assert changed is False
+    assert updated["title"] == "Oxygène"
+    assert enr.db_manager.claims == []
+    assert enr.db_manager.origins[0] == (
+        "album", "al1", "title", "tag_consensus", "observed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_local_title_is_a_noop():
+    enr = _enricher()
+    album = {"id": "al1"}
+    changed = await enr._resolve_album_title(album, dict(album), [MB_CLAIM])
+    assert changed is False
+    assert enr.db_manager.claims == [] and enr.db_manager.origins == []

--- a/packages/kalinka-plugin-localfiles/tests/test_resolver.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_resolver.py
@@ -133,3 +133,13 @@ def test_display_name_recase_is_order_independent():
     b = Claim("name", "The Beatles", "deezer:2", "inferred")
     assert resolve_display_name("THE BEATLES", [a, b]).source == \
         resolve_display_name("THE BEATLES", [b, a]).source
+
+
+def test_display_name_title_field_labels_local_claim():
+    # Album titles resolve under the same rule; the field param labels the
+    # synthesized local claim so recorded provenance is per-field accurate.
+    ext = Claim("title", "Abbey Road", "musicbrainz:r1", "inferred")
+    w = resolve_display_name("ABBEY ROAD", [ext], field="title")
+    assert w.value == "Abbey Road"
+    kept = resolve_display_name("Oxygène", [], field="title")
+    assert kept.value == "Oxygène" and kept.field == "title"


### PR DESCRIPTION
Second field wired through the claims/resolution path (§7), mirroring the
artist-name slice (#97). An external release match now supplies a canonical
album title **casing** without ever replacing a genuinely different local
title — a fuzzy edition match can't silently rewrite what the tags/cue/folder
say the album is.

## What changed
- **resolver**: `resolve_display_name` gains an optional `field` param so the
  synthesized local claim is labelled `title` (vs `name`). Cosmetic to
  resolution — both resolve local-first — but keeps recorded provenance
  per-field accurate.
- **musicbrainz**: `enrich_album` emits an `inferred` `title` claim from the
  matched release (mirrors the artist name claim).
- **enricher**: `_enrich_album` collects plugin claims and calls the new
  `_resolve_album_title`, which records the claim, resolves via
  `resolve_display_name`, applies the winner, and records `resolved_origin`
  (even when the uncontested local value wins).

## Semantics (same rule as artist name, §7)
- Local title equal up to case/whitespace → adopt the external's canonical
  surface form (`ABBEY ROAD` → `Abbey Road`).
- Local title genuinely different → keep local (external ignored).
- verified/pinned external → replaces outright (no such source today).
- No external claim → keep local, still record provenance.

## Notes
- No DB schema change — `record_claim` / `record_resolved_origin` already take
  an `entity_type`, so `"album"` works as-is.
- Like slice 1, resolution runs during the enrichment pass for
  not-fully-enriched albums; an already-fully-enriched album isn't revisited
  for re-casing (parity with the artist path).
- MB `ENRICHER_VERSION` unchanged: title canonicalization never flips a FAILED
  row to enriched, so no FAILED-row retry sweep is needed.

## Tests
- `test_resolver.py`: `field` param labels the local claim for titles.
- `test_enricher_title_resolution.py` (new): re-case on match, keep-local on
  difference, record origin for uncontested local, no-op on missing title.
- Full localfiles suite: 448 passed (playqueue flake excluded per usual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)