### PR TITLE
Enrichment redesign, Phase 2d slice 3: external-first origin/era fields via claims

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
@@ -8,7 +8,7 @@ import logging
 from typing import Optional
 
 from ..config_model import LocalFilesConfig
-from ..resolution.resolver import Claim, resolve_display_name
+from ..resolution.resolver import Claim, resolve_display_name, resolve_field
 
 from .musicbrainz_plugin import MusicBrainzPlugin
 from .acoustid_plugin import AcoustIdPlugin
@@ -37,6 +37,14 @@ TRACK_REQUIRED_FIELDS = [
     "duration",
     "track_number",
 ]
+
+# Origin/era fields resolved external-first (Phase 2d slice 3). A local tag
+# value is an `observed` claim; a fuzzy MB match is `inferred`, so for
+# genre/year/language the local tag wins when present, while country/area/
+# original_year (no competing local tag) are filled by MB. See resolver
+# `_EXTERNAL_FIRST_FIELDS`.
+ARTIST_EXTERNAL_FIELDS = ("country", "area")
+ALBUM_EXTERNAL_FIELDS = ("genre", "year", "original_year", "language")
 
 # Global variables to manage enricher state. The enricher runs inside the
 # librarian process (Phase 2b); the indexer feeds it "enrich"/"stop" over an
@@ -264,6 +272,12 @@ class MetadataEnricher:
         if await self._resolve_artist_name(artist, updated_artist, emitted_claims):
             had_updates = True
 
+        # Resolve external-first origin fields (country/area) from claims.
+        if await self._resolve_external_fields(
+            "artist", artist, updated_artist, emitted_claims, ARTIST_EXTERNAL_FIELDS
+        ):
+            had_updates = True
+
         # After all plugins, if still not fully enriched, mark as failed
         if (
             not is_fully_enriched
@@ -357,6 +371,57 @@ class MetadataEnricher:
             return True
         return False
 
+    async def _resolve_external_fields(
+        self,
+        entity_type: str,
+        entity: dict,
+        updated: dict,
+        emitted_claims: list,
+        fields,
+    ) -> bool:
+        """Resolve external-first origin/era fields from claims (Phase 2d slice
+        3). For each field, the pre-plugin local value is an `observed`
+        tag_consensus claim and each emitted external value is `inferred`; the
+        resolver picks the winner (local tag beats fuzzy MB for genre/year/
+        language; MB fills country/area/original_year uncontested). Records the
+        winner in resolved_origin and returns True if any value changed."""
+        entity_id = entity["id"]
+        ext_by_field: dict[str, list] = {}
+        for c in emitted_claims:
+            f = c.get("field")
+            if f in fields:
+                ext_by_field.setdefault(f, []).append(c)
+
+        changed = False
+        for field in fields:
+            externals = ext_by_field.get(field, [])
+            local_value = entity.get(field)
+            claims = []
+            if local_value not in (None, ""):
+                claims.append(
+                    Claim(field, local_value, "tag_consensus", "observed")
+                )
+            for c in externals:
+                await self.db_manager.record_claim(
+                    entity_type, entity_id, field, c["value"], c["source"], c["tier"]
+                )
+                claims.append(
+                    Claim(field, c["value"], c["source"], c["tier"],
+                          c.get("evidence_ref"))
+                )
+            if not claims:
+                continue
+
+            winner = resolve_field(claims, current_value=local_value)
+            await self.db_manager.record_resolved_origin(
+                entity_type, entity_id, field, winner.source, winner.tier,
+                winner.evidence_ref,
+            )
+            if winner.value != updated.get(field):
+                updated[field] = winner.value
+                changed = True
+        return changed
+
     async def _process_albums(self) -> int:
         """Process non-enriched albums"""
         processed_albums = set()
@@ -419,6 +484,13 @@ class MetadataEnricher:
         # Resolve the display title from claims: a matching external match
         # supplies canonical casing without replacing a different local title.
         if await self._resolve_album_title(album, updated_album, emitted_claims):
+            had_updates = True
+
+        # Resolve external-first origin/era fields (genre/year/original_year/
+        # language): local tags win over fuzzy MB where present.
+        if await self._resolve_external_fields(
+            "album", album, updated_album, emitted_claims, ALBUM_EXTERNAL_FIELDS
+        ):
             had_updates = True
 
         # After all plugins, if still not fully enriched, mark as failed

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
@@ -326,6 +326,18 @@ class MusicBrainzPlugin(EnricherPlugin):
                     "source": f"musicbrainz:{artist_mbid}",
                     "tier": "inferred",
                 })
+            # Origin fields are external-first: a fuzzy match is inferred, but
+            # for country/area there's no competing local tag, so it fills
+            # uncontested. Emitted as claims (resolution finalizes + records
+            # provenance) in addition to the direct update.
+            for field in ("country", "area"):
+                if field in updates:
+                    claims.append({
+                        "field": field,
+                        "value": updates[field],
+                        "source": f"musicbrainz:{artist_mbid}",
+                        "tier": "inferred",
+                    })
 
             return {"updates": updates, "mbid": artist_mbid, "claims": claims}
 
@@ -561,6 +573,18 @@ class MusicBrainzPlugin(EnricherPlugin):
                     "source": f"musicbrainz:{release_mbid}",
                     "tier": "inferred",
                 })
+            # External-first origin/era fields. genre/year/language have a
+            # competing local tag (observed) that outranks this inferred claim,
+            # so the local value wins when present; original_year has no local
+            # tag, so MB fills it. Resolution decides + records provenance.
+            for field in ("genre", "year", "original_year", "language"):
+                if field in updates:
+                    claims.append({
+                        "field": field,
+                        "value": updates[field],
+                        "source": f"musicbrainz:{release_mbid}",
+                        "tier": "inferred",
+                    })
 
             return {"updates": updates, "mbid": release_mbid, "claims": claims}
 

--- a/packages/kalinka-plugin-localfiles/tests/test_enricher_external_fields.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_enricher_external_fields.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Phase 2d, slice 3: external-first origin/era fields resolved from claims.
+
+A fuzzy MusicBrainz match is `inferred`; a local file tag is `observed`. So
+for genre/year/language the local tag wins when present, while country/area/
+original_year (no competing local tag) are filled by MB. Provenance for the
+winner is always recorded.
+"""
+
+import pytest
+
+from kalinka_plugin_localfiles.enricher.enricher import (
+    ALBUM_EXTERNAL_FIELDS,
+    ARTIST_EXTERNAL_FIELDS,
+    MetadataEnricher,
+)
+
+
+class FakeDb:
+    def __init__(self):
+        self.claims = []
+        self.origins = []
+
+    async def record_claim(self, et, eid, field, value, source, tier):
+        self.claims.append((et, eid, field, value, source, tier))
+
+    async def record_resolved_origin(self, et, eid, field, source, tier, ev=None):
+        self.origins.append((et, eid, field, source, tier))
+
+
+def _enricher():
+    enr = MetadataEnricher.__new__(MetadataEnricher)
+    enr.db_manager = FakeDb()
+    return enr
+
+
+def _mb(field, value, mbid="rel-1"):
+    return {"field": field, "value": value, "source": f"musicbrainz:{mbid}",
+            "tier": "inferred"}
+
+
+@pytest.mark.asyncio
+async def test_local_tag_genre_beats_fuzzy_mb():
+    enr = _enricher()
+    album = {"id": "al1", "genre": "Krautrock"}   # from file tags (observed)
+    updated = {**album, "genre": "Electronic"}    # MB already overwrote via update
+    changed = await enr._resolve_external_fields(
+        "album", album, updated, [_mb("genre", "Electronic")], ALBUM_EXTERNAL_FIELDS
+    )
+    assert changed is True
+    assert updated["genre"] == "Krautrock"        # local tag wins back
+    # origin recorded as the local source
+    assert ("album", "al1", "genre", "tag_consensus", "observed") in enr.db_manager.origins
+
+
+@pytest.mark.asyncio
+async def test_mb_fills_original_year_uncontested():
+    enr = _enricher()
+    album = {"id": "al1"}                          # no local original_year
+    updated = {"id": "al1", "original_year": 1979}  # MB update
+    changed = await enr._resolve_external_fields(
+        "album", album, updated, [_mb("original_year", 1979)], ALBUM_EXTERNAL_FIELDS
+    )
+    # winner == already-set MB value, so no *change*, but provenance recorded.
+    assert changed is False
+    assert updated["original_year"] == 1979
+    assert ("album", "al1", "original_year", "musicbrainz:rel-1", "inferred") \
+        in enr.db_manager.origins
+
+
+@pytest.mark.asyncio
+async def test_local_year_beats_mb_year():
+    enr = _enricher()
+    album = {"id": "al1", "year": 1984}            # tag year (release pressing)
+    updated = {**album, "year": 1990}              # MB reissue year
+    changed = await enr._resolve_external_fields(
+        "album", album, updated, [_mb("year", 1990)], ALBUM_EXTERNAL_FIELDS
+    )
+    assert changed is True
+    assert updated["year"] == 1984
+
+
+@pytest.mark.asyncio
+async def test_artist_country_filled_uncontested():
+    enr = _enricher()
+    artist = {"id": "ar1"}
+    updated = {"id": "ar1", "country": "IT"}
+    changed = await enr._resolve_external_fields(
+        "artist", artist, updated, [_mb("country", "IT", mbid="a-1")],
+        ARTIST_EXTERNAL_FIELDS,
+    )
+    assert changed is False
+    assert updated["country"] == "IT"
+    assert ("artist", "ar1", "country", "musicbrainz:a-1", "inferred") \
+        in enr.db_manager.origins
+
+
+@pytest.mark.asyncio
+async def test_no_claims_for_field_is_skipped():
+    enr = _enricher()
+    album = {"id": "al1"}                           # no local, no external
+    updated = {"id": "al1"}
+    changed = await enr._resolve_external_fields(
+        "album", album, updated, [], ALBUM_EXTERNAL_FIELDS
+    )
+    assert changed is False
+    assert enr.db_manager.claims == [] and enr.db_manager.origins == []


### PR DESCRIPTION
Third slice on the claims/resolution path (§7). Routes the origin/era fields
through the resolver so provenance is recorded and, per the tier model, the
right source wins per field.

## Tier model (design doc §7)
- A local file tag is **observed**; a fuzzy-accepted MB match is **inferred**
  (however high its score). Higher tier wins; per-field source precedence only
  breaks *within-tier* ties.
- So **genre / year / language**: a local observed tag **beats** the inferred
  MB value → the file's tag wins when present. This **reverses** today's
  last-writer-wins, where MB overwrote the tag.
- **country / area / original_year**: no competing local tag → MB fills them
  uncontested (and external-first precedence keeps external above the
  library-inference source that arrives in a later slice).

## What changed
- **musicbrainz**: `enrich_artist` emits `country`/`area`; `enrich_album`
  emits `genre`/`year`/`original_year`/`language` as `inferred` claims
  (alongside the existing direct updates).
- **enricher**: new generic `_resolve_external_fields(entity_type, entity,
  updated, claims, fields)`, called from `_enrich_artist`
  (`ARTIST_EXTERNAL_FIELDS`) and `_enrich_album` (`ALBUM_EXTERNAL_FIELDS`).
  Per field: pre-plugin local value → observed `tag_consensus` claim; each MB
  value → inferred claim; `resolve_field` picks the winner; `resolved_origin`
  records it; `updated[field]` is corrected to the winner.

## Behaviour change to review live
genre/year/language now prefer the file's tags over MB. Review a few albums
after a rebuild — this is the intended model but a visible shift.

## Important: re-index, not just re-enrich
The local claim's value is read from the album/artist row (indexer-set from
tags at index time), not re-derived from tag evidence each pass. On a bare
re-enrich (flip `enriched=0`) a row may still hold a *prior MB* value, which
would then be treated as the local tag. Do a **library rebuild** to see the
true flip. A tag-consensus-from-evidence claim source is a follow-up (relates
to 2g library inference).

## Notes
- No DB schema change (`record_claim`/`record_resolved_origin` already take an
  `entity_type`; the fields already exist as columns).
- Track-level `recording_year` deferred (separate `_enrich_track` path).
- MB `ENRICHER_VERSION` unchanged: resolution never flips a FAILED row to
  enriched, so no FAILED-row retry sweep is needed.

## Tests
- `test_enricher_external_fields.py` (new): local tag beats MB for genre/year;
  MB fills original_year/country uncontested; empty-claims is a no-op.
- Full localfiles suite: 453 passed (playqueue flake excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)