### PR TITLE
clustering: detach flat V/A dump folders + strip [CD NNNNN] catalogue titles

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
@@ -115,11 +115,18 @@ def _is_catalog_paren(contents: str) -> bool:
     """True for a pressing/catalog parenthetical (strip), False for a
     descriptive one like (Soundtrack) / (Remastered) / a bare year (keep)."""
     c = contents.strip()
-    if not c or _DESCRIPTIVE_RE.search(c):
+    if not c:
+        return False
+    # A 5+ digit run is a catalogue/pressing number — decisive even when a
+    # descriptive word rides along ("[CD 61407]", "[Disc 12345]"), so this is
+    # checked before the descriptive bail below (which keeps "(Disc 1)").
+    if _CATALOG_DIGITS_RE.search(c):
+        return True
+    if _DESCRIPTIVE_RE.search(c):
         return False
     if re.fullmatch(r"(?:19|20)\d{2}", c):   # a bare year -> keep
         return False
-    if _CATALOG_DIGITS_RE.search(c) or _FORMAT_TOKEN_RE.search(c):
+    if _FORMAT_TOKEN_RE.search(c):
         return True
     # "Label CAT123, Country" shape: has a comma and an uppercase label token.
     return "," in c and bool(re.search(r"[A-Z]{2,}", c))

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
@@ -48,6 +48,15 @@ def is_va_folder(distinct_artists: int, n_tracks: int) -> bool:
     )
 
 
+def is_declared_va_folder(folder: str) -> bool:
+    """True when the folder name explicitly declares a various-artists
+    compilation ("VA - X" / "Various Artists - X"). Such a folder is a
+    deliberate compilation even without shared album tags, so the flat-dump
+    detach heuristic must leave it alone."""
+    name = os.path.basename(folder.rstrip("/")).strip()
+    return bool(VA_PREFIX_RE.match(name))
+
+
 def compilation_title(folder: str) -> Optional[str]:
     """Album title for a V/A folder, or None if it's a generic dump.
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
@@ -18,6 +18,7 @@ from ..utils.name_utils import clean_display_name, normalize_for_id
 from .classify import (
     VARIOUS_ARTISTS_ID,
     compilation_title,
+    is_declared_va_folder,
     is_va_folder,
     normalize_album_title,
     strip_artist_prefix,
@@ -146,6 +147,48 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
         for t, _ in rows
         if t.get("artist_id") and t.get("artist_name")
     }
+
+    # Folder-level V/A dump: a flat playlist folder (nearly every track a
+    # different artist) with no shared album tag. The partition engine would
+    # otherwise fragment it — tracks with their own cover art each split into a
+    # single-artist album, art-less ones clump into V/A umbrella albums. The
+    # V/A folder policy (detach to unknown_album so tracks surface as singles
+    # under their real artist) is the right outcome for the whole folder, so
+    # short-circuit before partitioning. A real compilation is protected two
+    # ways: its tracks share an album tag (fails the no-shared-album test), or
+    # the folder is an explicitly declared "VA - X" compilation (exempted).
+    folder_real_artists = {
+        t.get("artist_id")
+        for t, _ in rows
+        if t.get("artist_id") and t.get("artist_id") != "unknown_artist"
+    }
+    album_keys = [f.album_key for f in features if f.album_key]
+    dominant_album_cov = (
+        Counter(album_keys).most_common(1)[0][1] / len(rows) if album_keys else 0.0
+    )
+    if (
+        is_va_folder(len(folder_real_artists), len(rows))
+        and dominant_album_cov < 0.5
+        and not is_declared_va_folder(folder)
+    ):
+        return FolderPlan(
+            folder=folder,
+            clusters=[
+                ClusterPlan(
+                    [t["id"] for t, _ in rows],
+                    "singles_pool",
+                    "",
+                    "unknown_artist",
+                    {
+                        "reason": "va_dump_folder",
+                        "distinct_artists": len(folder_real_artists),
+                        "tracks": len(rows),
+                    },
+                    folder,
+                )
+            ],
+            split=False,
+        )
 
     result = partition_folder(features)
     clusters: List[ClusterPlan] = []

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
@@ -138,6 +138,40 @@ def test_plan_generic_dump_is_singles_pool():
     assert c.anchor_artist_id == "unknown_artist"
 
 
+def test_plan_flat_va_dump_detaches_to_singles():
+    # A flat playlist folder (Jamendo-style): many artists, no shared album
+    # tag, each track its own cover art. Must NOT fragment into per-art albums
+    # + V/A umbrellas — the whole folder detaches to unknown_album so tracks
+    # surface as singles under their real artist.
+    rows = [
+        (_track(f"t{i}", artist_id=f"artist_{i}", track_number=i),
+         _ev(art=f"phash_{i}"))               # distinct per-track art
+        for i in range(1, 13)                 # 12 tracks, 12 artists, no album
+    ]
+    plan = plan_folder(
+        "/music/Playlist - Urban - 500604904 --- Jamendo - MP3", rows
+    )
+    assert len(plan.clusters) == 1
+    c = plan.clusters[0]
+    assert c.kind == "singles_pool"
+    assert c.anchor_artist_id == "unknown_artist"
+    assert c.grouping_basis["reason"] == "va_dump_folder"
+    assert len(c.track_ids) == 12             # every track detached, none lost
+
+
+def test_plan_shared_album_tag_survives_many_artists():
+    # A real V/A compilation with a shared album tag is NOT a dump even though
+    # every track is a different artist — the shared tag protects it.
+    rows = [
+        (_track(f"t{i}", artist_id=f"artist_{i}", track_number=i),
+         _ev(album="Now That's What I Call Music 50"))
+        for i in range(1, 13)
+    ]
+    plan = plan_folder("/music/Now 50", rows)
+    assert len(plan.clusters) == 1
+    assert plan.clusters[0].kind == "compilation"
+
+
 def test_multidisc_in_one_folder_strips_disc_suffix_from_title():
     # Both discs tagged "… (Disc N)" in one folder collapse to one album whose
     # title drops the disc marker.

--- a/packages/kalinka-plugin-localfiles/tests/test_title_normalize.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_title_normalize.py
@@ -22,6 +22,11 @@ from kalinka_plugin_localfiles.clustering.classify import normalize_album_title
      "Ellington, Mingus, Roach - Money Jungle"),
     ("Playlist - Urban - 500604904 --- Jamendo - MP3",
      "Playlist - Urban"),
+    # Bracketed catalogue number ("CD" + a long digit run) — a pressing id,
+    # not the "(CD 1)" disc marker, so it is stripped.
+    ("Talks [CD 61407]", "Talks"),
+    ("Classic Queen [CD 61311]", "Classic Queen"),
+    ("Queen Talks [1992, Canada, CD 61407]", "Queen Talks"),
 ])
 def test_strips_junk(raw, clean):
     assert normalize_album_title(raw) == clean
@@ -37,6 +42,7 @@ def test_strips_junk(raw, clean):
     "The Best Of Michael Jackson (Disk 2)",  # disc marker left to disc logic
     "Discovery (2001)",                   # bare year in paren kept
     "1984",                               # a title that *is* a year
+    "Iceberg Forces [CC Edition]",        # descriptive bracket (no catalog id) kept
 ])
 def test_leaves_real_titles_untouched(title):
     assert normalize_album_title(title) == title


### PR DESCRIPTION
Two independent album-hygiene fixes surfaced by the enrichment assessment.

## 1. Flat V/A dump folders fragment (the bigger one)
A flat playlist folder — nearly every track a different artist, no shared
album tag (a Jamendo `Playlist - … --- Jamendo - MP3` dump: 69 tracks, 59
artists) — was shattered into **13 bogus albums**: tracks carrying their own
cover art each split into a single-artist album (the partition engine blocks
on `art_phash`), while art-less ones clumped into `various_artists` umbrella
albums. The per-group V/A check can't catch the singletons.

`plan_folder` now detects this at **folder scope, before partitioning**: when
the folder is V/A (`is_va_folder` over all real artists) **and** no album tag
covers ≥50% of tracks, every track goes to a single `singles_pool`
(`unknown_album`) so it surfaces as a single under its real artist — the V/A
folder policy applied to the whole folder instead of per fragment.

Real compilations are protected two ways: a **shared album tag** fails the
no-shared-album test (a proper "Now 50" stays one compilation), and an
explicitly declared **`VA - X`** folder is exempted (`is_declared_va_folder`).

## 2. `[CD NNNNN]` catalogue numbers leak into titles
`Talks [CD 61407]`, `Classic Queen [CD 61311]`, `Greatest Hits [CD 61265]` —
`_is_catalog_paren` bailed on any bracket containing "CD" (kept for the
"(CD 1)" disc marker), so a catalogue id survived. The 5+ digit
catalogue-number rule is now checked first, so `[CD 61407]` /
`[1992, Canada, CD 61407]` strip while `(CD 1)` / `(Disc 2)` and descriptive
brackets like `[CC Edition]` stay.

## Tests
- `test_cluster_planner.py`: flat dump → singles (all tracks retained); shared
  album tag survives many artists; declared `VA - X` still a compilation.
- `test_title_normalize.py`: catalogue brackets strip, descriptive/disc/year
  parentheticals preserved.
- Full localfiles suite: 454 passed (playqueue flake excluded).

## Deploy note
Both apply at index/cluster time — a library **rebuild** is needed for the
Jamendo folder to re-cluster and the affected titles to re-derive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)