### PR TITLE
Enrichment slice 3 + clustering hygiene (consolidates #99 + #100, Copilot addressed)

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
@@ -115,11 +115,18 @@ def _is_catalog_paren(contents: str) -> bool:
     """True for a pressing/catalog parenthetical (strip), False for a
     descriptive one like (Soundtrack) / (Remastered) / a bare year (keep)."""
     c = contents.strip()
-    if not c or _DESCRIPTIVE_RE.search(c):
+    if not c:
+        return False
+    # A 5+ digit run is a catalogue/pressing number — decisive even when a
+    # descriptive word rides along ("[CD 61407]", "[Disc 12345]"), so this is
+    # checked before the descriptive bail below (which keeps "(Disc 1)").
+    if _CATALOG_DIGITS_RE.search(c):
+        return True
+    if _DESCRIPTIVE_RE.search(c):
         return False
     if re.fullmatch(r"(?:19|20)\d{2}", c):   # a bare year -> keep
         return False
-    if _CATALOG_DIGITS_RE.search(c) or _FORMAT_TOKEN_RE.search(c):
+    if _FORMAT_TOKEN_RE.search(c):
         return True
     # "Label CAT123, Country" shape: has a comma and an uppercase label token.
     return "," in c and bool(re.search(r"[A-Z]{2,}", c))

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
@@ -48,6 +48,15 @@ def is_va_folder(distinct_artists: int, n_tracks: int) -> bool:
     )
 
 
+def is_declared_va_folder(folder: str) -> bool:
+    """True when the folder name explicitly declares a various-artists
+    compilation ("VA - X" / "Various Artists - X"). Such a folder is a
+    deliberate compilation even without shared album tags, so the flat-dump
+    detach heuristic must leave it alone."""
+    name = os.path.basename(folder.rstrip("/")).strip()
+    return bool(VA_PREFIX_RE.match(name))
+
+
 def compilation_title(folder: str) -> Optional[str]:
     """Album title for a V/A folder, or None if it's a generic dump.
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/classify.py
@@ -63,6 +63,7 @@ def compilation_title(folder: str) -> Optional[str]:
     A folder explicitly marked ``VA -`` / ``Various Artists -`` is a declared
     compilation and bypasses the generic-dump heuristic.
     """
+    folder = folder.rstrip("/")  # a trailing "/" would make basename empty
     name = os.path.basename(folder).strip()
     title = VA_PREFIX_RE.sub("", name).strip()
     explicit_va = title != name

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/clustering/planner.py
@@ -18,6 +18,7 @@ from ..utils.name_utils import clean_display_name, normalize_for_id
 from .classify import (
     VARIOUS_ARTISTS_ID,
     compilation_title,
+    is_declared_va_folder,
     is_va_folder,
     normalize_album_title,
     strip_artist_prefix,
@@ -146,6 +147,48 @@ def plan_folder(folder: str, rows: List[Tuple[Dict, Optional[Dict]]]) -> FolderP
         for t, _ in rows
         if t.get("artist_id") and t.get("artist_name")
     }
+
+    # Folder-level V/A dump: a flat playlist folder (nearly every track a
+    # different artist) with no shared album tag. The partition engine would
+    # otherwise fragment it — tracks with their own cover art each split into a
+    # single-artist album, art-less ones clump into V/A umbrella albums. The
+    # V/A folder policy (detach to unknown_album so tracks surface as singles
+    # under their real artist) is the right outcome for the whole folder, so
+    # short-circuit before partitioning. A real compilation is protected two
+    # ways: its tracks share an album tag (fails the no-shared-album test), or
+    # the folder is an explicitly declared "VA - X" compilation (exempted).
+    folder_real_artists = {
+        t.get("artist_id")
+        for t, _ in rows
+        if t.get("artist_id") and t.get("artist_id") != "unknown_artist"
+    }
+    album_keys = [f.album_key for f in features if f.album_key]
+    dominant_album_cov = (
+        Counter(album_keys).most_common(1)[0][1] / len(rows) if album_keys else 0.0
+    )
+    if (
+        is_va_folder(len(folder_real_artists), len(rows))
+        and dominant_album_cov < 0.5
+        and not is_declared_va_folder(folder)
+    ):
+        return FolderPlan(
+            folder=folder,
+            clusters=[
+                ClusterPlan(
+                    [t["id"] for t, _ in rows],
+                    "singles_pool",
+                    "",
+                    "unknown_artist",
+                    {
+                        "reason": "va_dump_folder",
+                        "distinct_artists": len(folder_real_artists),
+                        "tracks": len(rows),
+                    },
+                    folder,
+                )
+            ],
+            split=False,
+        )
 
     result = partition_folder(features)
     clusters: List[ClusterPlan] = []

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher.py
@@ -8,7 +8,7 @@ import logging
 from typing import Optional
 
 from ..config_model import LocalFilesConfig
-from ..resolution.resolver import Claim, resolve_display_name
+from ..resolution.resolver import Claim, resolve_display_name, resolve_field
 
 from .musicbrainz_plugin import MusicBrainzPlugin
 from .acoustid_plugin import AcoustIdPlugin
@@ -37,6 +37,14 @@ TRACK_REQUIRED_FIELDS = [
     "duration",
     "track_number",
 ]
+
+# Origin/era fields resolved external-first (Phase 2d slice 3). A local tag
+# value is an `observed` claim; a fuzzy MB match is `inferred`, so for
+# genre/year/language the local tag wins when present, while country/area/
+# original_year (no competing local tag) are filled by MB. See resolver
+# `_EXTERNAL_FIRST_FIELDS`.
+ARTIST_EXTERNAL_FIELDS = ("country", "area")
+ALBUM_EXTERNAL_FIELDS = ("genre", "year", "original_year", "language")
 
 # Global variables to manage enricher state. The enricher runs inside the
 # librarian process (Phase 2b); the indexer feeds it "enrich"/"stop" over an
@@ -264,6 +272,12 @@ class MetadataEnricher:
         if await self._resolve_artist_name(artist, updated_artist, emitted_claims):
             had_updates = True
 
+        # Resolve external-first origin fields (country/area) from claims.
+        if await self._resolve_external_fields(
+            "artist", artist, updated_artist, emitted_claims, ARTIST_EXTERNAL_FIELDS
+        ):
+            had_updates = True
+
         # After all plugins, if still not fully enriched, mark as failed
         if (
             not is_fully_enriched
@@ -357,6 +371,57 @@ class MetadataEnricher:
             return True
         return False
 
+    async def _resolve_external_fields(
+        self,
+        entity_type: str,
+        entity: dict,
+        updated: dict,
+        emitted_claims: list,
+        fields,
+    ) -> bool:
+        """Resolve external-first origin/era fields from claims (Phase 2d slice
+        3). For each field, the pre-plugin local value is an `observed`
+        tag_consensus claim and each emitted external value is `inferred`; the
+        resolver picks the winner (local tag beats fuzzy MB for genre/year/
+        language; MB fills country/area/original_year uncontested). Records the
+        winner in resolved_origin and returns True if any value changed."""
+        entity_id = entity["id"]
+        ext_by_field: dict[str, list] = {}
+        for c in emitted_claims:
+            f = c.get("field")
+            if f in fields:
+                ext_by_field.setdefault(f, []).append(c)
+
+        changed = False
+        for field in fields:
+            externals = ext_by_field.get(field, [])
+            local_value = entity.get(field)
+            claims = []
+            if local_value not in (None, ""):
+                claims.append(
+                    Claim(field, local_value, "tag_consensus", "observed")
+                )
+            for c in externals:
+                await self.db_manager.record_claim(
+                    entity_type, entity_id, field, c["value"], c["source"], c["tier"]
+                )
+                claims.append(
+                    Claim(field, c["value"], c["source"], c["tier"],
+                          c.get("evidence_ref"))
+                )
+            if not claims:
+                continue
+
+            winner = resolve_field(claims, current_value=local_value)
+            await self.db_manager.record_resolved_origin(
+                entity_type, entity_id, field, winner.source, winner.tier,
+                winner.evidence_ref,
+            )
+            if winner.value != updated.get(field):
+                updated[field] = winner.value
+                changed = True
+        return changed
+
     async def _process_albums(self) -> int:
         """Process non-enriched albums"""
         processed_albums = set()
@@ -419,6 +484,13 @@ class MetadataEnricher:
         # Resolve the display title from claims: a matching external match
         # supplies canonical casing without replacing a different local title.
         if await self._resolve_album_title(album, updated_album, emitted_claims):
+            had_updates = True
+
+        # Resolve external-first origin/era fields (genre/year/original_year/
+        # language): local tags win over fuzzy MB where present.
+        if await self._resolve_external_fields(
+            "album", album, updated_album, emitted_claims, ALBUM_EXTERNAL_FIELDS
+        ):
             had_updates = True
 
         # After all plugins, if still not fully enriched, mark as failed

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/enricher_db.py
@@ -483,11 +483,15 @@ class AsyncEnricherDb:
         entity_type: str,
         entity_id: str,
         field: str,
-        value: str,
+        value: str | int,
         source: str,
         tier: str,
     ) -> None:
-        """Record one field-level claim (upsert per entity/field/source)."""
+        """Record one field-level claim (upsert per entity/field/source).
+
+        ``value`` is str for text fields, int for numeric origin/era fields
+        (year, original_year); SQLite stores it in the TEXT column either way.
+        """
         async with self._open() as conn:
             await conn.execute(
                 """

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/musicbrainz_plugin.py
@@ -326,6 +326,18 @@ class MusicBrainzPlugin(EnricherPlugin):
                     "source": f"musicbrainz:{artist_mbid}",
                     "tier": "inferred",
                 })
+            # Origin fields are external-first: a fuzzy match is inferred, but
+            # for country/area there's no competing local tag, so it fills
+            # uncontested. Emitted as claims (resolution finalizes + records
+            # provenance) in addition to the direct update.
+            for field in ("country", "area"):
+                if field in updates:
+                    claims.append({
+                        "field": field,
+                        "value": updates[field],
+                        "source": f"musicbrainz:{artist_mbid}",
+                        "tier": "inferred",
+                    })
 
             return {"updates": updates, "mbid": artist_mbid, "claims": claims}
 
@@ -561,6 +573,18 @@ class MusicBrainzPlugin(EnricherPlugin):
                     "source": f"musicbrainz:{release_mbid}",
                     "tier": "inferred",
                 })
+            # External-first origin/era fields. genre/year/language have a
+            # competing local tag (observed) that outranks this inferred claim,
+            # so the local value wins when present; original_year has no local
+            # tag, so MB fills it. Resolution decides + records provenance.
+            for field in ("genre", "year", "original_year", "language"):
+                if field in updates:
+                    claims.append({
+                        "field": field,
+                        "value": updates[field],
+                        "source": f"musicbrainz:{release_mbid}",
+                        "tier": "inferred",
+                    })
 
             return {"updates": updates, "mbid": release_mbid, "claims": claims}
 

--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/resolver.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/resolution/resolver.py
@@ -72,7 +72,10 @@ _EXTERNAL_FIRST_FIELDS = frozenset(
 @dataclass(frozen=True)
 class Claim:
     field: str
-    value: str
+    # str for identity/text fields; int for numeric origin/era fields
+    # (year, original_year). Resolution compares by (tier, source), never by
+    # the value itself, so the mixed type is safe here.
+    value: str | int
     source: str  # e.g. "tag_consensus" or "musicbrainz:0d7f…"
     tier: str
     evidence_ref: Optional[str] = None
@@ -104,7 +107,7 @@ def _score(claim: Claim) -> tuple:
 
 
 def resolve_field(
-    claims: Iterable[Claim], current_value: Optional[str] = None
+    claims: Iterable[Claim], current_value: Optional[str | int] = None
 ) -> Optional[Claim]:
     """Pick the winning claim for a single field.
 

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
@@ -125,6 +125,20 @@ def test_plan_va_folder_is_compilation():
     assert c.anchor_artist_id == "various_artists"
 
 
+def test_plan_declared_va_with_trailing_slash():
+    # A trailing "/" must not make basename empty and misclassify a declared
+    # V/A compilation as a generic dump (Copilot review, PR #100).
+    rows = [
+        (_track(f"t{i}", artist_id=f"artist_{i}", track_number=i),
+         _ev(album=f"track by {i}"))
+        for i in range(1, 7)
+    ]
+    plan = plan_folder("/music/VA - Summer Hits/", rows)
+    assert len(plan.clusters) == 1
+    assert plan.clusters[0].kind == "compilation"
+    assert plan.clusters[0].title == "Summer Hits"
+
+
 def test_plan_generic_dump_is_singles_pool():
     rows = [
         (_track(f"t{i}", artist_id=f"artist_{i}", track_number=i), _ev())

--- a/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_cluster_planner.py
@@ -138,6 +138,40 @@ def test_plan_generic_dump_is_singles_pool():
     assert c.anchor_artist_id == "unknown_artist"
 
 
+def test_plan_flat_va_dump_detaches_to_singles():
+    # A flat playlist folder (Jamendo-style): many artists, no shared album
+    # tag, each track its own cover art. Must NOT fragment into per-art albums
+    # + V/A umbrellas — the whole folder detaches to unknown_album so tracks
+    # surface as singles under their real artist.
+    rows = [
+        (_track(f"t{i}", artist_id=f"artist_{i}", track_number=i),
+         _ev(art=f"phash_{i}"))               # distinct per-track art
+        for i in range(1, 13)                 # 12 tracks, 12 artists, no album
+    ]
+    plan = plan_folder(
+        "/music/Playlist - Urban - 500604904 --- Jamendo - MP3", rows
+    )
+    assert len(plan.clusters) == 1
+    c = plan.clusters[0]
+    assert c.kind == "singles_pool"
+    assert c.anchor_artist_id == "unknown_artist"
+    assert c.grouping_basis["reason"] == "va_dump_folder"
+    assert len(c.track_ids) == 12             # every track detached, none lost
+
+
+def test_plan_shared_album_tag_survives_many_artists():
+    # A real V/A compilation with a shared album tag is NOT a dump even though
+    # every track is a different artist — the shared tag protects it.
+    rows = [
+        (_track(f"t{i}", artist_id=f"artist_{i}", track_number=i),
+         _ev(album="Now That's What I Call Music 50"))
+        for i in range(1, 13)
+    ]
+    plan = plan_folder("/music/Now 50", rows)
+    assert len(plan.clusters) == 1
+    assert plan.clusters[0].kind == "compilation"
+
+
 def test_multidisc_in_one_folder_strips_disc_suffix_from_title():
     # Both discs tagged "… (Disc N)" in one folder collapse to one album whose
     # title drops the disc marker.

--- a/packages/kalinka-plugin-localfiles/tests/test_enricher_external_fields.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_enricher_external_fields.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Phase 2d, slice 3: external-first origin/era fields resolved from claims.
+
+A fuzzy MusicBrainz match is `inferred`; a local file tag is `observed`. So
+for genre/year/language the local tag wins when present, while country/area/
+original_year (no competing local tag) are filled by MB. Provenance for the
+winner is always recorded.
+"""
+
+import pytest
+
+from kalinka_plugin_localfiles.enricher.enricher import (
+    ALBUM_EXTERNAL_FIELDS,
+    ARTIST_EXTERNAL_FIELDS,
+    MetadataEnricher,
+)
+
+
+class FakeDb:
+    def __init__(self):
+        self.claims = []
+        self.origins = []
+
+    async def record_claim(self, et, eid, field, value, source, tier):
+        self.claims.append((et, eid, field, value, source, tier))
+
+    async def record_resolved_origin(self, et, eid, field, source, tier, ev=None):
+        self.origins.append((et, eid, field, source, tier))
+
+
+def _enricher():
+    enr = MetadataEnricher.__new__(MetadataEnricher)
+    enr.db_manager = FakeDb()
+    return enr
+
+
+def _mb(field, value, mbid="rel-1"):
+    return {"field": field, "value": value, "source": f"musicbrainz:{mbid}",
+            "tier": "inferred"}
+
+
+@pytest.mark.asyncio
+async def test_local_tag_genre_beats_fuzzy_mb():
+    enr = _enricher()
+    album = {"id": "al1", "genre": "Krautrock"}   # from file tags (observed)
+    updated = {**album, "genre": "Electronic"}    # MB already overwrote via update
+    changed = await enr._resolve_external_fields(
+        "album", album, updated, [_mb("genre", "Electronic")], ALBUM_EXTERNAL_FIELDS
+    )
+    assert changed is True
+    assert updated["genre"] == "Krautrock"        # local tag wins back
+    # origin recorded as the local source
+    assert ("album", "al1", "genre", "tag_consensus", "observed") in enr.db_manager.origins
+
+
+@pytest.mark.asyncio
+async def test_mb_fills_original_year_uncontested():
+    enr = _enricher()
+    album = {"id": "al1"}                          # no local original_year
+    updated = {"id": "al1", "original_year": 1979}  # MB update
+    changed = await enr._resolve_external_fields(
+        "album", album, updated, [_mb("original_year", 1979)], ALBUM_EXTERNAL_FIELDS
+    )
+    # winner == already-set MB value, so no *change*, but provenance recorded.
+    assert changed is False
+    assert updated["original_year"] == 1979
+    assert ("album", "al1", "original_year", "musicbrainz:rel-1", "inferred") \
+        in enr.db_manager.origins
+
+
+@pytest.mark.asyncio
+async def test_local_year_beats_mb_year():
+    enr = _enricher()
+    album = {"id": "al1", "year": 1984}            # tag year (release pressing)
+    updated = {**album, "year": 1990}              # MB reissue year
+    changed = await enr._resolve_external_fields(
+        "album", album, updated, [_mb("year", 1990)], ALBUM_EXTERNAL_FIELDS
+    )
+    assert changed is True
+    assert updated["year"] == 1984
+
+
+@pytest.mark.asyncio
+async def test_artist_country_filled_uncontested():
+    enr = _enricher()
+    artist = {"id": "ar1"}
+    updated = {"id": "ar1", "country": "IT"}
+    changed = await enr._resolve_external_fields(
+        "artist", artist, updated, [_mb("country", "IT", mbid="a-1")],
+        ARTIST_EXTERNAL_FIELDS,
+    )
+    assert changed is False
+    assert updated["country"] == "IT"
+    assert ("artist", "ar1", "country", "musicbrainz:a-1", "inferred") \
+        in enr.db_manager.origins
+
+
+@pytest.mark.asyncio
+async def test_no_claims_for_field_is_skipped():
+    enr = _enricher()
+    album = {"id": "al1"}                           # no local, no external
+    updated = {"id": "al1"}
+    changed = await enr._resolve_external_fields(
+        "album", album, updated, [], ALBUM_EXTERNAL_FIELDS
+    )
+    assert changed is False
+    assert enr.db_manager.claims == [] and enr.db_manager.origins == []

--- a/packages/kalinka-plugin-localfiles/tests/test_resolver.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_resolver.py
@@ -55,6 +55,21 @@ def test_within_tier_field_precedence_external_first_for_country():
     assert resolve_field(claims).value == "FR"
 
 
+def test_numeric_claim_values_resolve(  # Copilot review, PR #99
+):
+    # year/original_year are int claims: local observed tag beats fuzzy MB,
+    # and the returned value keeps its int type (resolution never compares by
+    # value, so mixed str/int is safe).
+    winner = resolve_field(
+        [
+            _c(1984, "tag_consensus", "observed", field="year"),
+            _c(1990, "musicbrainz:r1", "inferred", field="year"),
+        ],
+        current_value=1984,
+    )
+    assert winner.value == 1984 and isinstance(winner.value, int)
+
+
 def test_incumbency_breaks_ties():
     # Two equal-tier, equal-precedence rivals (same source base): the value
     # already shown keeps winning so display doesn't churn.

--- a/packages/kalinka-plugin-localfiles/tests/test_title_normalize.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_title_normalize.py
@@ -22,6 +22,11 @@ from kalinka_plugin_localfiles.clustering.classify import normalize_album_title
      "Ellington, Mingus, Roach - Money Jungle"),
     ("Playlist - Urban - 500604904 --- Jamendo - MP3",
      "Playlist - Urban"),
+    # Bracketed catalogue number ("CD" + a long digit run) — a pressing id,
+    # not the "(CD 1)" disc marker, so it is stripped.
+    ("Talks [CD 61407]", "Talks"),
+    ("Classic Queen [CD 61311]", "Classic Queen"),
+    ("Queen Talks [1992, Canada, CD 61407]", "Queen Talks"),
 ])
 def test_strips_junk(raw, clean):
     assert normalize_album_title(raw) == clean
@@ -37,6 +42,7 @@ def test_strips_junk(raw, clean):
     "The Best Of Michael Jackson (Disk 2)",  # disc marker left to disc logic
     "Discovery (2001)",                   # bare year in paren kept
     "1984",                               # a title that *is* a year
+    "Iceberg Forces [CC Edition]",        # descriptive bracket (no catalog id) kept
 ])
 def test_leaves_real_titles_untouched(title):
     assert normalize_album_title(title) == title


### PR DESCRIPTION
Single landing that consolidates the two previously-separate PRs plus their
Copilot review fixes, so everything merges and rebuilds together.

## Contents
- **#99 — Phase 2d slice 3: external-first origin/era fields via claims.** MB
  emits country/area (artist) and genre/year/original_year/language (album)
  as `inferred` claims; `_resolve_external_fields` resolves them. Local
  observed tags win genre/year/language; country/area/original_year fill
  uncontested. Provenance in `resolved_origin`.
- **#100 — clustering hygiene.** Flat V/A dump folders (e.g. a Jamendo
  `Playlist - …` dump) detach to singles instead of fragmenting into per-art
  albums + `various_artists` umbrellas; `[CD NNNNN]` catalogue numbers strip
  from album titles.

## Copilot review fixes (folded in)
- **#99**: `Claim.value` / `record_claim(value)` widened to `str | int` — the
  numeric year fields no longer contradict a str-only annotation.
- **#100**: `compilation_title` strips a trailing `/` like
  `is_declared_va_folder`, so a declared `VA - X/` folder isn't misclassified
  as a generic dump.

## Tests
Full localfiles suite: **461 passed** (playqueue flake excluded), including
new cases for numeric-claim resolution and the trailing-slash declared-VA
folder.

## Deploy note
Applies at index/enrich time — a library rebuild picks up the clustering and
resolution changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)