### PR TITLE
Enrichment redesign Phase 2f: AcoustID identity rescue mode

### DIFF
--- a/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
+++ b/packages/kalinka-plugin-localfiles/src/kalinka_plugin_localfiles/enricher/acoustid_plugin.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__.split(".")[-1])
 class AcoustIdPlugin(EnricherPlugin):
     """AcoustID audio fingerprinting plugin for track identification"""
 
-    ENRICHER_VERSION = 1
+    ENRICHER_VERSION = 2  # 2f: rescue-mode gating + fill-only writes
 
     def __init__(self, config: LocalFilesConfig, db_manager):
         self.config = config
@@ -539,29 +539,41 @@ class AcoustIdPlugin(EnricherPlugin):
         """
         return None
 
+    @staticmethod
+    def _artist_absent(track: Dict) -> bool:
+        """True when no local source resolved the track's artist."""
+        return track.get("artist_id") in (None, "", "unknown_artist")
+
+    @staticmethod
+    def _title_absent(track: Dict) -> bool:
+        """True when no local source resolved the track's title."""
+        return not (track.get("title") or "").strip()
+
     async def enrich_track(self, track: Dict) -> Optional[Dict]:
         """
-        Enrich track using audio fingerprinting
+        Enrich track using audio fingerprinting (rescue mode, §6.3).
 
         This will:
-        1. Skip if track is already enriched
+        1. Skip unless a local source left the artist or title absent
         2. Generate fingerprint from audio file
         3. Look up fingerprint in AcoustID
-        4. Extract metadata and update track
-        5. Create missing artists and albums if necessary
+        4. Record the recording mbid and fill only the absent field(s) —
+           never overwrite a local title or repoint a known artist
         """
         try:
             # Skip if track is already enriched or no file path
             if track.get("enriched") or not track.get("file_path"):
                 return None
 
-            if (
-                track.get("artist_id") != "unknown_artist"
-                and track.get("album_id") != "unknown_album"
-            ):
+            # Rescue mode (§6.3): fire only when local evidence left the artist
+            # or title absent. A missing *album* no longer triggers a lookup —
+            # album identity is the clustering pass's job, not a fingerprint's.
+            artist_absent = self._artist_absent(track)
+            title_absent = self._title_absent(track)
+            if not (artist_absent or title_absent):
                 logger.debug(
                     f"Skipping acoustid enrichment for track {track.get('title', 'Unknown')} - "
-                    f"Already enriched or has known artist/album"
+                    f"artist and title already resolved locally"
                 )
                 return None
 
@@ -630,41 +642,32 @@ class AcoustIdPlugin(EnricherPlugin):
                 f"Artist: {match_info.get('artist_name')}"
             )
 
+            # The recording mbid is the rescue result and always recorded;
+            # everything else is fill-only (§6.3).
             updates = {
                 "mbid": match_info["recording_mbid"],
-                "match_score": int(match_info["score"] * 100),  # Convert to 0-100 scale
+                "match_score": int(match_info["score"] * 100),  # 0-100 scale
             }
 
-            updates["title"] = match_info["title"]
+            if title_absent and match_info.get("title"):
+                updates["title"] = match_info["title"]
 
-            # Track items that need further enrichment
             changed_items = {"artists": set(), "albums": set()}
 
-            # Create or get artist if needed
-            if match_info.get("artist_name"):
-                # Store original artist ID to check if a new one was created
+            # Fill the artist only when absent; never move a track off a known one.
+            if artist_absent and match_info.get("artist_name"):
                 original_artist_id = track.get("artist_id")
-
                 artist_id = await self._create_or_get_artist(
                     match_info["artist_name"], match_info.get("artist_mbid")
                 )
-
                 if artist_id:
                     updates["artist_id"] = artist_id
                     updates["artist_name"] = match_info["artist_name"]
-
-                    # Check if this is a newly created or different artist
                     if artist_id != original_artist_id:
-                        logger.debug(
-                            f"Adding artist {artist_id} to changed items for further enrichment"
-                        )
                         changed_items["artists"].add(artist_id)
 
-            # AcoustID no longer creates albums or moves a track between them:
-            # album membership is owned by the clustering pass (§3 invariant),
-            # so a single confident fingerprint match can't fragment a
-            # coherent local album by re-pointing one track to a new album row.
-
+            # Album membership stays with the clustering pass (§3); AcoustID
+            # never creates albums or moves a track (powers removed in 1f).
             result = {"updates": updates}
 
             # If we have any items that need further enrichment, add them to result

--- a/packages/kalinka-plugin-localfiles/tests/test_acoustid_rescue_mode.py
+++ b/packages/kalinka-plugin-localfiles/tests/test_acoustid_rescue_mode.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Phase 2f: AcoustID narrowed to identity rescue mode.
+
+AcoustID's only job is "what track is this?" when local evidence couldn't
+answer. It fires solely when the artist or title is still absent after every
+local source — a missing *album* no longer triggers a lookup (album identity
+is the clustering pass's job) — and its writes are fill-only: it records the
+recording mbid but never overwrites a local title or repoints a known artist.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from kalinka_plugin_localfiles.config_model import LocalFilesConfig
+from kalinka_plugin_localfiles.enricher.acoustid_plugin import AcoustIdPlugin
+
+
+class _FakeDb:
+    """Minimal db_manager stand-in — rescue-mode tests never reach it."""
+
+    async def save_fingerprint(self, *a, **k):
+        return None
+
+    async def get_album_by_id(self, *a, **k):
+        return None
+
+    async def get_artist_by_mbid(self, *a, **k):
+        return None
+
+    async def search_artists(self, *a, **k):
+        return [], 0
+
+    async def insert_artist(self, *a, **k):
+        return None
+
+
+def _plugin() -> AcoustIdPlugin:
+    cfg = LocalFilesConfig(db_path=":memory:")
+    cfg.enricher.plugins.acoustid.api_key = "test-key"
+    return AcoustIdPlugin(cfg, _FakeDb())
+
+
+# --- gating -----------------------------------------------------------------
+
+
+def test_version_bumped_for_rescue_mode():
+    # Bumping ENRICHER_VERSION re-opens previously-FAILED tracks so the new
+    # gate is re-evaluated (fingerprint-gated retry).
+    assert AcoustIdPlugin.ENRICHER_VERSION >= 2
+
+
+def test_absence_helpers():
+    assert AcoustIdPlugin._artist_absent({"artist_id": "unknown_artist"})
+    assert AcoustIdPlugin._artist_absent({"artist_id": None})
+    assert AcoustIdPlugin._artist_absent({})
+    assert not AcoustIdPlugin._artist_absent({"artist_id": "ar1"})
+
+    assert AcoustIdPlugin._title_absent({"title": ""})
+    assert AcoustIdPlugin._title_absent({"title": "   "})
+    assert AcoustIdPlugin._title_absent({})
+    assert not AcoustIdPlugin._title_absent({"title": "Song"})
+
+
+@pytest.mark.asyncio
+async def test_missing_album_alone_does_not_trigger_lookup():
+    """The key 2f change: a track with a known artist + title but stuck in
+    unknown_album is NOT fingerprinted — no fpcalc, no web request."""
+    plugin = _plugin()
+    track = {
+        "id": "t1",
+        "file_path": "/m/t1.flac",
+        "artist_id": "ar1",
+        "title": "Real Song",
+        "album_id": "unknown_album",
+        "enriched": 0,
+    }
+    with patch.object(plugin, "_generate_fingerprint") as gen:
+        result = await plugin.enrich_track(track)
+    assert result is None
+    gen.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unknown_artist_triggers_lookup():
+    plugin = _plugin()
+    track = {
+        "id": "t1",
+        "file_path": "/m/t1.flac",
+        "artist_id": "unknown_artist",
+        "title": "Some Title",
+        "album_id": "al1",
+        "enriched": 0,
+    }
+    with patch.object(
+        plugin, "_generate_fingerprint", return_value=(None, None)
+    ) as gen:
+        await plugin.enrich_track(track)
+    gen.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_absent_title_triggers_lookup():
+    plugin = _plugin()
+    track = {
+        "id": "t1",
+        "file_path": "/m/t1.flac",
+        "artist_id": "ar1",
+        "title": "",
+        "album_id": "al1",
+        "enriched": 0,
+    }
+    with patch.object(
+        plugin, "_generate_fingerprint", return_value=(None, None)
+    ) as gen:
+        await plugin.enrich_track(track)
+    gen.assert_called_once()
+
+
+# --- fill-only writes -------------------------------------------------------
+
+
+_MATCH = {
+    "score": 0.95,
+    "recording_mbid": "rec-mbid",
+    "title": "MB Title",
+    "artist_name": "MB Artist",
+    "artist_mbid": "art-mbid",
+    "album_title": None,
+    "album_mbid": None,
+}
+
+
+async def _run_with_match(plugin, track):
+    with patch.object(
+        plugin, "_generate_fingerprint", return_value=("fp", 200)
+    ), patch.object(
+        plugin, "_lookup_fingerprint", return_value=[{"x": 1}]
+    ), patch.object(
+        plugin, "_get_best_match_info", return_value=dict(_MATCH)
+    ):
+        return await plugin.enrich_track(track)
+
+
+@pytest.mark.asyncio
+async def test_absent_title_is_filled_from_match():
+    plugin = _plugin()
+    track = {
+        "id": "t1",
+        "file_path": "/m/t1.flac",
+        "artist_id": "ar1",  # known artist
+        "title": "",  # absent title → the rescue field
+        "album_id": "al1",
+        "enriched": 0,
+    }
+    result = await _run_with_match(plugin, track)
+    updates = result["updates"]
+    assert updates["mbid"] == "rec-mbid"
+    assert updates["title"] == "MB Title"
+    # Known artist must not be repointed.
+    assert "artist_id" not in updates
+
+
+@pytest.mark.asyncio
+async def test_present_title_is_not_overwritten():
+    plugin = _plugin()
+    track = {
+        "id": "t1",
+        "file_path": "/m/t1.flac",
+        "artist_id": "unknown_artist",  # this is the rescue field
+        "title": "Local Title",  # present → must survive
+        "album_id": "al1",
+        "enriched": 0,
+    }
+    result = await _run_with_match(plugin, track)
+    updates = result["updates"]
+    assert updates["mbid"] == "rec-mbid"
+    # Title is present locally → not overwritten.
+    assert "title" not in updates
+    # Artist was absent → filled.
+    assert updates["artist_name"] == "MB Artist"


### PR DESCRIPTION
Narrows AcoustID to identity rescue (§6.3 of the design doc). Dependency-free, changes live behaviour.

## What changed
- **Rescue-mode gate**: AcoustID fires only when the artist *or* title is still absent after every local source. A missing **album** no longer triggers a lookup — album identity is the clustering pass's job — so a track that already has both an artist and a title is never fingerprint-looked-up. Drops the wasteful global lookups on tracks merely stuck in `unknown_album`.
- **Fill-only writes**: the recording mbid is always recorded, but a title is never overwritten and a known artist is never repointed.
- `ENRICHER_VERSION` 1→2 so previously-FAILED tracks are re-evaluated under the new gate (fingerprint-gated retry).

(Album-create / track-move powers were already removed in Phase 1f.)

## Tests
`test_acoustid_rescue_mode.py` (7). Full localfiles suite: **473 passed**.

## Note on 2g
2g (library-wide inference) was pulled from this PR: as first drafted it inferred `tracks.recording_year` / `tracks.language`, columns nothing in the pipeline populates (the file's year tag is routed to `album.year`; per §6.5/§7 it can't be laundered into recording_year). It will be rebuilt as evidence-based tag-consensus (from `track_evidence.raw_tags`), which also closes the slice-3 caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)